### PR TITLE
refactor(moqt): simplify logger design

### DIFF
--- a/moqt/client.go
+++ b/moqt/client.go
@@ -73,6 +73,14 @@ func (c *Client) init() {
 	})
 }
 
+// log returns Client.Logger if set, otherwise a discard logger.
+func (c *Client) log() *slog.Logger {
+	if c.Logger != nil {
+		return c.Logger
+	}
+	return slog.New(slog.DiscardHandler)
+}
+
 // Dial establishes a new session to the specified URL using either WebTransport (https scheme) or QUIC (moqt scheme).
 // The provided TrackMux is used to route incoming service tracks if non-nil.
 // Dial returns the newly created Session or an error.
@@ -109,21 +117,18 @@ func generateSessionID() string {
 // It performs the WebTransport handshake and initializes a MOQ session stream.
 // `host` should be host:port and `path` is the path used for session setup.
 func (c *Client) DialWebTransport(ctx context.Context, host, path string, mux *TrackMux) (*Session, error) {
-	var clientLogger *slog.Logger
-	if c.Logger != nil {
-		clientLogger = c.Logger.With(
-			"host", host,
-		)
-	} else {
-		clientLogger = slog.New(slog.DiscardHandler)
-
-	}
-
 	if c.shuttingDown() {
 		return nil, ErrClientClosed
 	}
 
 	c.init()
+
+	var baseLogger *slog.Logger
+	if c.Logger != nil {
+		baseLogger = c.Logger
+	} else {
+		baseLogger = slog.New(slog.DiscardHandler)
+	}
 
 	dialTimeout := c.Config.setupTimeout()
 	dialCtx, cancelDial := context.WithTimeout(ctx, dialTimeout)
@@ -142,21 +147,22 @@ func (c *Client) DialWebTransport(ctx context.Context, host, path string, mux *T
 		return nil, err
 	}
 
-	connLogger := clientLogger.With(
+	connLogger := baseLogger.With(
 		"transport", "webtransport",
 		"local_address", conn.LocalAddr(),
 		"remote_address", conn.RemoteAddr(),
 		"quic_version", conn.ConnectionState().Version,
 		"alpn", conn.ConnectionState().TLS.NegotiatedProtocol,
 	)
+	connLogger.Info("connection established")
 
-	sessStream, err := openSessionStream(conn, path, webTransportExtensions(), connLogger)
+	sessStream, err := openSessionStream(conn, path, webTransportExtensions())
 	if err != nil {
 		return nil, err
 	}
 
 	var sess *Session
-	sess = newSession(conn, sessStream, mux, connLogger, func() { c.removeSession(sess) })
+	sess = newSession(conn, sessStream, mux, func() { c.removeSession(sess) })
 	c.addSession(sess)
 
 	return sess, nil
@@ -172,13 +178,6 @@ func (c *Client) DialQUIC(ctx context.Context, addr, path string, mux *TrackMux)
 	}
 
 	c.init()
-
-	var clientLogger *slog.Logger
-	if c.Logger == nil {
-		clientLogger = slog.New(slog.DiscardHandler)
-	} else {
-		clientLogger = c.Logger
-	}
 
 	dialTimeout := c.Config.setupTimeout()
 	dialCtx, cancelDial := context.WithTimeout(ctx, dialTimeout)
@@ -197,22 +196,13 @@ func (c *Client) DialQUIC(ctx context.Context, addr, path string, mux *TrackMux)
 		return nil, err
 	}
 
-	connLogger := clientLogger.With(
-		"transport", "quic",
-		"local_address", conn.LocalAddr(),
-		"remote_address", conn.RemoteAddr(),
-		"quic_version", conn.ConnectionState().Version,
-		"alpn", conn.ConnectionState().TLS.NegotiatedProtocol,
-	)
-	// TODO: Add connection ID
-
-	sessStream, err := openSessionStream(conn, path, quicExtensions(path), connLogger)
+	sessStream, err := openSessionStream(conn, path, quicExtensions(path))
 	if err != nil {
 		return nil, err
 	}
 
 	var sess *Session
-	sess = newSession(conn, sessStream, mux, connLogger, func() { c.removeSession(sess) })
+	sess = newSession(conn, sessStream, mux, func() { c.removeSession(sess) })
 	c.addSession(sess)
 
 	return sess, nil
@@ -236,7 +226,6 @@ func openSessionStream(
 	conn quic.Connection,
 	path string,
 	extensions *Extension,
-	connLogger *slog.Logger,
 ) (*sessionStream, error) {
 	stream, err := conn.OpenStream()
 	if err != nil {

--- a/moqt/client_test.go
+++ b/moqt/client_test.go
@@ -125,7 +125,7 @@ func TestClient_ShutdownContextCancel(t *testing.T) {
 		Path:             "path",
 		ClientExtensions: NewExtension(),
 	})
-	sess := newSession(mockConn, sessStream, NewTrackMux(), slog.Default(), nil)
+	sess := newSession(mockConn, sessStream, NewTrackMux(), nil)
 	c.addSession(sess)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -349,7 +349,7 @@ func TestClient_openSession(t *testing.T) {
 			if extProvider == nil {
 				extProvider = func() *Extension { return &Extension{} }
 			}
-			_, err := openSessionStream(conn, "/path", extProvider(), slog.Default())
+			_, err := openSessionStream(conn, "/path", extProvider())
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -648,7 +648,7 @@ func TestClient_OpenSession_NilExtensions(t *testing.T) {
 
 	// Expect panic when extensions is nil
 	assert.Panics(t, func() {
-		_, _ = openSessionStream(mockConn, "/test", nil, slog.Default())
+		_, _ = openSessionStream(mockConn, "/test", nil)
 	})
 }
 
@@ -704,7 +704,7 @@ func TestClient_OpenSession_Success(t *testing.T) {
 	extensions := func() *Extension {
 		return NewExtension()
 	}
-	sessStream, err := openSessionStream(mockConn, "/test", extensions(), slog.Default())
+	sessStream, err := openSessionStream(mockConn, "/test", extensions())
 	require.NoError(t, err)
 	require.NotNil(t, sessStream)
 
@@ -984,7 +984,7 @@ func TestClient_Shutdown_Timeout(t *testing.T) {
 		Path:             "path",
 		ClientExtensions: NewExtension(),
 	})
-	sess := newSession(mockConn, sessStream, NewTrackMux(), slog.Default(), nil)
+	sess := newSession(mockConn, sessStream, NewTrackMux(), nil)
 	c.addSession(sess)
 
 	// Create a context that times out quickly

--- a/moqt/router.go
+++ b/moqt/router.go
@@ -80,9 +80,8 @@ func (r *SetupRouter) Handler(pattern string) SetupHandler {
 
 func (r *SetupRouter) ServeMOQ(w SetupResponseWriter, req *SetupRequest) {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-
 	handler := r.Handler(req.Path)
+	r.mu.RUnlock()
 	if handler == nil {
 		handler = RejectSetupHandler
 	}

--- a/moqt/server.go
+++ b/moqt/server.go
@@ -112,11 +112,15 @@ func (s *Server) init() {
 		} else {
 			s.wtServer = webtransportgo.NewServer(checkOrigin)
 		}
-
-		if s.Logger != nil {
-			s.Logger = s.Logger.With("address", s.Addr)
-		}
 	})
+}
+
+// log returns Server.Logger if set, otherwise a discard logger.
+func (s *Server) log() *slog.Logger {
+	if s.Logger != nil {
+		return s.Logger
+	}
+	return slog.New(slog.DiscardHandler)
 }
 
 // ServeQUICListener accepts connections on the provided QUIC listener and handles them using the Server's configuration.
@@ -195,22 +199,17 @@ func (s *Server) HandleWebTransport(w http.ResponseWriter, r *http.Request) erro
 
 	s.init()
 
+	if r.TLS == nil {
+		s.log().Warn("connection rejected: plain HTTP is not supported; use HTTPS",
+			"remote_address", r.RemoteAddr,
+		)
+		http.Error(w, "plain HTTP is not supported; use HTTPS", http.StatusUpgradeRequired)
+		return fmt.Errorf("plain HTTP connection from %s", r.RemoteAddr)
+	}
+
 	conn, err := s.wtServer.Upgrade(w, r)
 	if err != nil {
 		return fmt.Errorf("failed to upgrade connection: %w", err)
-	}
-
-	var connLogger *slog.Logger
-	if s.Logger != nil {
-		connLogger = s.Logger.With(
-			"local_address", conn.LocalAddr(),
-			"remote_address", conn.RemoteAddr(),
-			"alpn", conn.ConnectionState().TLS.NegotiatedProtocol,
-			"quic_version", conn.ConnectionState().Version,
-		)
-		// TODO: Add connection ID
-	} else {
-		connLogger = slog.New(slog.DiscardHandler)
 	}
 
 	acceptCtx, cancelAccept := context.WithTimeout(r.Context(), s.Config.setupTimeout())
@@ -223,14 +222,10 @@ func (s *Server) HandleWebTransport(w http.ResponseWriter, r *http.Request) erro
 	// Set the path for the session
 	sessStr.Path = r.URL.Path
 
-	rsp := newResponseWriter(conn, sessStr, connLogger, s)
+	rsp := newResponseWriter(conn, sessStr, s)
 	req := sessStr.SetupRequest
 
-	if s.SetupHandler != nil {
-		s.SetupHandler.ServeMOQ(rsp, req)
-	} else {
-		DefaultRouter.ServeMOQ(rsp, req)
-	}
+	s.serveSetup(rsp, req)
 
 	return nil
 }
@@ -242,19 +237,6 @@ func (s *Server) handleNativeQUIC(conn quic.Connection) error {
 
 	s.init()
 
-	var connLogger *slog.Logger
-	if s.Logger != nil {
-		connLogger = s.Logger.With(
-			"local_address", conn.LocalAddr(),
-			"remote_address", conn.RemoteAddr(),
-			"alpn", conn.ConnectionState().TLS.NegotiatedProtocol,
-			"quic_version", conn.ConnectionState().Version,
-		)
-		// TODO: Add connection ID
-	} else {
-		connLogger = slog.New(slog.DiscardHandler)
-	}
-
 	acceptCtx, cancelAccept := context.WithTimeout(conn.Context(), s.Config.setupTimeout())
 	defer cancelAccept()
 	sessStr, err := acceptSessionStream(acceptCtx, conn)
@@ -262,16 +244,29 @@ func (s *Server) handleNativeQUIC(conn quic.Connection) error {
 		return fmt.Errorf("moq: failed to accept session stream: %w", err)
 	}
 
-	rsp := newResponseWriter(conn, sessStr, connLogger, s)
+	rsp := newResponseWriter(conn, sessStr, s)
 	req := sessStr.SetupRequest
 
-	if s.SetupHandler != nil {
-		s.SetupHandler.ServeMOQ(rsp, req)
-	} else {
-		DefaultRouter.ServeMOQ(rsp, req)
-	}
+	s.serveSetup(rsp, req)
 
 	return nil
+}
+
+// serveSetup dispatches the setup request to the configured handler, recovering
+// from any panic the handler may raise and logging it as a server-level error.
+func (s *Server) serveSetup(w SetupResponseWriter, req *SetupRequest) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			s.log().Error("panic in setup handler", "panic", rec)
+			_ = w.Reject(SetupFailedErrorCode)
+		}
+	}()
+
+	if s.SetupHandler != nil {
+		s.SetupHandler.ServeMOQ(w, req)
+	} else {
+		DefaultRouter.ServeMOQ(w, req)
+	}
 }
 
 func acceptSessionStream(acceptCtx context.Context, conn quic.Connection) (*sessionStream, error) {

--- a/moqt/server_test.go
+++ b/moqt/server_test.go
@@ -623,7 +623,7 @@ func TestServer_SessionManagement(t *testing.T) {
 				ClientExtensions: NewExtension(),
 			}
 			sessStream := newSessionStream(mockStream, req)
-			session := newSession(mockConn, sessStream, nil, slog.Default(), nil)
+			session := newSession(mockConn, sessStream, nil, nil)
 
 			// Test adding session
 			server.sessMu.Lock()
@@ -940,6 +940,7 @@ func TestServer_HandleWebTransport(t *testing.T) {
 
 			req := &http.Request{
 				URL: &url.URL{Path: "/test"},
+				TLS: &tls.ConnectionState{},
 			}
 
 			wtServer := &MockWebTransportServer{}
@@ -982,6 +983,7 @@ func TestServer_HandleWebTransport_WithNilLogger(t *testing.T) {
 	mockResponseWriter := &MockHTTPResponseWriter{}
 	req := &http.Request{
 		URL: &url.URL{Path: "/test"},
+		TLS: &tls.ConnectionState{},
 	}
 
 	wtServer := &MockWebTransportServer{}
@@ -1125,7 +1127,7 @@ func TestServer_AddRemoveSession(t *testing.T) {
 	sessStream := newSessionStream(mockStream, req)
 
 	// Create session using newSession but quickly close it to avoid long-running goroutines
-	session := newSession(mockConn, sessStream, nil, slog.Default(), nil)
+	session := newSession(mockConn, sessStream, nil, nil)
 
 	// Immediately terminate session to stop goroutines
 	defer func() { _ = session.CloseWithError(NoError, SessionErrorText(NoError)) }()
@@ -1218,7 +1220,7 @@ func TestServer_Shutdown(t *testing.T) {
 					ClientExtensions: NewExtension(),
 				}
 				sessStream := newSessionStream(mockStream, req)
-				session := newSession(mockConn, sessStream, nil, slog.Default(), nil)
+				session := newSession(mockConn, sessStream, nil, nil)
 				server.addSession(session)
 				defer func() { _ = session.CloseWithError(NoError, SessionErrorText(NoError)) }()
 			}
@@ -1569,7 +1571,7 @@ func TestServer_SessionLifecycle(t *testing.T) {
 					ClientExtensions: NewExtension(),
 				}
 				sessStream := newSessionStream(mockStream, req)
-				session := newSession(mockConn, sessStream, nil, slog.Default(), nil)
+				session := newSession(mockConn, sessStream, nil, nil)
 				sessions = append(sessions, session)
 
 				// Add session
@@ -1730,7 +1732,7 @@ func TestServer_EdgeCaseOperations(t *testing.T) {
 					ClientExtensions: NewExtension(),
 				}
 				sessStream := newSessionStream(mockStream, req)
-				session := newSession(mockConn, sessStream, nil, slog.Default(), nil)
+				session := newSession(mockConn, sessStream, nil, nil)
 
 				assert.NotPanics(t, func() {
 					server.removeSession(session)
@@ -1885,6 +1887,7 @@ func TestServer_WebTransportEdgeCases(t *testing.T) {
 
 				req := &http.Request{
 					URL: &url.URL{Path: "/test"},
+					TLS: &tls.ConnectionState{},
 				}
 
 				wtServer := &MockWebTransportServer{}

--- a/moqt/session.go
+++ b/moqt/session.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"sync"
 	"sync/atomic"
 
@@ -16,27 +15,15 @@ func newSession(
 	conn quic.Connection,
 	sessStream *sessionStream,
 	mux *TrackMux,
-	connLogger *slog.Logger,
 	onClose func(),
 ) *Session {
 	if mux == nil {
 		mux = DefaultMux
 	}
 
-	var sessLogger *slog.Logger
-	if connLogger == nil {
-		sessLogger = slog.New(slog.DiscardHandler)
-	} else {
-		sessLogger = connLogger.With(
-			"session_id", generateSessionID(),
-			"path", sessStream.Path,
-		)
-	}
-
 	sess := &Session{
 		sessionStream: sessStream,
 		ctx:           conn.Context(),
-		logger:        sessLogger,
 		conn:          conn,
 		mux:           mux,
 		trackReaders:  make(map[SubscribeID]*TrackReader),
@@ -77,8 +64,6 @@ type Session struct {
 	ctx context.Context // Context for the session
 
 	wg sync.WaitGroup // WaitGroup for session cleanup
-
-	logger *slog.Logger
 
 	conn quic.Connection
 
@@ -355,14 +340,12 @@ func (sess *Session) handleBiStreams() {
 			return
 		}
 
-		streamLogger := sess.logger
-
 		// Handle the stream
-		go sess.processBiStream(stream, streamLogger)
+		go sess.processBiStream(stream)
 	}
 }
 
-func (sess *Session) processBiStream(stream quic.Stream, streamLogger *slog.Logger) {
+func (sess *Session) processBiStream(stream quic.Stream) {
 	var streamType message.StreamType
 	err := streamType.Decode(stream)
 	if err != nil {
@@ -428,14 +411,12 @@ func (sess *Session) handleUniStreams() {
 			return
 		}
 
-		streamLogger := sess.logger
-
 		// Handle the stream
-		go sess.processUniStream(stream, streamLogger)
+		go sess.processUniStream(stream)
 	}
 }
 
-func (sess *Session) processUniStream(stream quic.ReceiveStream, streamLogger *slog.Logger) {
+func (sess *Session) processUniStream(stream quic.ReceiveStream) {
 	/*
 	 * Get a Stream Type ID
 	 */

--- a/moqt/session_benchmark_test.go
+++ b/moqt/session_benchmark_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log/slog"
 	"net"
 	"sync"
 	"testing"
@@ -73,7 +72,7 @@ func BenchmarkSession_Subscribe(b *testing.B) {
 			})
 
 			mux := NewTrackMux()
-			session := newSession(conn, sessStream, mux, slog.New(slog.DiscardHandler), nil)
+			session := newSession(conn, sessStream, mux, nil)
 
 			// Pre-generate paths
 			paths := make([]BroadcastPath, size)
@@ -150,7 +149,7 @@ func BenchmarkSession_ConcurrentSubscribe(b *testing.B) {
 			})
 
 			mux := NewTrackMux()
-			session := newSession(conn, sessStream, mux, slog.New(slog.DiscardHandler), nil)
+			session := newSession(conn, sessStream, mux, nil)
 
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -190,7 +189,7 @@ func BenchmarkSession_TrackReaderOperations(b *testing.B) {
 	})
 
 	mux := NewTrackMux()
-	session := newSession(conn, sessStream, mux, slog.New(slog.DiscardHandler), nil)
+	session := newSession(conn, sessStream, mux, nil)
 
 	b.ReportAllocs()
 
@@ -240,7 +239,7 @@ func BenchmarkSession_TrackWriterOperations(b *testing.B) {
 	})
 
 	mux := NewTrackMux()
-	session := newSession(conn, sessStream, mux, slog.New(slog.DiscardHandler), nil)
+	session := newSession(conn, sessStream, mux, nil)
 
 	b.ReportAllocs()
 
@@ -295,7 +294,7 @@ func BenchmarkSession_MapLookup(b *testing.B) {
 			})
 
 			mux := NewTrackMux()
-			session := newSession(conn, sessStream, mux, slog.New(slog.DiscardHandler), nil)
+			session := newSession(conn, sessStream, mux, nil)
 
 			// Pre-populate with track readers
 			for i := range size {
@@ -361,7 +360,7 @@ func BenchmarkSession_MemoryAllocation(b *testing.B) {
 				})
 
 				mux := NewTrackMux()
-				session := newSession(conn, sessStream, mux, slog.New(slog.DiscardHandler), nil)
+				session := newSession(conn, sessStream, mux, nil)
 
 				// Create many track readers
 				for j := range size {
@@ -410,7 +409,7 @@ func BenchmarkSession_ContextCancellation(b *testing.B) {
 		})
 
 		mux := NewTrackMux()
-		session := newSession(conn, sessStream, mux, slog.New(slog.DiscardHandler), nil)
+		session := newSession(conn, sessStream, mux, nil)
 
 		// Cancel context
 		cancel()

--- a/moqt/session_stream.go
+++ b/moqt/session_stream.go
@@ -3,7 +3,6 @@ package moqt
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"slices"
 	"sync"
 
@@ -75,21 +74,19 @@ func (r *response) AwaitAccepted() error {
 
 var _ SetupResponseWriter = (*responseWriter)(nil)
 
-func newResponseWriter(conn quic.Connection, sessStr *sessionStream, connLogger *slog.Logger, server *Server) *responseWriter {
+func newResponseWriter(conn quic.Connection, sessStr *sessionStream, server *Server) *responseWriter {
 	return &responseWriter{
 		sessionStream: sessStr,
 		conn:          conn,
-		connLogger:    connLogger,
 		server:        server,
 	}
 }
 
 type responseWriter struct {
 	*sessionStream
-	conn       quic.Connection
-	connLogger *slog.Logger
-	server     *Server
-	onceSetup  sync.Once
+	conn      quic.Connection
+	server    *Server
+	onceSetup sync.Once
 }
 
 func (w *responseWriter) SelectVersion(v Version) error {
@@ -129,7 +126,7 @@ func (w *responseWriter) accept(mux *TrackMux) (*Session, error) {
 	}
 
 	var sess *Session
-	sess = newSession(w.conn, w.sessionStream, mux, w.connLogger, func() { w.server.removeSession(sess) })
+	sess = newSession(w.conn, w.sessionStream, mux, func() { w.server.removeSession(sess) })
 	w.server.addSession(sess)
 
 	return sess, nil

--- a/moqt/session_stream_test.go
+++ b/moqt/session_stream_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"log/slog"
 	"net"
 	"sync"
 	"testing"
@@ -427,7 +426,7 @@ func TestAccept(t *testing.T) {
 
 			mockServer := &Server{}
 			mockServer.init() // Initialize the server properly
-			rw := newResponseWriter(mockConn, ss, slog.Default(), mockServer)
+			rw := newResponseWriter(mockConn, ss, mockServer)
 
 			// Use new API: SelectVersion, SetExtensions, then Accept
 			err := rw.SelectVersion(tt.version)
@@ -476,7 +475,7 @@ func TestAccept_OnlyOnce(t *testing.T) {
 
 	mockServer := &Server{}
 	mockServer.init() // Initialize the server properly
-	rw := newResponseWriter(mockConn, ss, slog.Default(), mockServer)
+	rw := newResponseWriter(mockConn, ss, mockServer)
 
 	version := Default
 	extensions := NewExtension()
@@ -527,7 +526,7 @@ func TestAccept_ConcurrentCalls(t *testing.T) {
 
 	mockServer := &Server{}
 	mockServer.init() // Initialize the server properly
-	rw := newResponseWriter(mockConn, ss, slog.Default(), mockServer)
+	rw := newResponseWriter(mockConn, ss, mockServer)
 
 	version := Default
 	extensions := NewExtension()
@@ -765,7 +764,7 @@ func TestAccept_NilParameters(t *testing.T) {
 
 	mockServer := &Server{}
 	mockServer.init() // Initialize the server properly
-	rw := newResponseWriter(mockConn, ss, slog.Default(), mockServer)
+	rw := newResponseWriter(mockConn, ss, mockServer)
 
 	version := Default
 
@@ -816,7 +815,7 @@ func TestAccept_MultipleVersions(t *testing.T) {
 
 			mockServer := &Server{}
 			mockServer.init() // Initialize the server properly
-			rw := newResponseWriter(mockConn, ss, slog.Default(), mockServer)
+			rw := newResponseWriter(mockConn, ss, mockServer)
 
 			extensions := NewExtension()
 
@@ -1139,7 +1138,7 @@ func TestAccept_ErrorHandling(t *testing.T) {
 
 			mockServer := &Server{}
 			mockServer.init() // Initialize the server properly
-			rw := newResponseWriter(mockConn, ss, slog.Default(), mockServer)
+			rw := newResponseWriter(mockConn, ss, mockServer)
 
 			// Set version and extensions before Accept
 			err := rw.SelectVersion(tt.version)
@@ -1219,7 +1218,7 @@ func TestAccept_ParameterHandling(t *testing.T) {
 
 			mockServer := &Server{}
 			mockServer.init() // Initialize the server properly
-			rw := newResponseWriter(mockConn, ss, slog.Default(), mockServer)
+			rw := newResponseWriter(mockConn, ss, mockServer)
 
 			extensions := tt.setupParam()
 
@@ -1275,7 +1274,7 @@ func TestAccept_BoundaryVersions(t *testing.T) {
 
 			mockServer := &Server{}
 			mockServer.init()
-			rw := newResponseWriter(mockConn, ss, slog.Default(), mockServer)
+			rw := newResponseWriter(mockConn, ss, mockServer)
 
 			// Set version and extensions before Accept
 			err := rw.SelectVersion(tt.version)
@@ -1363,7 +1362,7 @@ func TestAccept_Race(t *testing.T) {
 
 	mockServer := &Server{}
 	mockServer.init()
-	rw := newResponseWriter(mockConn, ss, slog.Default(), mockServer)
+	rw := newResponseWriter(mockConn, ss, mockServer)
 
 	const numGoroutines = 100
 	var wg sync.WaitGroup
@@ -1473,7 +1472,7 @@ func TestResponseWriter_SessionStream_Sharing(t *testing.T) {
 
 	mockServer := &Server{}
 	mockServer.init()
-	rw := newResponseWriter(mockConn, ss, slog.Default(), mockServer)
+	rw := newResponseWriter(mockConn, ss, mockServer)
 
 	version := Default
 	extensions := NewExtension()
@@ -1596,7 +1595,7 @@ func TestAccept_ParameterEdgeCases(t *testing.T) {
 
 			mockServer := &Server{}
 			mockServer.init()
-			rw := newResponseWriter(mockConn, ss, slog.Default(), mockServer)
+			rw := newResponseWriter(mockConn, ss, mockServer)
 
 			extensions := tt.setupExtensions()
 
@@ -1634,7 +1633,7 @@ func TestSessionStream_Reject(t *testing.T) {
 	sessStr := &sessionStream{
 		stream: mockStream,
 	}
-	w := newResponseWriter(mockConn, sessStr, slog.Default(), nil)
+	w := newResponseWriter(mockConn, sessStr, nil)
 	err := w.Reject(SessionErrorCode(1))
 	assert.NoError(t, err)
 

--- a/moqt/session_test.go
+++ b/moqt/session_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"log/slog"
 	"net"
 	"testing"
 	"time"
@@ -49,7 +48,7 @@ func TestNewSession(t *testing.T) {
 				Path:             "test/path",
 				ClientExtensions: NewExtension(),
 			})
-			session := newSession(conn, sessStream, tt.mux, slog.Default(), nil)
+			session := newSession(conn, sessStream, tt.mux, nil)
 
 			if tt.expectOK {
 				assert.NotNil(t, session, "newSession should not return nil")
@@ -90,7 +89,7 @@ func TestNewSessionWithNilMux(t *testing.T) {
 				Path:             "test/path",
 				ClientExtensions: NewExtension(),
 			})
-			session := newSession(conn, sessStream, tt.mux, slog.Default(), nil)
+			session := newSession(conn, sessStream, tt.mux, nil)
 
 			if tt.expectDefault {
 				assert.Equal(t, DefaultMux, session.mux, "should use DefaultMux when nil mux is provided")
@@ -119,7 +118,7 @@ func TestNewSession_WithNilLogger(t *testing.T) {
 		ClientExtensions: NewExtension(),
 	})
 
-	session := newSession(conn, sessStream, NewTrackMux(), nil, nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	assert.NotNil(t, session, "session should be created with nil logger")
 
@@ -153,7 +152,7 @@ func TestNewSession_SessionStreamClosure(t *testing.T) {
 		ClientExtensions: NewExtension(),
 	})
 
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 	assert.NotNil(t, session)
 
 	cancel()
@@ -199,7 +198,7 @@ func TestSession_CloseWithError(t *testing.T) {
 				Path:             "test/path",
 				ClientExtensions: NewExtension(),
 			})
-			session := newSession(conn, sessStream, nil, slog.Default(), nil)
+			session := newSession(conn, sessStream, nil, nil)
 
 			err := session.CloseWithError(tt.code, tt.msg)
 			assert.NoError(t, err, "CloseWithError should not return error")
@@ -266,7 +265,7 @@ func TestSession_Subscribe(t *testing.T) {
 				Path:             "test/path",
 				ClientExtensions: NewExtension(),
 			})
-			session := newSession(conn, sessStream, nil, slog.Default(), nil)
+			session := newSession(conn, sessStream, nil, nil)
 
 			track, err := session.Subscribe(tt.path, tt.name, tt.config)
 
@@ -304,7 +303,7 @@ func TestSession_Subscribe_OpenError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, nil, slog.Default(), nil)
+	session := newSession(conn, sessStream, nil, nil)
 
 	config := &TrackConfig{
 		TrackPriority: TrackPriority(1),
@@ -341,7 +340,7 @@ func TestSession_Subscribe_OpenStreamApplicationError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, nil, slog.Default(), nil)
+	session := newSession(conn, sessStream, nil, nil)
 
 	config := &TrackConfig{TrackPriority: 1}
 
@@ -381,7 +380,7 @@ func TestSession_Subscribe_EncodeStreamTypeError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, nil, slog.Default(), nil)
+	session := newSession(conn, sessStream, nil, nil)
 
 	config := &TrackConfig{TrackPriority: 1}
 
@@ -422,7 +421,7 @@ func TestSession_Subscribe_EncodeStreamTypeStreamError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, nil, slog.Default(), nil)
+	session := newSession(conn, sessStream, nil, nil)
 
 	config := &TrackConfig{TrackPriority: 1}
 
@@ -474,7 +473,7 @@ func TestSession_Subscribe_NilConfig(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, nil, slog.Default(), nil)
+	session := newSession(conn, sessStream, nil, nil)
 
 	// Pass nil config - should use default
 	reader, err := session.Subscribe("/test", "video", nil)
@@ -520,7 +519,7 @@ func TestSession_Subscribe_EncodeSubscribeMessageStreamError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, nil, slog.Default(), nil)
+	session := newSession(conn, sessStream, nil, nil)
 
 	config := &TrackConfig{TrackPriority: 1}
 
@@ -570,7 +569,7 @@ func TestSession_Subscribe_EncodeSubscribeMessageRemoteStreamError(t *testing.T)
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, nil, slog.Default(), nil)
+	session := newSession(conn, sessStream, nil, nil)
 
 	config := &TrackConfig{TrackPriority: 1}
 
@@ -614,7 +613,7 @@ func TestSession_Subscribe_DecodeSubscribeOkStreamError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, nil, slog.Default(), nil)
+	session := newSession(conn, sessStream, nil, nil)
 
 	config := &TrackConfig{TrackPriority: 1}
 
@@ -656,7 +655,7 @@ func TestSession_Subscribe_DecodeSubscribeOkError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, nil, slog.Default(), nil)
+	session := newSession(conn, sessStream, nil, nil)
 
 	config := &TrackConfig{TrackPriority: 1}
 
@@ -684,7 +683,7 @@ func TestSession_Context(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, nil, slog.Default(), nil)
+	session := newSession(conn, sessStream, nil, nil)
 
 	ctx := session.Context()
 	assert.NotNil(t, ctx, "Context should not be nil")
@@ -709,7 +708,7 @@ func TestSession_nextSubscribeID(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, nil, slog.Default(), nil)
+	session := newSession(conn, sessStream, nil, nil)
 
 	id1 := session.nextSubscribeID()
 	id2 := session.nextSubscribeID()
@@ -749,7 +748,7 @@ func TestSession_HandleBiStreams_AcceptError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, nil, slog.Default(), nil)
+	session := newSession(conn, sessStream, nil, nil)
 
 	// Wait for the background goroutine to attempt AcceptStream/AcceptUniStream
 	select {
@@ -782,7 +781,7 @@ func TestSession_HandleUniStreamsAcceptError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, nil, slog.Default(), nil)
+	session := newSession(conn, sessStream, nil, nil)
 
 	// Wait a bit for the background goroutine to try accepting
 	time.Sleep(50 * time.Millisecond)
@@ -813,7 +812,7 @@ func TestSession_ConcurrentAccess(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, nil, slog.Default(), nil)
+	session := newSession(conn, sessStream, nil, nil)
 
 	// Test concurrent access
 	done := make(chan struct{})
@@ -874,7 +873,7 @@ func TestSession_ContextCancellation(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, nil, slog.Default(), nil)
+	session := newSession(conn, sessStream, nil, nil)
 
 	ctx := session.Context()
 	assert.NotNil(t, ctx)
@@ -910,7 +909,7 @@ func TestSession_WithRealMux(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, mux, slog.Default(), nil)
+	session := newSession(conn, sessStream, mux, nil)
 
 	assert.Equal(t, mux, session.mux, "Mux should be set correctly in the session")
 
@@ -936,7 +935,7 @@ func TestSession_GoAway(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	// Test goAway - now it calls updateSession
 	err := session.goAway("test-uri")
@@ -1020,7 +1019,7 @@ func TestSession_AcceptAnnounce(t *testing.T) {
 				Path:             "test/path",
 				ClientExtensions: NewExtension(),
 			})
-			session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+			session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 			announceStream := &MockQUICStream{}
 			tt.setupMocks(conn, announceStream)
@@ -1057,7 +1056,7 @@ func TestSession_AddTrackWriter(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	writer := &TrackWriter{}
 	id := SubscribeID(1)
@@ -1087,7 +1086,7 @@ func TestSession_RemoveTrackWriter(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	writer := &TrackWriter{}
 	id := SubscribeID(1)
@@ -1118,7 +1117,7 @@ func TestSession_RemoveTrackReader(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	reader := &TrackReader{}
 	id := SubscribeID(1)
@@ -1156,7 +1155,7 @@ func TestSession_AddTrackReader(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	reader := &TrackReader{}
 	id := SubscribeID(1)
@@ -1183,7 +1182,7 @@ func TestSession_ProcessBiStream_Announce(t *testing.T) {
 		ClientExtensions: NewExtension(),
 	})
 	mux := NewTrackMux()
-	session := newSession(conn, sessStream, mux, slog.Default(), nil)
+	session := newSession(conn, sessStream, mux, nil)
 
 	// Create a mock stream for ANNOUNCE
 	mockStream := &MockQUICStream{}
@@ -1223,12 +1222,10 @@ func TestSession_ProcessBiStream_Announce(t *testing.T) {
 		return n, err
 	}
 
-	streamLogger := slog.Default().With("stream_id", mockStream.StreamID())
-
 	// This will block, so we run it in a goroutine
 	done := make(chan struct{})
 	go func() {
-		session.processBiStream(mockStream, streamLogger)
+		session.processBiStream(mockStream)
 		close(done)
 	}()
 
@@ -1260,7 +1257,7 @@ func TestSession_ProcessBiStream_Subscribe(t *testing.T) {
 		ClientExtensions: NewExtension(),
 	})
 	mux := NewTrackMux()
-	session := newSession(conn, sessStream, mux, slog.Default(), nil)
+	session := newSession(conn, sessStream, mux, nil)
 
 	// Create a mock stream for SUBSCRIBE
 	mockStream := &MockQUICStream{}
@@ -1308,12 +1305,10 @@ func TestSession_ProcessBiStream_Subscribe(t *testing.T) {
 		}
 	})
 
-	streamLogger := slog.Default().With("stream_id", mockStream.StreamID())
-
 	// This will block in serveTrack, so we run it in a goroutine
 	done := make(chan struct{})
 	go func() {
-		session.processBiStream(mockStream, streamLogger)
+		session.processBiStream(mockStream)
 		close(done)
 	}()
 
@@ -1352,7 +1347,7 @@ func TestSession_ProcessBiStream_InvalidStreamType(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	// Create a mock stream with invalid stream type
 	mockStream := &MockQUICStream{}
@@ -1372,11 +1367,9 @@ func TestSession_ProcessBiStream_InvalidStreamType(t *testing.T) {
 		return n, nil
 	}
 
-	streamLogger := slog.Default().With("stream_id", mockStream.StreamID())
-
 	done := make(chan struct{})
 	go func() {
-		session.processBiStream(mockStream, streamLogger)
+		session.processBiStream(mockStream)
 		close(done)
 	}()
 
@@ -1406,7 +1399,7 @@ func TestSession_ProcessBiStream_DecodeStreamTypeError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	mockStream := &MockQUICStream{}
 	mockStream.On("StreamID").Return(quic.StreamID(5))
@@ -1414,11 +1407,9 @@ func TestSession_ProcessBiStream_DecodeStreamTypeError(t *testing.T) {
 		return 0, io.ErrUnexpectedEOF
 	}
 
-	streamLogger := slog.Default().With("stream_id", mockStream.StreamID())
-
 	done := make(chan struct{})
 	go func() {
-		session.processBiStream(mockStream, streamLogger)
+		session.processBiStream(mockStream)
 		close(done)
 	}()
 
@@ -1447,10 +1438,10 @@ func TestSession_ProcessBiStream_DecodeAnnounceMessageError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	mockStream := &MockQUICStream{}
-	mockStream.On("StreamID").Return(quic.StreamID(7))
+	mockStream.On("StreamID").Return(quic.StreamID(7)).Maybe()
 	mockStream.On("CancelWrite", mock.Anything).Return().Maybe()
 	mockStream.On("CancelRead", mock.Anything).Return().Maybe()
 
@@ -1468,8 +1459,7 @@ func TestSession_ProcessBiStream_DecodeAnnounceMessageError(t *testing.T) {
 		return 0, io.ErrUnexpectedEOF
 	}
 
-	streamLogger := slog.Default().With("stream_id", mockStream.StreamID())
-	session.processBiStream(mockStream, streamLogger)
+	session.processBiStream(mockStream)
 
 	mockStream.AssertExpectations(t)
 }
@@ -1490,10 +1480,10 @@ func TestSession_ProcessBiStream_DecodeSubscribeMessageError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	mockStream := &MockQUICStream{}
-	mockStream.On("StreamID").Return(quic.StreamID(9))
+	mockStream.On("StreamID").Return(quic.StreamID(9)).Maybe()
 	mockStream.On("CancelWrite", mock.Anything).Return().Maybe()
 	mockStream.On("CancelRead", mock.Anything).Return().Maybe()
 
@@ -1511,8 +1501,7 @@ func TestSession_ProcessBiStream_DecodeSubscribeMessageError(t *testing.T) {
 		return 0, io.ErrUnexpectedEOF
 	}
 
-	streamLogger := slog.Default().With("stream_id", mockStream.StreamID())
-	session.processBiStream(mockStream, streamLogger)
+	session.processBiStream(mockStream)
 
 	mockStream.AssertExpectations(t)
 }
@@ -1533,7 +1522,7 @@ func TestSession_ProcessUniStream_Group(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	// Add a track reader
 	mockTrackStream := &MockQUICStream{}
@@ -1572,9 +1561,7 @@ func TestSession_ProcessUniStream_Group(t *testing.T) {
 	}
 	mockRecvStream.On("Context").Return(context.Background())
 
-	streamLogger := slog.Default().With("stream_id", mockRecvStream.StreamID())
-
-	session.processUniStream(mockRecvStream, streamLogger)
+	session.processUniStream(mockRecvStream)
 
 	// Verify group was enqueued
 	time.Sleep(10 * time.Millisecond)
@@ -1598,11 +1585,11 @@ func TestSession_ProcessUniStream_UnknownSubscribeID(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	// Create a mock receive stream for GROUP with unknown subscribe ID
 	mockRecvStream := &MockQUICReceiveStream{}
-	mockRecvStream.On("StreamID").Return(quic.StreamID(5))
+	mockRecvStream.On("StreamID").Return(quic.StreamID(5)).Maybe()
 	mockRecvStream.On("CancelRead", quic.StreamErrorCode(InvalidSubscribeIDErrorCode)).Return()
 
 	// Prepare StreamType + GroupMessage with unknown subscribe ID
@@ -1626,9 +1613,7 @@ func TestSession_ProcessUniStream_UnknownSubscribeID(t *testing.T) {
 		return n, nil
 	}
 
-	streamLogger := slog.Default().With("stream_id", mockRecvStream.StreamID())
-
-	session.processUniStream(mockRecvStream, streamLogger)
+	session.processUniStream(mockRecvStream)
 
 	mockRecvStream.AssertExpectations(t)
 
@@ -1651,7 +1636,7 @@ func TestSession_ProcessUniStream_InvalidStreamType(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	// Create a mock receive stream with invalid stream type
 	mockRecvStream := &MockQUICReceiveStream{}
@@ -1671,11 +1656,9 @@ func TestSession_ProcessUniStream_InvalidStreamType(t *testing.T) {
 		return n, nil
 	}
 
-	streamLogger := slog.Default().With("stream_id", mockRecvStream.StreamID())
-
 	done := make(chan struct{})
 	go func() {
-		session.processUniStream(mockRecvStream, streamLogger)
+		session.processUniStream(mockRecvStream)
 		close(done)
 	}()
 
@@ -1705,16 +1688,15 @@ func TestSession_ProcessUniStream_DecodeStreamTypeError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	mockRecvStream := &MockQUICReceiveStream{}
-	mockRecvStream.On("StreamID").Return(quic.StreamID(11))
+	mockRecvStream.On("StreamID").Return(quic.StreamID(11)).Maybe()
 	mockRecvStream.ReadFunc = func(p []byte) (int, error) {
 		return 0, io.ErrUnexpectedEOF
 	}
 
-	streamLogger := slog.Default().With("stream_id", mockRecvStream.StreamID())
-	session.processUniStream(mockRecvStream, streamLogger)
+	session.processUniStream(mockRecvStream)
 
 	mockRecvStream.AssertExpectations(t)
 }
@@ -1735,10 +1717,10 @@ func TestSession_ProcessUniStream_DecodeGroupMessageError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	mockRecvStream := &MockQUICReceiveStream{}
-	mockRecvStream.On("StreamID").Return(quic.StreamID(13))
+	mockRecvStream.On("StreamID").Return(quic.StreamID(13)).Maybe()
 
 	var buf bytes.Buffer
 	err := message.StreamTypeGroup.Encode(&buf)
@@ -1754,8 +1736,7 @@ func TestSession_ProcessUniStream_DecodeGroupMessageError(t *testing.T) {
 		return 0, io.ErrUnexpectedEOF
 	}
 
-	streamLogger := slog.Default().With("stream_id", mockRecvStream.StreamID())
-	session.processUniStream(mockRecvStream, streamLogger)
+	session.processUniStream(mockRecvStream)
 
 	mockRecvStream.AssertExpectations(t)
 }
@@ -1776,7 +1757,7 @@ func TestSession_Subscribe_TerminatingSession(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	// Terminate the session
 	err := session.CloseWithError(NoError, "")
@@ -1812,7 +1793,7 @@ func TestSession_AcceptAnnounce_TerminatingSession(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	// Terminate the session
 	err := session.CloseWithError(NoError, "")
@@ -1853,7 +1834,7 @@ func TestSession_AcceptAnnounce_OpenStreamApplicationError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	reader, err := session.AcceptAnnounce("/test/prefix/")
 
@@ -1888,7 +1869,7 @@ func TestSession_AcceptAnnounce_EncodeStreamTypeError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	reader, err := session.AcceptAnnounce("/test/prefix/")
 
@@ -1927,7 +1908,7 @@ func TestSession_AcceptAnnounce_EncodeStreamTypeStreamError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	reader, err := session.AcceptAnnounce("/test/prefix/")
 
@@ -1978,7 +1959,7 @@ func TestSession_AcceptAnnounce_EncodePleaseMessageStreamError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	reader, err := session.AcceptAnnounce("/test/prefix/")
 
@@ -2021,7 +2002,7 @@ func TestSession_AcceptAnnounce_DecodeInitMessageStreamError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	reader, err := session.AcceptAnnounce("/test/prefix/")
 
@@ -2059,7 +2040,7 @@ func TestSession_AcceptAnnounce_DecodeInitMessageError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	reader, err := session.AcceptAnnounce("/test/prefix/")
 
@@ -2085,7 +2066,7 @@ func TestSession_CloseWithError_AlreadyTerminating(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	// First termination
 	err1 := session.CloseWithError(NoError, "first termination")
@@ -2120,7 +2101,7 @@ func TestSession_Terminate_WithApplicationError(t *testing.T) {
 		Path:             "test/path",
 		ClientExtensions: NewExtension(),
 	})
-	session := newSession(conn, sessStream, NewTrackMux(), slog.Default(), nil)
+	session := newSession(conn, sessStream, NewTrackMux(), nil)
 
 	err := session.CloseWithError(InternalSessionErrorCode, "test error")
 


### PR DESCRIPTION
## 概要

`Server` / `Client` のロガー設計を整理し、シンプルかつ Go の慣習に沿った形にしました。

## 変更内容

### ロガーの引き回しを廃止
- `Session`・`sessionStream`・`responseWriter` から `logger` フィールド・`connLogger` パラメータを削除
- `newSession` / `newResponseWriter` のシグネチャを簡素化
- `processBiStream` / `processUniStream` から `streamLogger` 引数を削除

### nil-safe ヘルパーを追加
- `Server.log() *slog.Logger` — `Server.Logger` が nil なら `slog.DiscardHandler`
- `Client.log() *slog.Logger` — `Client.Logger` が nil なら `slog.DiscardHandler`

### `.With()` エンリッチメントを廃止
- `makeConnLogger` ヘルパーを削除
- `init()` 内の `s.Logger.With("address", s.Addr)` を削除
- `DialWebTransport` / `DialQUIC` 内の `baseLogger.With(...)` パターンを削除
- ログ属性（transport / alpn / quic_version / local_address など）の付加はアプリケーション側の責務とする

### セットアップハンドラのパニック回復を整備
- `serveSetup(w, req)` メソッドを追加し、ハンドラのパニックを `s.log().Error(...)` で記録したうえで `Reject` する

### plain HTTP 接続のガードを追加
- `HandleWebTransport` の冒頭で `r.TLS == nil` を検出
- `s.log().Warn(...)` でログ出力 + HTTP 426 Upgrade Required を返す

### router.go のロック修正
- `ServeMOQ` で `defer r.mu.RUnlock()` を解除し、ハンドラ呼び出し前に `RLock` を解放するよう修正（デッドロック防止）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling with panic recovery in setup request processing to prevent unexpected failures.
  * Improved connection establishment logging for better visibility into connection lifecycle.

* **Security**
  * Enforced HTTPS requirement for WebTransport connections.

* **Improvements**
  * Centralized logging infrastructure for more consistent error reporting across connections.
  * Optimized lock management for improved concurrency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->