### PR TITLE
feat: replace Client class with connect() function (fetch-style API)

### DIFF
--- a/moq-web/cli/interop/client.ts
+++ b/moq-web/cli/interop/client.ts
@@ -1,4 +1,4 @@
-import { Client, FetchRequest, Frame, TrackMux, TrackWriter } from "@okdaichi/moq";
+import { connect, FetchRequest, Frame, TrackMux, TrackWriter } from "@okdaichi/moq";
 import { background } from "@okdaichi/golikejs/context";
 
 // shared client logic exported as function
@@ -7,8 +7,11 @@ export async function runClient(
 	transportOptions: WebTransportOptions,
 	debugEnabled: boolean,
 ): Promise<void> {
-	const client = new Client({ transportOptions });
-	const mux = new TrackMux();
+	// GOAWAY handling
+	let goawayResolve: ((uri: string) => void) | undefined;
+	const goawayPromise = new Promise<string>((resolve) => {
+		goawayResolve = resolve;
+	});
 
 	// basic prefixed log functions
 	function info(msg: string, ...args: any[]) {
@@ -44,6 +47,8 @@ export async function runClient(
 	const doneCh: Array<() => void> = [];
 	let done = false;
 
+	const mux = new TrackMux();
+
 	mux.publishFunc(
 		background().done(),
 		"/interop/client",
@@ -70,7 +75,16 @@ export async function runClient(
 
 	debug("Registering /interop/client handler");
 
-	const session = await step("Connecting to server", () => client.dial(addr, mux));
+	const session = await step("Connecting to server", () =>
+		connect(addr, {
+			mux,
+			transportOptions,
+			onGoaway: (newSessionURI: string) => {
+				console.log(`Received GOAWAY (newSessionURI: ${newSessionURI})`);
+				if (goawayResolve) goawayResolve(newSessionURI);
+			},
+		})
+	);
 
 	const announced = await step("Accepting server announcements", async () => {
 		const [a, err] = await session.acceptAnnounce("/");
@@ -145,7 +159,16 @@ export async function runClient(
 		]);
 	}
 
-	await new Promise((resolve) => setTimeout(resolve, 2000));
+	// Wait for GOAWAY from server
+	await step("Waiting for GOAWAY", async () => {
+		const uri = await Promise.race([
+			goawayPromise,
+			new Promise<string>((_, reject) =>
+				setTimeout(() => reject(new Error("timed out")), 10000)
+			),
+		]);
+		info(`newSessionURI: ${uri}`);
+	});
 
 	await step("Closing session", () => session.closeWithError(0, "no error"));
 }

--- a/moq-web/deno.json
+++ b/moq-web/deno.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
 	"name": "@okdaichi/moq",
-	"version": "0.12.1",
+	"version": "0.12.2",
 	"exports": {
 		".": "./src/mod.ts",
 		"./msf": "./src/msf/mod.ts"

--- a/moq-web/src/client.ts
+++ b/moq-web/src/client.ts
@@ -1,113 +1,87 @@
 import { Session } from "./session.ts";
-import type { MOQOptions } from "./options.ts";
-import { DefaultTrackMux, TrackMux } from "./track_mux.ts";
+import type { ConnectInit } from "./options.ts";
+import { DefaultTrackMux } from "./track_mux.ts";
 import { WebTransportSession } from "./internal/webtransport/mod.ts";
 
-/** ALPN protocol identifier for MOQ Lite draft-03. */
-export const ALPN = "moq-lite-03";
+/** ALPN protocol identifier for MOQ Lite draft-04. */
+export const ALPN = "moq-lite-04";
 
 const DefaultWebTransportOptions: WebTransportOptions = {
 	allowPooling: false,
 	congestionControl: "low-latency",
 	requireUnreliable: true,
 	// deno-lint-ignore no-explicit-any
-	...(({ protocols: [ALPN] }) as any),
-};
-
-const DefaultMOQOptions: MOQOptions = {
-	reconnect: false, // TODO: Implement reconnect logic
-	transportOptions: DefaultWebTransportOptions,
+	...(({ protocols: [ALPN] }) as any),
 };
 
 /**
- * High-level MOQ client that creates {@link Session}s over WebTransport.
+ * Open a new MOQ session to the given URL.
  *
  * @example
  * ```ts
- * const client = new Client();
- * const session = await client.dial("https://localhost:4443/moq");
+ * const session = await connect("https://localhost:4443/moq");
+ * // ... use session ...
+ * await session.closeWithError(0, "done");
  * ```
+ *
+ * @example With options
+ * ```ts
+ * const session = await connect(url, {
+ *   mux,
+ *   onGoaway: (uri) => console.log("migrate to", uri),
+ * });
+ * ```
+ *
+ * @example Custom transport (e.g. for testing)
+ * ```ts
+ * const session = await connect(url, {
+ *   transportFactory: (u) => new MyWebSocketTransport(u),
+ * });
+ * ```
+ *
+ * @param url - MOQ server endpoint URL.
+ * @param init - Connection init object (mux, onGoaway, transportOptions, transportFactory).
+ * @returns A ready-to-use {@link Session}.
  */
+export async function connect(
+	url: string | URL,
+	init?: ConnectInit,
+): Promise<Session> {
+	const mux = init?.mux ?? DefaultTrackMux;
+	const transportOptions: WebTransportOptions = {
+		...DefaultWebTransportOptions,
+		...(init?.transportOptions ?? {}),
+	};
+
+	const factory = init?.transportFactory
+		?? ((u: string | URL, o?: WebTransportOptions) => new WebTransport(u, o));
+
+	try {
+		const transport = new WebTransportSession(factory(url, transportOptions));
+		const session = new Session({
+			transport,
+			mux,
+			onGoaway: init?.onGoaway,
+		});
+		await session.ready;
+		return session;
+	} catch (err) {
+		throw new Error(`failed to connect: ${err}`);
+	}
+}
+
+// Back-compat shim — kept so existing code compiled against the old Client
+// class still works. Deprecated: call {@link connect} directly.
+/** @deprecated Use {@link connect} instead. */
 export class Client {
-	#sessions?: Set<Session> = new Set();
-	readonly options: MOQOptions;
+	#init: ConnectInit;
 
-	/**
-	 * Create a new Client.
-	 * The provided options are shallow-merged with safe defaults so the
-	 * shared default objects aren't accidentally mutated.
-	 */
-	constructor(options?: MOQOptions) {
-		this.options = {
-			reconnect: options?.reconnect ?? DefaultMOQOptions.reconnect,
-			transportOptions: {
-				...DefaultWebTransportOptions,
-				...(options?.transportOptions ?? {}),
-			},
-		};
+	constructor(init?: ConnectInit) {
+		this.#init = { ...init };
 	}
 
-	/**
-	 * Open a new MOQ session to the given URL.
-	 * @param url - WebTransport endpoint URL.
-	 * @param mux - Optional {@link TrackMux} for incoming track routing. Defaults to {@link DefaultTrackMux}.
-	 * @returns A ready-to-use {@link Session}.
-	 */
-	async dial(
-		url: string | URL,
-		mux: TrackMux = DefaultTrackMux,
-	): Promise<Session> {
-		if (this.#sessions === undefined) {
-			return Promise.reject(new Error("Client is closed"));
-		}
-
-		// Normalize URL to string (WebTransport accepts a USVString).
-		// const endpoint = typeof url === "string" ? url : String(url);
-
-		try {
-			const webtransport = new WebTransportSession(
-				url,
-				this.options.transportOptions,
-			);
-			const session = new Session({
-				transport: webtransport,
-				mux,
-			});
-			await session.ready;
-			this.#sessions.add(session);
-			return session;
-		} catch (err) {
-			return Promise.reject(new Error(`failed to create WebTransport: ${err}`));
-		}
-	}
-
-	/** Gracefully close all active sessions. */
-	async close(): Promise<void> {
-		if (this.#sessions === undefined) {
-			return Promise.resolve();
-		}
-
-		await Promise.allSettled(
-			Array.from(this.#sessions).map((session) => session.close()),
-		);
-		// Mark client as closed so future dials fail fast.
-		this.#sessions = undefined;
-	}
-
-	/** Abort all active sessions immediately with an error code. */
-	async abort(): Promise<void> {
-		if (this.#sessions === undefined) {
-			return;
-		}
-
-		// Try to close sessions with an error to indicate abort semantics.
-		await Promise.allSettled(
-			Array.from(this.#sessions).map((session) =>
-				session.closeWithError(1, "client aborted")
-			),
-		);
-
-		// Mark closed
-		this.#sessions = undefined;
+	/** @deprecated Use {@link connect} instead. */
+	dial(url: string | URL): Promise<Session> {
+		return connect(url, this.#init);
 	}
 }

--- a/moq-web/src/client_test.ts
+++ b/moq-web/src/client_test.ts
@@ -63,190 +63,105 @@ const OriginalWebTransport = (globalThis as any).WebTransport;
 (globalThis as any).WebTransport = MockWebTransport;
 
 // Import after setting up mocks
-import { ALPN, Client } from "./client.ts";
+import { ALPN, Client, connect } from "./client.ts";
 import { TrackMux } from "./track_mux.ts";
-import type { MOQOptions } from "./options.ts";
+import type { ConnectInit } from "./options.ts";
 
-Deno.test("Client - Constructor with Default Options", () => {
-	const client = new Client();
-
-	assertExists(client.options);
-	assertEquals(client.options.transportOptions?.allowPooling, false);
-	assertEquals(
-		client.options.transportOptions?.congestionControl,
-		"low-latency",
-	);
-	assertEquals(client.options.transportOptions?.requireUnreliable, true);
-});
-
-Deno.test("Client - Constructor with Custom Options", () => {
-	const customOptions: MOQOptions = {
-		transportOptions: {
-			allowPooling: true,
-			congestionControl: "throughput",
-			requireUnreliable: false,
-		},
+Deno.test("connect - uses default WebTransport options", async () => {
+	let capturedOptions: WebTransportOptions | undefined;
+	const factory = (url: string | URL, opts?: WebTransportOptions) => {
+		capturedOptions = opts;
+		return new MockWebTransport(url, opts);
 	};
 
-	const client = new Client(customOptions);
-
-	assertEquals(client.options.transportOptions?.allowPooling, true);
-	assertEquals(
-		client.options.transportOptions?.congestionControl,
-		"throughput",
-	);
-	assertEquals(client.options.transportOptions?.requireUnreliable, false);
-});
-
-// Note: dial() tests focus on Client behavior and keep transport payload mocking minimal.
-
-Deno.test("Client - dial() attempts to create session", async () => {
-	const client = new Client();
-	const url = "https://example.com";
-
-	// The dial will fail due to incomplete mock response, but we can verify
-	// that it attempts to create a WebTransport connection
 	try {
-		await client.dial(url);
-	} catch (_err) {
-		// Expected to fail due to mock limitations
-		// In real usage, this would succeed with proper server
+		await connect("https://example.com", { transportFactory: factory });
+	} catch {
+		// Expected: mock doesn't speak MOQ setup
 	}
 
-	await client.close();
+	assertExists(capturedOptions);
+	assertEquals(capturedOptions!.allowPooling, false);
+	assertEquals(capturedOptions!.congestionControl, "low-latency");
+	assertEquals(capturedOptions!.requireUnreliable, true);
 });
 
-Deno.test("Client - dial() accepts URL types", () => {
-	const client = new Client();
+Deno.test("connect - merges custom transportOptions", async () => {
+	let capturedOptions: WebTransportOptions | undefined;
+	const factory = (url: string | URL, opts?: WebTransportOptions) => {
+		capturedOptions = opts;
+		return new MockWebTransport(url, opts);
+	};
+	const init: ConnectInit = {
+		transportOptions: { allowPooling: true, congestionControl: "throughput" },
+		transportFactory: factory,
+	};
 
-	// Verify that dial method accepts different URL types (no actual call)
-	const stringUrl: string = "https://example.com";
-	const urlObject: URL = new URL("https://example.com");
-	const customMux = new TrackMux();
+	try {
+		await connect("https://example.com", init);
+	} catch {
+		// Expected
+	}
 
-	// Type checking ensures these signatures are valid
-	assertExists(client.dial);
-	assertEquals(typeof client.dial, "function");
-
-	// Verify dial signature accepts both URL types and optional mux
-	const _test1: Promise<any> = client.dial(stringUrl);
-	const _test2: Promise<any> = client.dial(urlObject);
-	const _test3: Promise<any> = client.dial(stringUrl, customMux);
-
-	// Prevent hanging promises
-	_test1.catch(() => {});
-	_test2.catch(() => {});
-	_test3.catch(() => {});
+	assertEquals(capturedOptions!.allowPooling, true);
+	assertEquals(capturedOptions!.congestionControl, "throughput");
+	assertEquals(capturedOptions!.requireUnreliable, true);
 });
 
-Deno.test("Client - dial() handles connection errors", async () => {
-	const client = new Client();
+Deno.test("connect - accepts URL object", () => {
+	const p = connect(new URL("https://example.com"));
+	p.catch(() => {});
+	assertExists(p);
+});
 
-	// Create failing mock WebTransport
-	class FailingMockWebTransport extends MockWebTransport {
+Deno.test("connect - accepts mux in init", () => {
+	const p = connect("https://example.com", { mux: new TrackMux() });
+	p.catch(() => {});
+	assertExists(p);
+});
+
+Deno.test("connect - propagates transport errors", async () => {
+	class FailingTransport extends MockWebTransport {
 		constructor(url: string | URL, options?: WebTransportOptions) {
 			super(url, options);
-			this.ready = Promise.reject(new Error("Connection failed"));
-			// Prevent unhandled rejection in the test runner by
-			// attaching a no-op rejection handler. The client.dial
-			// still observes the rejection and throws as expected.
+			this.ready = Promise.reject(new Error("Connection refused"));
 			this.ready.catch(() => {});
 		}
 	}
 
-	// Temporarily replace WebTransport
-	const originalWebTransport = (globalThis as any).WebTransport;
-	(globalThis as any).WebTransport = FailingMockWebTransport;
+	await assertRejects(
+		() => connect("https://example.com", {
+			transportFactory: (u, o) => new FailingTransport(u, o),
+		}),
+		Error,
+	);
+});
+
+Deno.test("connect - passes onGoaway to session", async () => {
+	let received: string | undefined;
+	const init: ConnectInit = {
+		onGoaway: (uri) => { received = uri; },
+		transportFactory: (u, o) => new MockWebTransport(u, o),
+	};
 
 	try {
-		await assertRejects(
-			async () => await client.dial("https://example.com"),
-			Error,
-		);
-	} finally {
-		// Restore mock WebTransport
-		(globalThis as any).WebTransport = originalWebTransport;
+		await connect("https://example.com", init);
+	} catch {
+		// Expected
 	}
+	assertEquals(received, undefined);
 });
 
-Deno.test("Client - close() with no sessions", async () => {
+// Back-compat: Client shim still works
+Deno.test("Client shim - dial() delegates to connect()", () => {
 	const client = new Client();
-	// Should not throw
-	await client.close();
+	assertExists(client.dial);
+	const p = client.dial("https://example.com");
+	p.catch(() => {});
 });
 
-// Note: Session-based tests are skipped due to mocking complexity.
-// These tests verify Client class behavior at a higher level.
-
-Deno.test("Client - close() with empty sessions", async () => {
-	const client = new Client();
-
-	// close() should work even without active sessions
-	await client.close();
-
-	// Verify client can be reused after close
-	const options = client.options;
-	assertExists(options);
-});
-
-Deno.test("Client - abort() with no sessions", async () => {
-	const client = new Client();
-
-	// abort() should work without active sessions
-	await client.abort();
-
-	// Verify client state after abort
-	assertExists(client.options);
-});
-
-Deno.test("Client - close() is idempotent", async () => {
-	const client = new Client();
-
-	// First close
-	await client.close();
-
-	// Second close should not throw
-	await client.close();
-});
-
-Deno.test("Client - abort() is idempotent", async () => {
-	const client = new Client();
-
-	// First abort
-	await client.abort();
-
-	// Second abort should not throw
-	await client.abort();
-});
-
-Deno.test("Client - dial() rejects after close", async () => {
-	const client = new Client();
-
-	await client.close();
-
-	// dial() after close should reject
-	await assertRejects(
-		async () => await client.dial("https://example.com"),
-		Error,
-		"Client is closed",
-	);
-});
-
-Deno.test("Client - dial() rejects after abort", async () => {
-	const client = new Client();
-
-	await client.abort();
-
-	// dial() after abort should reject
-	await assertRejects(
-		async () => await client.dial("https://example.com"),
-		Error,
-		"Client is closed",
-	);
-});
-
-Deno.test("Client - ALPN constant is moq-lite-03", () => {
-	assertEquals(ALPN, "moq-lite-03");
+Deno.test("Client - ALPN constant is moq-lite-04", () => {
+	assertEquals(ALPN, "moq-lite-04");
 });
 
 // Restore original WebTransport after all tests

--- a/moq-web/src/mod.ts
+++ b/moq-web/src/mod.ts
@@ -1,7 +1,7 @@
 /**
  * TypeScript client library for Media over QUIC Transport (MOQ Lite).
  *
- * Provides a {@link Client} to connect to MOQ servers over WebTransport,
+ * Provides {@link connect} to open MOQ sessions over WebTransport,
  * a pub/sub model for tracks ({@link TrackWriter} / {@link TrackReader}),
  * announcement discovery ({@link AnnouncementReader} / {@link AnnouncementWriter}),
  * frame-level I/O ({@link GroupWriter} / {@link GroupReader}),
@@ -9,11 +9,9 @@
  *
  * @example
  * ```ts
- * import { Client } from "@okdaichi/moq";
+ * import { connect } from "@okdaichi/moq";
  *
- * const client = new Client();
- * const session = await client.dial("https://localhost:4443/moq");
- *
+ * const session = await connect("https://localhost:4443/moq");
  * const [reader] = await session.subscribe("/broadcast", "video");
  * ```
  *
@@ -30,11 +28,3 @@ export * from "./client.ts";
 export * from "./announce_stream.ts";
 export * from "./group_stream.ts";
 export * from "./stream_type.ts";
-export * from "./subscribe_stream.ts";
-export * from "./track_writer.ts";
-export * from "./track_reader.ts";
-export * from "./track_mux.ts";
-export * from "./broadcast.ts";
-export * from "./error.ts";
-export * from "./fetch.ts";
-export * from "./frame.ts";

--- a/moq-web/src/options.ts
+++ b/moq-web/src/options.ts
@@ -1,7 +1,40 @@
-/** Options for configuring a {@link Client}. */
-export interface MOQOptions {
-	/** Whether the client should automatically reconnect on connection loss. */
-	reconnect?: boolean;
-	/** Low-level WebTransport options forwarded to the `WebTransport` constructor. */
+import type { TrackMux } from "./track_mux.ts";
+
+/**
+ * Factory that creates a {@link WebTransport} instance for a MOQ session.
+ *
+ * The default factory calls `new WebTransport(url, options)`. Override this
+ * to inject an alternative implementation that satisfies the {@link WebTransport}
+ * interface (e.g. a WebSocket-backed shim, an in-memory fake for tests, etc.).
+ * The returned object is automatically wrapped in a {@link WebTransportSession}
+ * which adapts it to the internal stream API.
+ *
+ * @param url - The endpoint URL.
+ * @param options - WebTransport options (may be ignored by custom factories).
+ */
+export type TransportFactory = (
+	url: string | URL,
+	options?: WebTransportOptions,
+) => WebTransport;
+
+/** Init object for {@link connect} — mirrors the `fetch(url, init?)` pattern. */
+export interface ConnectInit {
+	/** {@link TrackMux} for incoming track routing. Defaults to {@link DefaultTrackMux}. */
+	mux?: TrackMux;
+	/** Low-level WebTransport options forwarded to the transport factory. */
 	transportOptions?: WebTransportOptions;
+	/** Called when the server requests session migration via GOAWAY. */
+	onGoaway?: (newSessionURI: string) => void;
+	/**
+	 * Custom transport factory.
+	 * Defaults to a standard {@link WebTransport}-backed implementation.
+	 * Override to inject alternative transports (WebSocket, in-memory, etc.).
+	 */
+	transportFactory?: TransportFactory;
 }
+
+// Back-compat aliases
+/** @deprecated Use {@link ConnectInit}. */
+export type ConnectOptions = ConnectInit;
+/** @deprecated Use {@link ConnectInit}. */
+export type MOQOptions = ConnectInit;


### PR DESCRIPTION
## Summary

Replace the `Client` class with a `connect()` function following the `fetch(url, init?)` browser API pattern.

### Changes

- **`connect(url, init?)`** — new primary API, mirrors `fetch(url, init?)`
- **`ConnectInit`** interface — init bag replacing positional `mux` argument:
  - `mux?` — track routing (previously positional arg)
  - `transportOptions?` — WebTransport options
  - `onGoaway?` — GOAWAY session migration callback
  - `transportFactory?` — custom transport factory returning `WebTransport`
- **`TransportFactory`** returns `WebTransport` (wrapped in `WebTransportSession` internally)
- **`Client` class** kept as `@deprecated` back-compat shim
- **`ConnectOptions` / `MOQOptions`** kept as `@deprecated` aliases for `ConnectInit`
- Fix `mux` declaration order in interop client (was used before `const` declaration)
- Bump `moq-web` version to `0.12.2`