### PR TITLE
Add unit test for NewHopID to ensure it fits within 62-bit varint range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **moqt:** added `NewWebTransportServer(handler http.Handler)` factory function that creates a `WebTransportServer` with a custom `http.Handler`, allowing users to inject their own `ServeMux` or router instead of relying on `http.DefaultServeMux`.
 
+### Fixed
+
+- **moqt:** fixed `NewHopID()` so generated hop identifiers always fit within the 62-bit varint range used by MOQ wire encoding.
+
 ## [v0.13.0] - 2026-04-16
 
 ### Added

--- a/moqt/mux.go
+++ b/moqt/mux.go
@@ -27,7 +27,9 @@ func NewHopID() uint64 {
 		if _, err := rand.Read(b[:]); err != nil {
 			panic("moqt: crypto/rand unavailable: " + err.Error())
 		}
-		if id := binary.BigEndian.Uint64(b[:]); id != 0 {
+		// Mask to 62 bits to avoid overuint62
+		id := binary.BigEndian.Uint64(b[:]) & 0x3FFFFFFFFFFFFFFF
+		if id != 0 {
 			return id
 		}
 	}

--- a/moqt/mux_test.go
+++ b/moqt/mux_test.go
@@ -25,6 +25,16 @@ func TestNewTrackMux(t *testing.T) {
 	assert.NotNil(t, &mux.announcementTree, "mux announcementTree should be initialized")
 }
 
+func TestNewHopID_Fits62BitVarint(t *testing.T) {
+	const maxHopID uint64 = 0x3FFFFFFFFFFFFFFF
+
+	for i := 0; i < 1000; i++ {
+		id := NewHopID()
+		assert.NotZero(t, id, "NewHopID should never return zero")
+		assert.LessOrEqual(t, id, maxHopID, "NewHopID should fit within 62-bit varint range")
+	}
+}
+
 // Test Mux.Publish method
 func TestMux_Publish(t *testing.T) {
 	mux := NewTrackMux(0)


### PR DESCRIPTION
## Description

This PR adds a unit test for the `NewHopID` function to verify that it generates IDs within the 62-bit varint range and never returns zero.

## Related Issue

Closes #

## Changes

- Introduced a test case for `NewHopID`.
- Updated `NewHopID` to mask the generated ID to fit within the 62-bit range.

## Testing

Tested by running the new unit test to ensure it passes consistently.

## Checklist

- [ ] Comments added for complex logic
- [ ] Documentation updated if needed
- [ ] Tests added/updated

