### PR TITLE
Refactor WebTransportSession documentation and remove ConnectionStats method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Repository owner changed from `okdaichi` to `qumo-dev`.
+- **moqt:** WebTransport sessions no longer expose transport connection stats through the public `WebTransportSession` API. Connection stats are now treated as an optional raw transport capability and are accessed via type assertions on the underlying connection implementation.
 
 ## [v0.13.4] - 2026-04-20
 

--- a/moqt/internal/webtransportgo/session_wrapper.go
+++ b/moqt/internal/webtransportgo/session_wrapper.go
@@ -6,7 +6,6 @@ import (
 	"net"
 
 	quicgo_webtransportgo "github.com/okdaichi/webtransport-go"
-	"github.com/quic-go/quic-go"
 	"github.com/qumo-dev/gomoqt/transport"
 )
 
@@ -73,8 +72,4 @@ func (conn *sessionWrapper) RemoteAddr() net.Addr {
 
 func (conn *sessionWrapper) Subprotocol() string {
 	return conn.sess.SessionState().ApplicationProtocol
-}
-
-func (conn *sessionWrapper) ConnectionStats() quic.ConnectionStats {
-	return conn.sess.ConnectionStats()
 }

--- a/transport/webtransport.go
+++ b/transport/webtransport.go
@@ -1,5 +1,9 @@
 package transport
 
+// WebTransportSession represents a WebTransport session and its stream-oriented
+// transport connection. It intentionally does not expose connection-level stats
+// directly; transports that support stats may offer them through the optional
+// ConnectionStatsProvider interface.
 type WebTransportSession interface {
 	StreamConn
 	Subprotocol() string

--- a/transport/webtransport.go
+++ b/transport/webtransport.go
@@ -2,8 +2,8 @@ package transport
 
 // WebTransportSession represents a WebTransport session and its stream-oriented
 // transport connection. It intentionally does not expose connection-level stats
-// directly; transports that support stats may offer them through the optional
-// ConnectionStatsProvider interface.
+// directly; transports that support stats may offer them through an optional
+// stats-provider interface implemented by the concrete session type.
 type WebTransportSession interface {
 	StreamConn
 	Subprotocol() string


### PR DESCRIPTION
## Description

Remove the `ConnectionStats` method from `sessionWrapper` and update the documentation for `WebTransportSession` to clarify that it does not expose connection-level stats directly.

## Related Issue

Closes #98

## Changes

- Removed `ConnectionStats` method from `sessionWrapper`.
- Updated documentation for `WebTransportSession`.

## Testing

How was this tested?

## Checklist

- [ ] Comments added for complex logic
- [ ] Documentation updated if needed
- [ ] Tests added/updated

