### PR TITLE
feat: improve session and probe configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **moqt:** `Session.ProbeTargets() <-chan ProbeResult` — publisher-side channel for the latest subscriber target bitrate (buffered 1, latest-value semantics).
+
 ### Changed
 
 - Repository owner changed from `okdaichi` to `qumo-dev`.
-- **moqt:** WebTransport sessions no longer expose transport connection stats through the public `WebTransportSession` API. Connection stats are now treated as an optional raw transport capability and are accessed via type assertions on the underlying connection implementation.
+- **moqt:** `Session.Probe(targetBitrate uint64) (<-chan ProbeResult, error)` — reuses the same stream on repeated calls; channel is closed when the stream or session ends.
+- **moqt:** `ProbeResult.RTT` removed; RTT is available via the underlying transport API.
+- **moqt:** Publisher enforces a single active incoming probe stream; a new stream cancels the previous one.
 
 ## [v0.13.4] - 2026-04-20
 

--- a/cmd/interop/client/main.go
+++ b/cmd/interop/client/main.go
@@ -122,12 +122,21 @@ func main() {
 
 	// Step 4: Probe the server bitrate
 	fmt.Print("Probing server bitrate...")
-	probeResult, err := sess.Probe(1_000_000)
+	probeCh, err := sess.Probe(1_000_000)
 	if err != nil {
 		fmt.Printf("failed\n  Error: %v\n", err)
 		return
 	}
-	fmt.Printf("ok (measured: %d bps, rtt: %d ms)\n", probeResult.Bitrate, probeResult.RTT)
+	probeResult, ok := <-probeCh
+	if !ok {
+		fmt.Printf("failed\n  Error: probe stream closed without result\n")
+		return
+	}
+	if probeResult.Err != nil {
+		fmt.Printf("failed\n  Error: %v\n", probeResult.Err)
+		return
+	}
+	fmt.Printf("ok (measured: %d bps)\n", probeResult.Bitrate)
 
 	// Channel to signal that the publish handler has completed
 	doneCh := make(chan struct{}, 1)

--- a/moqt/config.go
+++ b/moqt/config.go
@@ -9,6 +9,19 @@ type Config struct {
 	// SetupTimeout is the maximum time to wait for session setup to complete.
 	// If zero, a default timeout of 5 seconds is used.
 	SetupTimeout time.Duration
+
+	// ProbeInterval is the ticker period for the publisher-side probe loop.
+	// If zero, defaults to 100ms.
+	ProbeInterval time.Duration
+
+	// ProbeMaxAge is the maximum interval between probe sends regardless of
+	// bitrate change. If zero, defaults to 10s.
+	ProbeMaxAge time.Duration
+
+	// ProbeMaxDelta is the fractional change threshold (0.0–1.0) that triggers
+	// an early probe send before ProbeMaxAge elapses.
+	// If zero, defaults to 0.10 (10%).
+	ProbeMaxDelta float64
 }
 
 // setupTimeout returns the configured setup timeout or a default value.
@@ -19,12 +32,39 @@ func (c *Config) setupTimeout() time.Duration {
 	return 5 * time.Second
 }
 
+// probeInterval returns the configured probe interval or the default (100ms).
+func (c *Config) probeInterval() time.Duration {
+	if c != nil && c.ProbeInterval > 0 {
+		return c.ProbeInterval
+	}
+	return 100 * time.Millisecond
+}
+
+// probeMaxAge returns the configured probe max age or the default (10s).
+func (c *Config) probeMaxAge() time.Duration {
+	if c != nil && c.ProbeMaxAge > 0 {
+		return c.ProbeMaxAge
+	}
+	return 10 * time.Second
+}
+
+// probeMaxDelta returns the configured probe max delta or the default (0.10).
+func (c *Config) probeMaxDelta() float64 {
+	if c != nil && c.ProbeMaxDelta > 0 {
+		return c.ProbeMaxDelta
+	}
+	return 0.10
+}
+
 // Clone creates a copy of the Config.
 func (c *Config) Clone() *Config {
 	if c == nil {
 		return nil
 	}
 	return &Config{
-		SetupTimeout: c.SetupTimeout,
+		SetupTimeout:  c.SetupTimeout,
+		ProbeInterval: c.ProbeInterval,
+		ProbeMaxAge:   c.ProbeMaxAge,
+		ProbeMaxDelta: c.ProbeMaxDelta,
 	}
 }

--- a/moqt/dialer.go
+++ b/moqt/dialer.go
@@ -111,7 +111,7 @@ func (d *Dialer) DialWebTransport(ctx context.Context, host, path string, mux *T
 	)
 	connLogger.Info("connection established")
 
-	return newSession(conn, mux, nil, d.FetchHandler, d.OnGoaway, d.Logger), nil
+	return newSession(conn, mux, nil, d.Config, d.FetchHandler, d.OnGoaway, d.Logger), nil
 }
 
 // DialQUIC establishes a new session over native QUIC by dialing the provided
@@ -143,5 +143,5 @@ func (d *Dialer) DialQUIC(ctx context.Context, addr string, mux *TrackMux) (*Ses
 		return nil, err
 	}
 
-	return newSession(conn, mux, nil, d.FetchHandler, d.OnGoaway, d.Logger), nil
+	return newSession(conn, mux, nil, d.Config, d.FetchHandler, d.OnGoaway, d.Logger), nil
 }

--- a/moqt/server.go
+++ b/moqt/server.go
@@ -290,7 +290,7 @@ func (u *WebTransportHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		manager = v.(*connManager)
 	}
 
-	sess := newSession(conn, u.TrackMux, manager, u.FetchHandler, nil, u.Logger)
+	sess := newSession(conn, u.TrackMux, manager, u.Config, u.FetchHandler, nil, u.Logger)
 
 	u.Handler.ServeMOQ(sess)
 }
@@ -315,7 +315,7 @@ func (f HandleFunc) ServeMOQ(sess *Session) {
 
 func (s *Server) handleNativeQUIC(conn StreamConn) error {
 	if s.Handler != nil {
-		sess := newSession(conn, s.TrackMux, s.connManager, s.FetchHandler, nil, s.Logger)
+		sess := newSession(conn, s.TrackMux, s.connManager, s.Config, s.FetchHandler, nil, s.Logger)
 		s.Handler.ServeMOQ(sess)
 	}
 	return fmt.Errorf("no native QUIC handler configured")

--- a/moqt/server_test.go
+++ b/moqt/server_test.go
@@ -211,7 +211,7 @@ func TestServer_addRemoveSession_ShutdownCompletesWhenLastSessionLeaves(t *testi
 
 	conn := &FakeStreamConn{}
 
-	sess := newSession(conn, nil, nil, nil, nil, nil)
+	sess := newSession(conn, nil, nil, nil, nil, nil, nil)
 	t.Cleanup(func() { _ = sess.CloseWithError(NoError, "") })
 
 	s.connManager.addConn(conn)

--- a/moqt/session.go
+++ b/moqt/session.go
@@ -24,7 +24,8 @@ const (
 // It manages bidirectional and unidirectional streams, subscriptions, and
 // announcements for a single peer connection.
 type Session struct {
-	ctx context.Context // Context for the session
+	ctx    context.Context // Context for the session
+	config *Config
 
 	wg sync.WaitGroup // WaitGroup for session cleanup
 
@@ -48,12 +49,23 @@ type Session struct {
 	// sessErr       error
 
 	connManager *connManager
+
+	// probe stream state (subscriber side, lazily initialized)
+	outgoingProbeMu     sync.Mutex
+	outgoingProbeStream transport.Stream
+	outgoingProbeCh     chan ProbeResult
+
+	// incoming probe stream state (publisher side)
+	incomingProbeMu      sync.Mutex
+	incomingProbeStream  transport.Stream
+	incomingProbeTargets chan ProbeResult
 }
 
 func newSession(
 	conn StreamConn,
 	mux *TrackMux,
 	manager *connManager,
+	config *Config,
 	fetchHandler FetchHandler,
 	onGoaway func(newSessionURI string),
 	logger *slog.Logger,
@@ -64,15 +76,17 @@ func newSession(
 
 	connCtx := conn.Context()
 	sess := &Session{
-		ctx:          connCtx,
-		conn:         conn,
-		mux:          mux,
-		fetchHandler: fetchHandler,
-		onGoaway:     onGoaway,
-		logger:       logger,
-		trackReaders: make(map[SubscribeID]*TrackReader),
-		trackWriters: make(map[SubscribeID]*TrackWriter),
-		connManager:  manager,
+		ctx:                  connCtx,
+		config:               config.Clone(),
+		conn:                 conn,
+		mux:                  mux,
+		fetchHandler:         fetchHandler,
+		onGoaway:             onGoaway,
+		logger:               logger,
+		trackReaders:         make(map[SubscribeID]*TrackReader),
+		trackWriters:         make(map[SubscribeID]*TrackWriter),
+		connManager:          manager,
+		incomingProbeTargets: make(chan ProbeResult, 1),
 	}
 
 	if manager != nil {
@@ -398,60 +412,108 @@ func (sess *Session) AcceptAnnounce(prefix string) (*AnnouncementReader, error) 
 type ProbeResult struct {
 	// Bitrate is the measured bitrate in bits per second. A value of 0 means unknown.
 	Bitrate uint64
-	// RTT is the smoothed round-trip time in milliseconds. A value of 0 means unknown.
-	RTT uint64
+	// Err is non-nil when the probe stream was closed with an error.
+	Err error
 }
 
-// Probe sends a bitrate probe request to the remote peer and returns the
-// measured bitrate and RTT reported by the response.
-func (sess *Session) Probe(bitrate uint64) (*ProbeResult, error) {
+// Probe sends a target bitrate hint to the publisher and returns a channel
+// that receives the measured bitrate reported by the publisher.
+// Calling Probe again on the same session updates the target bitrate.
+// The channel is closed when the probe stream ends or the session terminates.
+func (sess *Session) Probe(targetBitrate uint64) (<-chan ProbeResult, error) {
 	if sess.terminating() {
 		return nil, ErrClosedSession
 	}
 
-	stream, err := sess.conn.OpenStream()
-	if err != nil {
-		if appErr, ok := errors.AsType[*transport.ApplicationError](err); ok {
-			return nil, &SessionError{
-				ApplicationError: appErr,
+	sess.outgoingProbeMu.Lock()
+	defer sess.outgoingProbeMu.Unlock()
+
+	// Lazily open the probe stream.
+	if sess.outgoingProbeStream == nil {
+		stream, err := sess.conn.OpenStream()
+		if err != nil {
+			if appErr, ok := errors.AsType[*transport.ApplicationError](err); ok {
+				return nil, &SessionError{ApplicationError: appErr}
 			}
+			return nil, fmt.Errorf("failed to open stream for probe: %w", err)
 		}
 
-		return nil, fmt.Errorf("failed to open stream for probe: %w", err)
-	}
-	defer stream.Close()
+		if err := message.StreamTypeProbe.Encode(stream); err != nil {
+			if strErr, ok := errors.AsType[*transport.StreamError](err); ok {
+				stream.CancelRead(strErr.ErrorCode)
+				return nil, err
+			}
+			cancelStreamWithError(stream, transport.StreamErrorCode(ProbeErrorCodeInternal))
+			return nil, fmt.Errorf("failed to encode stream type message: %w", err)
+		}
 
-	err = message.StreamTypeProbe.Encode(stream)
+		ch := make(chan ProbeResult)
+		sess.outgoingProbeStream = stream
+		sess.outgoingProbeCh = ch
+		go sess.readProbeResults(stream, ch)
+	}
+
+	// Send PROBE with the new target bitrate. Per draft4 the subscriber MAY send
+	// additional PROBE messages on the same stream to update the target.
+	err := message.ProbeMessage{
+		Bitrate: targetBitrate,
+		RTT:     0,
+	}.Encode(sess.outgoingProbeStream)
 	if err != nil {
 		if strErr, ok := errors.AsType[*transport.StreamError](err); ok {
-			stream.CancelRead(strErr.ErrorCode)
+			sess.outgoingProbeStream.CancelRead(strErr.ErrorCode)
 			return nil, err
 		}
-
-		cancelStreamWithError(stream, transport.StreamErrorCode(ProbeErrorCodeInternal))
-
-		return nil, fmt.Errorf("failed to encode stream type message: %w", err)
+		cancelStreamWithError(sess.outgoingProbeStream, transport.StreamErrorCode(ProbeErrorCodeInternal))
+		sess.outgoingProbeStream = nil
+		// probeCh will be closed by runProbeReader when it detects the stream error.
+		return nil, fmt.Errorf("failed to send probe message: %w", err)
 	}
 
-	err = message.ProbeMessage{Bitrate: bitrate, RTT: 0}.Encode(stream)
-	if err != nil {
-		if strErr, ok := errors.AsType[*transport.StreamError](err); ok {
-			stream.CancelRead(strErr.ErrorCode)
-			return nil, err
+	return sess.outgoingProbeCh, nil
+}
+
+// readProbeResults reads publisher PROBE messages from stream and forwards them to
+// ch. It is the sole writer to ch and the sole entity that closes it.
+func (sess *Session) readProbeResults(stream transport.Stream, ch chan ProbeResult) {
+	defer func() {
+		sess.outgoingProbeMu.Lock()
+		if sess.outgoingProbeStream == stream {
+			sess.outgoingProbeStream = nil
+			sess.outgoingProbeCh = nil
 		}
+		sess.outgoingProbeMu.Unlock()
+		close(ch)
+	}()
 
-		cancelStreamWithError(stream, transport.StreamErrorCode(ProbeErrorCodeInternal))
-
-		return nil, fmt.Errorf("failed to send PROBE message: %w", err)
+	for {
+		var pm message.ProbeMessage
+		if err := pm.Decode(stream); err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			select {
+			case ch <- ProbeResult{Err: err}:
+			case <-sess.ctx.Done():
+			}
+			return
+		}
+		select {
+		case ch <- ProbeResult{Bitrate: pm.Bitrate}:
+		case <-sess.ctx.Done():
+			return
+		}
 	}
+}
 
-	var resp message.ProbeMessage
-	err = resp.Decode(stream)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read PROBE response: %w", err)
-	}
-
-	return &ProbeResult{Bitrate: resp.Bitrate, RTT: resp.RTT}, nil
+// ProbeTargets returns a channel that receives the latest target bitrate (bits
+// per second) sent by the subscriber via PROBE messages. The channel has a
+// buffer of 1 and uses latest-value semantics: if the previous value has not
+// been consumed, it is replaced by the newer one.
+//
+// This is the publisher-side counterpart of [Session.Probe].
+func (sess *Session) ProbeTargets() <-chan ProbeResult {
+	return sess.incomingProbeTargets
 }
 
 // listenBiStreams accepts bidirectional streams and handles them based on their type.
@@ -566,7 +628,23 @@ func (sess *Session) processBiStream(stream transport.Stream) {
 			return
 		}
 	case message.StreamTypeProbe:
-		if err := sess.handleProbeStream(stream); err != nil {
+		// Enforce a single active incoming probe stream: cancel the previous one if any.
+		sess.incomingProbeMu.Lock()
+		if old := sess.incomingProbeStream; old != nil {
+			cancelStreamWithError(old, transport.StreamErrorCode(ProbeErrorCodeInternal))
+		}
+		sess.incomingProbeStream = stream
+		sess.incomingProbeMu.Unlock()
+
+		err := sess.handleProbeStream(stream)
+
+		sess.incomingProbeMu.Lock()
+		if sess.incomingProbeStream == stream {
+			sess.incomingProbeStream = nil
+		}
+		sess.incomingProbeMu.Unlock()
+
+		if err != nil {
 			sess.logError("probe stream error", err)
 			cancelStreamWithError(stream, transport.StreamErrorCode(ProbeErrorCodeInternal))
 			return
@@ -662,27 +740,66 @@ func cancelStreamWithError(stream transport.Stream, code transport.StreamErrorCo
 }
 
 func (sess *Session) handleProbeStream(stream transport.Stream) error {
-	provider, _ := sess.probeStatsProvider()
+	provider, ok := sess.conn.(probeStatsProvider)
+	if !ok {
+		return &ProbeError{StreamError: &transport.StreamError{ErrorCode: transport.StreamErrorCode(ProbeErrorCodeNotSupported)}}
+	}
 
+	// Decode the initial PROBE message from the subscriber.
+	var req message.ProbeMessage
+	if err := req.Decode(stream); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return err
+	}
+
+	// Background goroutine: read additional PROBE messages from subscriber and
+	// forward the latest target bitrate to incomingProbeTargets.
+	// Per draft4 §5.1.4 the subscriber MAY send additional PROBE messages on
+	// the same stream; latest-value semantics: only the most recent target is kept.
+	go func() {
+		for {
+			var update message.ProbeMessage
+			if err := update.Decode(stream); err != nil {
+				return
+			}
+			// Discard stale value if the reader hasn't consumed it yet.
+			select {
+			case <-sess.incomingProbeTargets:
+			default:
+			}
+			select {
+			case sess.incomingProbeTargets <- ProbeResult{Bitrate: update.Bitrate}:
+			default:
+			}
+		}
+	}()
+
+	ticker := time.NewTicker(sess.config.probeInterval())
+	defer ticker.Stop()
+
+	maxAge := sess.config.probeMaxAge()
+	maxDelta := sess.config.probeMaxDelta()
 	tracker := &probeMeasurementTracker{}
 	for {
-		var pm message.ProbeMessage
-		err := pm.Decode(stream)
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				return nil
+		select {
+		case now := <-ticker.C:
+			stats := provider.ConnectionStats()
+			msg, ok := tracker.next(stats, now, maxAge, maxDelta)
+			if !ok {
+				continue
 			}
-			return err
-		}
-
-		if provider == nil {
-			return &ProbeError{StreamError: &transport.StreamError{ErrorCode: transport.StreamErrorCode(ProbeErrorCodeNotSupported)}}
-		}
-		stats := provider.ConnectionStats()
-		measured := tracker.measure(stats, pm.Bitrate, time.Now())
-		rtt := tracker.smoothedRTT(stats)
-		if err := (message.ProbeMessage{Bitrate: measured, RTT: rtt}).Encode(stream); err != nil {
-			return err
+			if err := msg.Encode(stream); err != nil {
+				if errors.Is(err, io.EOF) {
+					return nil
+				}
+				return err
+			}
+		case <-stream.Context().Done():
+			return nil
+		case <-sess.ctx.Done():
+			return nil
 		}
 	}
 }
@@ -692,53 +809,77 @@ type probeStatsProvider interface {
 }
 
 type probeMeasurementTracker struct {
+	// bitrate measurement state
 	initialized bool
 	bytesSent   uint64
 	sampleTime  time.Time
+
+	// throttle state
+	lastBitrate uint64
+	lastSentAt  time.Time
 }
 
-func (sess *Session) probeStatsProvider() (probeStatsProvider, bool) {
-	provider, ok := sess.conn.(probeStatsProvider)
-	return provider, ok
+func (t *probeMeasurementTracker) next(stats quic.ConnectionStats, now time.Time, maxAge time.Duration, maxDelta float64) (message.ProbeMessage, bool) {
+	bitrate := t.measureBitrate(stats, now)
+
+	if t.lastSentAt.IsZero() {
+		t.record(bitrate, now)
+		return message.ProbeMessage{Bitrate: bitrate}, true
+	}
+
+	if now.Sub(t.lastSentAt) >= maxAge ||
+		hasDelta(t.lastBitrate, bitrate, maxDelta) {
+		t.record(bitrate, now)
+		return message.ProbeMessage{Bitrate: bitrate}, true
+	}
+
+	return message.ProbeMessage{}, false
 }
 
-func (t *probeMeasurementTracker) measure(stats quic.ConnectionStats, fallback uint64, now time.Time) uint64 {
+func (t *probeMeasurementTracker) record(bitrate uint64, now time.Time) {
+	t.lastBitrate = bitrate
+	t.lastSentAt = now
+}
+
+func (t *probeMeasurementTracker) measureBitrate(stats quic.ConnectionStats, now time.Time) uint64 {
 	if !t.initialized {
 		t.initialized = true
 		t.bytesSent = stats.BytesSent
 		t.sampleTime = now
-		return fallback
+		return 0
 	}
 
 	elapsed := now.Sub(t.sampleTime)
 	if elapsed <= 0 {
-		return fallback
+		return t.lastBitrate
 	}
 
 	bytesSent := stats.BytesSent
-	bytesDelta := bytesSent
-	if bytesDelta >= t.bytesSent {
-		bytesDelta -= t.bytesSent
-	} else {
-		bytesDelta = 0
+	var bytesDelta uint64
+	if bytesSent >= t.bytesSent {
+		bytesDelta = bytesSent - t.bytesSent
 	}
-	if bytesDelta == 0 {
-		t.bytesSent = bytesSent
-		t.sampleTime = now
-		return fallback
-	}
-
 	t.bytesSent = bytesSent
 	t.sampleTime = now
-	return uint64((float64(bytesDelta) * 8) / elapsed.Seconds())
-}
 
-func (t *probeMeasurementTracker) smoothedRTT(stats quic.ConnectionStats) uint64 {
-	rtt := stats.SmoothedRTT
-	if rtt <= 0 {
+	if bytesDelta == 0 {
 		return 0
 	}
-	return uint64(rtt.Milliseconds())
+
+	return uint64(float64(bytesDelta) * 8 / elapsed.Seconds())
+}
+
+func hasDelta(oldVal, newVal uint64, maxDelta float64) bool {
+	if oldVal == 0 {
+		return newVal != 0
+	}
+	var diff float64
+	if newVal >= oldVal {
+		diff = float64(newVal - oldVal)
+	} else {
+		diff = float64(oldVal - newVal)
+	}
+	return diff/float64(oldVal) >= maxDelta
 }
 
 func (sess *Session) handleGoawayStream(stream transport.Stream) error {

--- a/moqt/session_benchmark_test.go
+++ b/moqt/session_benchmark_test.go
@@ -45,8 +45,7 @@ func BenchmarkSession_Subscribe(b *testing.B) {
 				return mockBiStream, nil
 			}
 
-			mux := NewTrackMux(0)
-			session := newSession(conn, mux, nil, nil, nil, nil)
+			session := newTestSession(conn)
 
 			// Pre-generate paths
 			paths := make([]BroadcastPath, size)
@@ -101,8 +100,7 @@ func BenchmarkSession_ConcurrentSubscribe(b *testing.B) {
 				return mockBiStream, nil
 			}
 
-			mux := NewTrackMux(0)
-			session := newSession(conn, mux, nil, nil, nil, nil)
+			session := newTestSession(conn)
 
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -127,8 +125,7 @@ func BenchmarkSession_ConcurrentSubscribe(b *testing.B) {
 func BenchmarkSession_TrackReaderOperations(b *testing.B) {
 	conn := &FakeStreamConn{}
 
-	mux := NewTrackMux(0)
-	session := newSession(conn, mux, nil, nil, nil, nil)
+	session := newTestSession(conn)
 
 	b.ReportAllocs()
 
@@ -156,8 +153,7 @@ func BenchmarkSession_TrackReaderOperations(b *testing.B) {
 func BenchmarkSession_TrackWriterOperations(b *testing.B) {
 	conn := &FakeStreamConn{}
 
-	mux := NewTrackMux(0)
-	session := newSession(conn, mux, nil, nil, nil, nil)
+	session := newTestSession(conn)
 
 	b.ReportAllocs()
 
@@ -195,8 +191,7 @@ func BenchmarkSession_MapLookup(b *testing.B) {
 		b.Run(fmt.Sprintf("size-%d", size), func(b *testing.B) {
 			conn := &FakeStreamConn{}
 
-			mux := NewTrackMux(0)
-			session := newSession(conn, mux, nil, nil, nil, nil)
+			session := newTestSession(conn)
 
 			// Pre-populate with track readers
 			for i := range size {
@@ -240,8 +235,7 @@ func BenchmarkSession_MemoryAllocation(b *testing.B) {
 			for range b.N {
 				conn := &FakeStreamConn{}
 
-				mux := NewTrackMux(0)
-				session := newSession(conn, mux, nil, nil, nil, nil)
+				session := newTestSession(conn)
 
 				// Create many track readers
 				for j := range size {
@@ -269,8 +263,7 @@ func BenchmarkSession_ContextCancellation(b *testing.B) {
 		conn := &FakeStreamConn{}
 		conn.ParentCtx = ctx
 
-		mux := NewTrackMux(0)
-		session := newSession(conn, mux, nil, nil, nil, nil)
+		session := newTestSession(conn)
 
 		// Cancel context
 		cancel()

--- a/moqt/session_test.go
+++ b/moqt/session_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,7 +19,7 @@ import (
 )
 
 func newTestSession(conn StreamConn) *Session {
-	return newSession(conn, NewTrackMux(0), nil, nil, nil, nil)
+	return newSession(conn, NewTrackMux(0), nil, nil, nil, nil, nil)
 }
 
 func newTestSessionWithConn(tb testing.TB, opts ...func(*FakeStreamConn)) (*Session, *FakeStreamConn) {
@@ -52,7 +53,7 @@ func TestNewSession(t *testing.T) {
 			conn.OpenStreamFunc = func() (transport.Stream, error) { return nil, io.EOF }
 			conn.OpenStreamFunc = func() (transport.Stream, error) { return nil, io.EOF }
 
-			session := newSession(conn, tt.mux, nil, nil, nil, nil)
+			session := newSession(conn, tt.mux, nil, nil, nil, nil, nil)
 
 			if tt.expectOK {
 				assert.NotNil(t, session, "newSession should not return nil")
@@ -95,7 +96,7 @@ func TestNewSessionWithNilMux(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			conn := &FakeStreamConn{}
 
-			session := newSession(conn, tt.mux, nil, nil, nil, nil)
+			session := newSession(conn, tt.mux, nil, nil, nil, nil, nil)
 
 			if tt.expectDefault {
 				assert.Equal(t, DefaultMux, session.mux, "should use DefaultMux when nil mux is provided")
@@ -111,6 +112,20 @@ func TestNewSession_WithNilLogger(t *testing.T) {
 	session, _ := newTestSessionWithConn(t)
 
 	assert.NotNil(t, session, "session should be created with nil logger")
+}
+
+func TestNewSession_ConfigIsCloned(t *testing.T) {
+	conn := &FakeStreamConn{}
+	cfg := &Config{ProbeInterval: 50 * time.Millisecond}
+
+	session := newSession(conn, nil, nil, cfg, nil, nil, nil)
+	defer session.CloseWithError(InternalSessionErrorCode, "terminate reason")
+
+	// mutate the original after newSession
+	cfg.ProbeInterval = 999 * time.Second
+
+	assert.Equal(t, 50*time.Millisecond, session.config.ProbeInterval,
+		"session.config should not be affected by mutations to the original Config")
 }
 
 func TestNewSession_ClosureOnContextCancel(t *testing.T) {
@@ -662,7 +677,8 @@ func TestSession_WithRealMux(t *testing.T) {
 
 	mux := NewTrackMux(0)
 
-	session := newSession(conn, mux, nil, nil, nil, nil)
+	session := newTestSession(conn)
+	session.mux = mux
 
 	assert.Equal(t, mux, session.mux, "Mux should be set correctly in the session")
 
@@ -1247,42 +1263,6 @@ func TestSession_ProcessBiStream_FetchHandlerPanic(t *testing.T) {
 func TestSession_Probe(t *testing.T) {
 	conn := &FakeStreamConn{}
 
-	requestStream := &FakeQUICStream{}
-
-	var written bytes.Buffer
-	requestStream.WriteFunc = func(p []byte) (int, error) {
-		return written.Write(p)
-	}
-
-	var response bytes.Buffer
-	respMsg := message.ProbeMessage{Bitrate: 250000}
-	require.NoError(t, respMsg.Encode(&response))
-	requestStream.ReadFunc = response.Read
-
-	conn.OpenStreamFunc = func() (transport.Stream, error) { return requestStream, nil }
-
-	session := newTestSession(conn)
-
-	got, err := session.Probe(1000000)
-	require.NoError(t, err)
-	assert.Equal(t, uint64(250000), got.Bitrate)
-
-	var streamType message.StreamType
-	require.NoError(t, streamType.Decode(bytes.NewReader(written.Bytes()[:1])))
-	assert.Equal(t, message.StreamTypeProbe, streamType)
-
-	var sent message.ProbeMessage
-	require.NoError(t, sent.Decode(bytes.NewReader(written.Bytes()[1:])))
-	assert.Equal(t, uint64(1000000), sent.Bitrate)
-
-	_ = session.CloseWithError(NoError, "")
-}
-
-func TestSession_ProcessBiStream_Probe(t *testing.T) {
-	conn := &FakeStreamConn{}
-
-	session := newTestSession(conn)
-
 	probeStream := &FakeQUICStream{}
 
 	var written bytes.Buffer
@@ -1290,27 +1270,93 @@ func TestSession_ProcessBiStream_Probe(t *testing.T) {
 		return written.Write(p)
 	}
 
-	var incoming bytes.Buffer
-	require.NoError(t, message.StreamTypeProbe.Encode(&incoming))
-	require.NoError(t, message.ProbeMessage{Bitrate: 123456}.Encode(&incoming))
-	data := incoming.Bytes()
-	probeStream.ReadFunc = func(p []byte) (int, error) {
-		if len(data) == 0 {
-			return 0, io.EOF
-		}
-		n := copy(p, data)
-		data = data[n:]
-		return n, nil
-	}
+	// Publisher sends one ProbeMessage then EOF.
+	var response bytes.Buffer
+	require.NoError(t, message.ProbeMessage{Bitrate: 250000}.Encode(&response))
+	probeStream.ReadFunc = response.Read
 
-	session.processBiStream(probeStream)
+	conn.OpenStreamFunc = func() (transport.Stream, error) { return probeStream, nil }
 
-	var resp message.ProbeMessage
-	require.NoError(t, resp.Decode(bytes.NewReader(written.Bytes())))
-	assert.Equal(t, uint64(123456), resp.Bitrate)
-	assert.False(t, session.terminating(), "Session should not terminate after probe handling")
+	session := newTestSession(conn)
+
+	ch, err := session.Probe(1000000)
+	require.NoError(t, err)
+
+	// Channel should receive the publisher's ProbeMessage.
+	got := <-ch
+	assert.NoError(t, got.Err)
+	assert.Equal(t, uint64(250000), got.Bitrate)
+	assert.Equal(t, uint64(250000), got.Bitrate)
+
+	// Verify subscriber wrote StreamTypeProbe + ProbeMessage{Bitrate:1000000}.
+	r := bytes.NewReader(written.Bytes())
+	var streamType message.StreamType
+	require.NoError(t, streamType.Decode(r))
+	assert.Equal(t, message.StreamTypeProbe, streamType)
+	var sent message.ProbeMessage
+	require.NoError(t, sent.Decode(r))
+	assert.Equal(t, uint64(1000000), sent.Bitrate)
 
 	_ = session.CloseWithError(NoError, "")
+}
+
+func TestSession_ProcessBiStream_Probe(t *testing.T) {
+	conn := &FakeStreamConn{}
+	conn.ConnectionStatsFunc = func() quic.ConnectionStats {
+		return quic.ConnectionStats{}
+	}
+
+	session := newTestSession(conn)
+	session.config = &Config{ProbeInterval: 5 * time.Millisecond}
+
+	probeStream := &FakeQUICStream{}
+
+	received := make(chan message.ProbeMessage, 10)
+	probeStream.WriteFunc = func(p []byte) (int, error) {
+		var pm message.ProbeMessage
+		if err := pm.Decode(bytes.NewReader(p)); err == nil {
+			select {
+			case received <- pm:
+			default:
+			}
+		}
+		return len(p), nil
+	}
+
+	// Subscriber sends StreamTypeProbe + ProbeMessage{Bitrate: targetBitrate}.
+	var incoming bytes.Buffer
+	require.NoError(t, message.StreamTypeProbe.Encode(&incoming))
+	require.NoError(t, message.ProbeMessage{Bitrate: 1000000}.Encode(&incoming))
+	data := incoming.Bytes()
+	probeStream.ReadFunc = func(p []byte) (int, error) {
+		if len(data) > 0 {
+			n := copy(p, data)
+			data = data[n:]
+			return n, nil
+		}
+		return 0, io.EOF
+	}
+
+	done := make(chan struct{})
+	go func() {
+		session.processBiStream(probeStream)
+		close(done)
+	}()
+
+	// Wait for at least one ProbeMessage from the publisher.
+	select {
+	case <-received:
+		// Successfully received a probe response from publisher.
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("no probe message received")
+	}
+
+	_ = session.CloseWithError(NoError, "")
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("processBiStream did not complete")
+	}
 }
 
 func TestSession_ProcessBiStream_ProbeMultipleMessages(t *testing.T) {
@@ -1320,37 +1366,411 @@ func TestSession_ProcessBiStream_ProbeMultipleMessages(t *testing.T) {
 	}
 
 	session := newTestSession(conn)
+	session.config = &Config{ProbeInterval: 5 * time.Millisecond, ProbeMaxAge: 15 * time.Millisecond}
 
 	probeStream := &FakeQUICStream{}
 
-	var written bytes.Buffer
+	received := make(chan message.ProbeMessage, 20)
 	probeStream.WriteFunc = func(p []byte) (int, error) {
-		return written.Write(p)
+		var pm message.ProbeMessage
+		if err := pm.Decode(bytes.NewReader(p)); err == nil {
+			select {
+			case received <- pm:
+			default:
+			}
+		}
+		return len(p), nil
 	}
 
 	var incoming bytes.Buffer
 	require.NoError(t, message.StreamTypeProbe.Encode(&incoming))
-	require.NoError(t, message.ProbeMessage{Bitrate: 111000}.Encode(&incoming))
-	require.NoError(t, message.ProbeMessage{Bitrate: 222000}.Encode(&incoming))
+	require.NoError(t, message.ProbeMessage{Bitrate: 500000}.Encode(&incoming))
 	data := incoming.Bytes()
 	probeStream.ReadFunc = func(p []byte) (int, error) {
-		if len(data) == 0 {
-			return 0, io.EOF
+		if len(data) > 0 {
+			n := copy(p, data)
+			data = data[n:]
+			return n, nil
 		}
-		n := copy(p, data)
-		data = data[n:]
-		return n, nil
+		return 0, io.EOF
 	}
 
-	session.processBiStream(probeStream)
+	done := make(chan struct{})
+	go func() {
+		session.processBiStream(probeStream)
+		close(done)
+	}()
 
-	got := written.Bytes()
-	require.NotEmpty(t, got)
-	reader := bytes.NewReader(got)
-	for _, want := range []uint64{111000, 222000} {
-		var resp message.ProbeMessage
-		require.NoError(t, resp.Decode(reader))
-		assert.Equal(t, want, resp.Bitrate)
+	// Let multiple max-age-triggered sends accumulate.
+	time.Sleep(100 * time.Millisecond)
+
+	_ = session.CloseWithError(NoError, "")
+	<-done
+
+	assert.Greater(t, len(received), 1, "should have received multiple probe messages")
+}
+
+func TestSession_ProcessBiStream_ProbeTargets(t *testing.T) {
+	conn := &FakeStreamConn{}
+	conn.ConnectionStatsFunc = func() quic.ConnectionStats {
+		return quic.ConnectionStats{}
+	}
+
+	session := newTestSession(conn)
+
+	probeStream := &FakeQUICStream{}
+	probeStream.WriteFunc = func(p []byte) (int, error) { return len(p), nil }
+
+	// Subscriber sends: StreamTypeProbe + initial target + one updated target.
+	var incoming bytes.Buffer
+	require.NoError(t, message.StreamTypeProbe.Encode(&incoming))
+	require.NoError(t, message.ProbeMessage{Bitrate: 500000}.Encode(&incoming))
+	require.NoError(t, message.ProbeMessage{Bitrate: 1000000}.Encode(&incoming))
+	data := incoming.Bytes()
+
+	readCalled := make(chan struct{}, 1)
+	probeStream.ReadFunc = func(p []byte) (int, error) {
+		if len(data) > 0 {
+			n := copy(p, data)
+			data = data[n:]
+			return n, nil
+		}
+		// Signal that all data has been consumed.
+		select {
+		case readCalled <- struct{}{}:
+		default:
+		}
+		return 0, io.EOF
+	}
+
+	done := make(chan struct{})
+	go func() {
+		session.processBiStream(probeStream)
+		close(done)
+	}()
+
+	// Wait until the stream has been fully consumed.
+	select {
+	case <-readCalled:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("stream was not consumed")
+	}
+
+	// The updated target (1000000) should be available on ProbeTargets().
+	select {
+	case got := <-session.ProbeTargets():
+		assert.Equal(t, uint64(1000000), got.Bitrate)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("no target received on ProbeTargets()")
+	}
+
+	_ = session.CloseWithError(NoError, "")
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("processBiStream did not complete")
+	}
+}
+
+func TestSession_Probe_SecondCallReusesStream(t *testing.T) {
+	conn := &FakeStreamConn{}
+
+	var written bytes.Buffer
+	probeStream := &FakeQUICStream{}
+	probeStream.WriteFunc = func(p []byte) (int, error) { return written.Write(p) }
+	// Block reads so the stream stays open throughout the test.
+	probeStream.ReadFunc = func(p []byte) (int, error) {
+		<-probeStream.Context().Done()
+		return 0, io.EOF
+	}
+
+	openCount := 0
+	conn.OpenStreamFunc = func() (transport.Stream, error) {
+		openCount++
+		return probeStream, nil
+	}
+
+	session := newTestSession(conn)
+
+	ch1, err := session.Probe(1000000)
+	require.NoError(t, err)
+
+	ch2, err := session.Probe(2000000)
+	require.NoError(t, err)
+
+	// The same channel must be returned on the second call.
+	assert.Equal(t, ch1, ch2, "second Probe call should return the same channel")
+
+	// OpenStream must have been called exactly once.
+	assert.Equal(t, 1, openCount, "second Probe call must not open a new stream")
+
+	// Both ProbeMessages must have been written (after the StreamType header).
+	r := bytes.NewReader(written.Bytes())
+	var streamType message.StreamType
+	require.NoError(t, streamType.Decode(r))
+	assert.Equal(t, message.StreamTypeProbe, streamType)
+
+	var msg1 message.ProbeMessage
+	require.NoError(t, msg1.Decode(r))
+	assert.Equal(t, uint64(1000000), msg1.Bitrate)
+
+	var msg2 message.ProbeMessage
+	require.NoError(t, msg2.Decode(r))
+	assert.Equal(t, uint64(2000000), msg2.Bitrate)
+
+	_ = session.CloseWithError(NoError, "")
+}
+
+func TestSession_Probe_ChannelClosedOnSessionClose(t *testing.T) {
+	conn := &FakeStreamConn{}
+
+	// Make the probe stream's context a child of the connection context so that
+	// closing the connection cancels the stream, unblocking the read goroutine.
+	probeStream := &FakeQUICStream{
+		ParentCtx: conn.Context(),
+	}
+	probeStream.WriteFunc = func(p []byte) (int, error) { return len(p), nil }
+	// Block until the stream context is cancelled (which happens when the
+	// connection is closed and conn.Context() is cancelled).
+	probeStream.ReadFunc = func(p []byte) (int, error) {
+		<-probeStream.Context().Done()
+		return 0, context.Cause(probeStream.Context())
+	}
+	conn.OpenStreamFunc = func() (transport.Stream, error) { return probeStream, nil }
+
+	session := newTestSession(conn)
+
+	ch, err := session.Probe(1000000)
+	require.NoError(t, err)
+
+	// Close the session: cancels conn.Context() → probeStream.Context() → ReadFunc returns.
+	_ = session.CloseWithError(NoError, "")
+
+	// The channel must be closed (range or two-value receive must see ok=false).
+	for range ch {
+	}
+}
+
+func TestSession_ProcessBiStream_ProbeReplacesExisting(t *testing.T) {
+	conn := &FakeStreamConn{}
+	conn.ConnectionStatsFunc = func() quic.ConnectionStats { return quic.ConnectionStats{} }
+
+	session := newTestSession(conn)
+
+	// stream1: sends StreamTypeProbe + initial ProbeMessage, then blocks until cancelled.
+	var stream1Buf bytes.Buffer
+	require.NoError(t, message.StreamTypeProbe.Encode(&stream1Buf))
+	require.NoError(t, message.ProbeMessage{Bitrate: 500000}.Encode(&stream1Buf))
+	stream1Data := stream1Buf.Bytes()
+
+	stream1Active := make(chan struct{})
+	stream1 := &FakeQUICStream{}
+	stream1.WriteFunc = func(p []byte) (int, error) { return len(p), nil }
+	stream1.ReadFunc = func(p []byte) (int, error) {
+		if len(stream1Data) > 0 {
+			n := copy(p, stream1Data)
+			stream1Data = stream1Data[n:]
+			if len(stream1Data) == 0 {
+				select {
+				case stream1Active <- struct{}{}:
+				default:
+				}
+			}
+			return n, nil
+		}
+		// Block until cancelled by stream2 arrival.
+		<-stream1.Context().Done()
+		return 0, context.Cause(stream1.Context())
+	}
+
+	stream1Done := make(chan struct{})
+	go func() {
+		session.processBiStream(stream1)
+		close(stream1Done)
+	}()
+
+	// Wait until stream1 is fully consumed (registered as incomingProbeStream).
+	select {
+	case <-stream1Active:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("stream1 initial data was not consumed")
+	}
+
+	// stream2: sends StreamTypeProbe + initial ProbeMessage, then EOF.
+	var stream2Buf bytes.Buffer
+	require.NoError(t, message.StreamTypeProbe.Encode(&stream2Buf))
+	require.NoError(t, message.ProbeMessage{Bitrate: 1000000}.Encode(&stream2Buf))
+	stream2Data := stream2Buf.Bytes()
+
+	stream2 := &FakeQUICStream{}
+	stream2.WriteFunc = func(p []byte) (int, error) { return len(p), nil }
+	stream2.ReadFunc = func(p []byte) (int, error) {
+		if len(stream2Data) > 0 {
+			n := copy(p, stream2Data)
+			stream2Data = stream2Data[n:]
+			return n, nil
+		}
+		return 0, io.EOF
+	}
+
+	stream2Done := make(chan struct{})
+	go func() {
+		session.processBiStream(stream2)
+		close(stream2Done)
+	}()
+
+	// stream1 must be cancelled when stream2 takes over.
+	select {
+	case <-stream1Done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("stream1 was not cancelled when stream2 arrived")
+	}
+
+	// Close the session so stream2's handleProbeStream ticker loop exits.
+	_ = session.CloseWithError(NoError, "")
+
+	// stream2 must process normally and finish after session close.
+	select {
+	case <-stream2Done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("stream2 did not complete")
+	}
+}
+
+func TestSession_ProcessBiStream_ProbeDecodeError(t *testing.T) {
+	conn := &FakeStreamConn{}
+	conn.ConnectionStatsFunc = func() quic.ConnectionStats { return quic.ConnectionStats{} }
+
+	session := newTestSession(conn)
+
+	// Stream sends only StreamTypeProbe; subsequent reads for ProbeMessage.Decode return
+	// a non-EOF error, causing handleProbeStream to return an error.
+	var incoming bytes.Buffer
+	require.NoError(t, message.StreamTypeProbe.Encode(&incoming))
+
+	data := incoming.Bytes()
+	cancelReadCalled := make(chan transport.StreamErrorCode, 1)
+	cancelWriteCalled := make(chan transport.StreamErrorCode, 1)
+
+	probeStream := &FakeQUICStream{}
+	probeStream.WriteFunc = func(p []byte) (int, error) { return len(p), nil }
+	probeStream.ReadFunc = func(p []byte) (int, error) {
+		if len(data) > 0 {
+			n := copy(p, data)
+			data = data[n:]
+			return n, nil
+		}
+		return 0, errors.New("simulated read error")
+	}
+	probeStream.CancelReadFunc = func(code transport.StreamErrorCode) {
+		select {
+		case cancelReadCalled <- code:
+		default:
+		}
+	}
+	probeStream.CancelWriteFunc = func(code transport.StreamErrorCode) {
+		select {
+		case cancelWriteCalled <- code:
+		default:
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		session.processBiStream(probeStream)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("processBiStream did not complete after decode error")
+	}
+
+	// The stream must have been cancelled with ProbeErrorCodeInternal.
+	select {
+	case code := <-cancelReadCalled:
+		assert.Equal(t, transport.StreamErrorCode(ProbeErrorCodeInternal), code)
+	default:
+		t.Error("CancelRead was not called")
+	}
+	select {
+	case code := <-cancelWriteCalled:
+		assert.Equal(t, transport.StreamErrorCode(ProbeErrorCodeInternal), code)
+	default:
+		t.Error("CancelWrite was not called")
+	}
+
+	_ = session.CloseWithError(NoError, "")
+}
+
+func TestSession_ProbeTargets_LatestValueSemantics(t *testing.T) {
+	conn := &FakeStreamConn{}
+	conn.ConnectionStatsFunc = func() quic.ConnectionStats { return quic.ConnectionStats{} }
+
+	session := newTestSession(conn)
+
+	// Subscriber sends: StreamTypeProbe + initial target + two rapid updates.
+	// The background goroutine must discard the first update (800000) when the
+	// second update (1200000) arrives before the publisher has consumed it.
+	var incoming bytes.Buffer
+	require.NoError(t, message.StreamTypeProbe.Encode(&incoming))
+	require.NoError(t, message.ProbeMessage{Bitrate: 500000}.Encode(&incoming))
+	require.NoError(t, message.ProbeMessage{Bitrate: 800000}.Encode(&incoming))
+	require.NoError(t, message.ProbeMessage{Bitrate: 1200000}.Encode(&incoming))
+
+	data := incoming.Bytes()
+	// bgDone fires when the background goroutine has consumed all update messages
+	// and hits EOF on the next read.
+	var bgOnce sync.Once
+	bgDone := make(chan struct{})
+	probeStream := &FakeQUICStream{}
+	probeStream.WriteFunc = func(p []byte) (int, error) { return len(p), nil }
+	probeStream.ReadFunc = func(p []byte) (int, error) {
+		if len(data) > 0 {
+			n := copy(p, data)
+			data = data[n:]
+			return n, nil
+		}
+		bgOnce.Do(func() { close(bgDone) })
+		return 0, io.EOF
+	}
+
+	done := make(chan struct{})
+	go func() {
+		session.processBiStream(probeStream)
+		close(done)
+	}()
+
+	// Wait until the background goroutine has finished processing all updates.
+	select {
+	case <-bgDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("background goroutine did not consume all updates")
+	}
+
+	// Cancel the stream's write side so handleProbeStream's ticker loop exits.
+	probeStream.CancelWrite(transport.StreamErrorCode(0))
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("processBiStream did not complete")
+	}
+
+	// The channel must hold only the latest target (1200000).
+	select {
+	case got := <-session.ProbeTargets():
+		assert.Equal(t, uint64(1200000), got.Bitrate)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("no target on ProbeTargets()")
+	}
+
+	// No stale value must remain in the channel.
+	select {
+	case extra := <-session.ProbeTargets():
+		t.Errorf("unexpected stale target %d still in channel", extra.Bitrate)
+	default:
 	}
 
 	_ = session.CloseWithError(NoError, "")
@@ -1941,9 +2361,8 @@ func TestSession_Probe_ClosedSession(t *testing.T) {
 
 	_ = session.CloseWithError(NoError, "")
 
-	result, err := session.Probe(1000000)
+	_, err := session.Probe(1000000)
 	assert.Error(t, err)
-	assert.Nil(t, result)
 	assert.Equal(t, ErrClosedSession, err)
 }
 
@@ -1955,9 +2374,8 @@ func TestSession_Probe_OpenStreamError(t *testing.T) {
 
 	session := newTestSession(conn)
 
-	result, err := session.Probe(1000000)
+	_, err := session.Probe(1000000)
 	assert.Error(t, err)
-	assert.Nil(t, result)
 
 	_ = session.CloseWithError(NoError, "")
 }
@@ -1973,9 +2391,8 @@ func TestSession_Probe_OpenStreamApplicationError(t *testing.T) {
 
 	session := newTestSession(conn)
 
-	result, err := session.Probe(1000000)
+	_, err := session.Probe(1000000)
 	assert.Error(t, err)
-	assert.Nil(t, result)
 	var sessErr *SessionError
 	assert.ErrorAs(t, err, &sessErr)
 
@@ -1991,9 +2408,8 @@ func TestSession_Probe_EncodeStreamTypeError(t *testing.T) {
 
 	session := newTestSession(conn)
 
-	result, err := session.Probe(1000000)
+	_, err := session.Probe(1000000)
 	assert.Error(t, err)
-	assert.Nil(t, result)
 
 	_ = session.CloseWithError(NoError, "")
 }
@@ -2004,9 +2420,9 @@ func TestSession_Probe_EncodeProbeMessageError(t *testing.T) {
 	mockStream.WriteFunc = func(p []byte) (int, error) {
 		writeCallCount++
 		if writeCallCount == 1 {
-			return len(p), nil
+			return len(p), nil // StreamType succeeds
 		}
-		return 0, errors.New("write error")
+		return 0, errors.New("write error") // ProbeMessage fails
 	}
 
 	conn := &FakeStreamConn{}
@@ -2014,14 +2430,13 @@ func TestSession_Probe_EncodeProbeMessageError(t *testing.T) {
 
 	session := newTestSession(conn)
 
-	result, err := session.Probe(1000000)
+	_, err := session.Probe(1000000)
 	assert.Error(t, err)
-	assert.Nil(t, result)
 
 	_ = session.CloseWithError(NoError, "")
 }
 
-func TestSession_Probe_DecodeResponseError(t *testing.T) {
+func TestSession_Probe_DecodeProbeMessageError(t *testing.T) {
 	mockStream := &FakeQUICStream{}
 	mockStream.WriteFunc = func(p []byte) (int, error) { return len(p), nil }
 	mockStream.ReadFunc = func(p []byte) (int, error) { return 0, errors.New("read error") }
@@ -2031,9 +2446,12 @@ func TestSession_Probe_DecodeResponseError(t *testing.T) {
 
 	session := newTestSession(conn)
 
-	result, err := session.Probe(1000000)
-	assert.Error(t, err)
-	assert.Nil(t, result)
+	ch, err := session.Probe(1000000)
+	require.NoError(t, err)
+
+	// The error from the reader goroutine is delivered via the channel.
+	got := <-ch
+	assert.Error(t, got.Err)
 
 	_ = session.CloseWithError(NoError, "")
 }
@@ -2044,7 +2462,8 @@ func TestSession_logError(t *testing.T) {
 		logger := slog.New(slog.NewTextHandler(&logBuf, nil))
 
 		conn := &FakeStreamConn{}
-		session := newSession(conn, NewTrackMux(0), nil, nil, nil, logger)
+		session := newTestSession(conn)
+		session.logger = logger
 
 		session.logError("something failed", errors.New("test error"), "key", "value")
 
@@ -2068,7 +2487,8 @@ func TestSession_logError(t *testing.T) {
 		logger := slog.New(slog.NewTextHandler(&logBuf, nil))
 
 		conn := &FakeStreamConn{}
-		session := newSession(conn, NewTrackMux(0), nil, nil, nil, logger)
+		session := newTestSession(conn)
+		session.logger = logger
 
 		session.logError("msg", nil)
 		assert.Empty(t, logBuf.String())
@@ -2094,7 +2514,8 @@ func TestSession_processBiStream_logError(t *testing.T) {
 	}
 
 	conn := &FakeStreamConn{}
-	session := newSession(conn, NewTrackMux(0), nil, nil, nil, logger)
+	session := newTestSession(conn)
+	session.logger = logger
 
 	session.processBiStream(mockStream)
 
@@ -2116,7 +2537,8 @@ func TestSession_processUniStream_logError(t *testing.T) {
 	}
 
 	conn := &FakeStreamConn{}
-	session := newSession(conn, NewTrackMux(0), nil, nil, nil, logger)
+	session := newTestSession(conn)
+	session.logger = logger
 
 	session.processUniStream(mockStream)
 


### PR DESCRIPTION
## Summary

### Added
- **moqt:** `Session.ProbeTargets() <-chan ProbeResult` — publisher-side channel that delivers the latest subscriber target bitrate (buffered 1, latest-value semantics).

### Changed
- **moqt:** `Session.Probe(targetBitrate uint64) (<-chan ProbeResult, error)` — now reuses a single stream across repeated calls; the returned channel is closed when the stream or session ends.
- **moqt:** `ProbeResult.RTT` removed; RTT is available via the underlying transport API.
- **moqt:** Publisher enforces a single active incoming probe stream; opening a new stream cancels the previous one.
- **moqt:** Probe parameters (`ProbeInterval`, `ProbeMaxAge`, `ProbeMaxDelta`) moved from package-level variables to `Config` fields with nil-safe accessor methods. Defaults: 100 ms / 10 s / 10%.
- **moqt:** `newSession` clones the passed `*Config` to prevent external mutation from affecting the session.
- **cmd/interop:** Updated interop client to use the new channel-based `Probe` API; removed RTT from output.