### PR TITLE
Add Session.Stats() method for session statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **moqt:** `Session.ProbeTargets() <-chan ProbeResult` — publisher-side channel for the latest subscriber target bitrate (buffered 1, latest-value semantics).
-- **moq-web:** `Session.probe()` support with `ProbeResult` handling for bitrate measurement.
-
-### Changed
-
-- Repository owner changed from `okdaichi` to `qumo-dev`.
-- **moqt:** `Session.Probe()` reuses the same stream on repeated calls; the channel is closed when the stream or session ends.
-- **moqt:** `ProbeResult.RTT` removed; RTT is available via the underlying transport API.
-- **moqt:** Publisher now enforces a single active incoming probe stream; a new stream cancels the previous one.
-
-### Fixed
-
-- **moqt:** Fixed probe stream cleanup on session or stream close.
+- **moqt:** `Session.Stats()` returns `SessionStats` with estimated bitrate, transport RTT, bytes sent, and bytes received.
 
 ## [v0.14.0] - 2026-04-23
 

--- a/docs/moqt/content/en/docs/moq/probe.md
+++ b/docs/moqt/content/en/docs/moq/probe.md
@@ -22,8 +22,8 @@ type ProbeResult struct {
 |-----------|----------|----------------------------------------------------------------|
 | `Bitrate` | `uint64` | The measured bitrate in bits per second. 0 means unknown.      |
 
-> **Note:** RTT is not included in `ProbeResult`. Use the underlying
-> transport API (e.g. `(*quic.Conn).ConnectionStats()`) to obtain RTT.
+> **Note:** RTT is not included in `ProbeResult`.
+> Use `Session.Stats()` or the underlying transport API (e.g. `(*quic.Conn).ConnectionStats()`) to obtain RTT, bytes sent, and bytes received.
 
 ## Notify Target Bitrate
 

--- a/docs/moqt/content/en/docs/moq/session.md
+++ b/docs/moqt/content/en/docs/moq/session.md
@@ -19,6 +19,7 @@ func (s *Session) AcceptAnnounce(prefix string) (*AnnouncementReader, error)
 func (s *Session) Fetch(req *FetchRequest) (*GroupReader, error)
 func (s *Session) Probe(targetBitrate uint64) (<-chan ProbeResult, error)
 func (s *Session) ProbeTargets() <-chan ProbeResult
+func (s *Session) Stats() SessionStats
 func (s *Session) CloseWithError(code SessionErrorCode, msg string) error
 func (s *Session) Context() context.Context
 func (s *Session) ConnectionState() ConnectionState
@@ -44,6 +45,29 @@ The `ConnectionState` struct contains:
 |-----------|---------------------------|---------------------------------------------|
 | `Version` | `string`                  | The negotiated MOQ protocol version (e.g., `"moq-lite-04"`) |
 | `TLS`     | `*tls.ConnectionState`     | TLS connection state when available          |
+
+## Connection Statistics
+
+Use `Session.Stats()` to fetch a point-in-time snapshot of the session's observable metrics.
+
+```go
+stats := sess.Stats()
+fmt.Printf("estimated bitrate=%d bps\n", stats.EstimatedBitrate)
+fmt.Printf("rtt=%s\n", stats.RTT)
+fmt.Printf("bytes sent=%d\n", stats.BytesSent)
+fmt.Printf("bytes received=%d\n", stats.BytesReceived)
+```
+
+`SessionStats` includes:
+
+| Field             | Type           | Description |
+|------------------|----------------|-------------|
+| `EstimatedBitrate` | `uint64`       | Latest measured outbound bitrate from the probe mechanism. Zero until a measurement is available. |
+| `RTT`            | `time.Duration`| Smoothed round-trip time from the underlying transport. Zero when unavailable. |
+| `BytesSent`      | `uint64`       | Total bytes sent on the underlying connection. Zero when unavailable. |
+| `BytesReceived`  | `uint64`       | Total bytes received on the underlying connection. Zero when unavailable. |
+
+The values are zero when the current transport does not expose the corresponding metrics, such as some WebTransport browser sessions.
 
 ## Subscribe to a Track
 

--- a/moq-web/deno.json
+++ b/moq-web/deno.json
@@ -23,7 +23,7 @@
 		"verbatimModuleSyntax": false
 	},
 	"imports": {
-		"@okdaichi/golikejs": "jsr:@okdaichi/golikejs@0.8.0",
+		"@okdaichi/golikejs": "jsr:@okdaichi/golikejs@0.9.0",
 		"@std/assert": "jsr:@std/assert@^1.0.16",
 		"@std/cli": "jsr:@std/cli@^1.0.24",
 		"@std/path": "jsr:@std/path@^1.1.3",

--- a/moq-web/deno.lock
+++ b/moq-web/deno.lock
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@okdaichi/golikejs@0.8.0": "0.8.0",
+    "jsr:@okdaichi/golikejs@0.9.0": "0.9.0",
     "jsr:@std/assert@^1.0.15": "1.0.16",
     "jsr:@std/assert@^1.0.16": "1.0.16",
     "jsr:@std/async@^1.0.15": "1.0.15",
@@ -16,8 +16,8 @@
     "npm:zod@^3.24.2": "3.25.76"
   },
   "jsr": {
-    "@okdaichi/golikejs@0.8.0": {
-      "integrity": "dd1a6418bf53ae80078881e8bfe114e1a666f5e158b7fe2d17d60b34f28edc9a"
+    "@okdaichi/golikejs@0.9.0": {
+      "integrity": "9e99fab2a4a96c6b04143b37ecd5d18e9783fce4b5cdb716a3cabdb44fc5c00e"
     },
     "@std/assert@1.0.16": {
       "integrity": "6a7272ed1eaa77defe76e5ff63ca705d9c495077e2d5fd0126d2b53fc5bd6532",
@@ -111,7 +111,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@okdaichi/golikejs@0.8.0",
+      "jsr:@okdaichi/golikejs@0.9.0",
       "jsr:@std/assert@^1.0.16",
       "jsr:@std/cli@^1.0.24",
       "jsr:@std/path@^1.1.3",

--- a/moq-web/src/group_stream_test.ts
+++ b/moq-web/src/group_stream_test.ts
@@ -45,7 +45,9 @@ Deno.test("GroupWriter", async (t) => {
 		const [ctx] = withCancelCause(background());
 		// failure writer that always returns an error
 		const writer: SendStream = {
-			write: spy(async (_p: Uint8Array): Promise<[number, Error | undefined]> => [0, new Error("fail")]),
+			write: spy(async (
+				_p: Uint8Array,
+			): Promise<[number, Error | undefined]> => [0, new Error("fail")]),
 			close: async () => {},
 			cancel: async (_code: number) => {},
 			closed: () => new Promise<void>(() => {}),
@@ -324,7 +326,9 @@ Deno.test("GroupReader", async (t) => {
 
 	await t.step("readFrame returns EOFError when stream closes immediately", async () => {
 		const rs: ReceiveStream = {
-			read: spy(async (_p: Uint8Array): Promise<[number, Error | undefined]> => [0, new EOFError()]),
+			read: spy(async (
+				_p: Uint8Array,
+			): Promise<[number, Error | undefined]> => [0, new EOFError()]),
 			cancel: async (_code: number) => {},
 			closed: () => new Promise<void>(() => {}),
 		};

--- a/moq-web/src/group_stream_test.ts
+++ b/moq-web/src/group_stream_test.ts
@@ -45,7 +45,7 @@ Deno.test("GroupWriter", async (t) => {
 		const [ctx] = withCancelCause(background());
 		// failure writer that always returns an error
 		const writer: SendStream = {
-			write: spy(async (_p: Uint8Array) => [0, new Error("fail")]),
+			write: spy(async (_p: Uint8Array): Promise<[number, Error | undefined]> => [0, new Error("fail")]),
 			close: async () => {},
 			cancel: async (_code: number) => {},
 			closed: () => new Promise<void>(() => {}),
@@ -324,7 +324,7 @@ Deno.test("GroupReader", async (t) => {
 
 	await t.step("readFrame returns EOFError when stream closes immediately", async () => {
 		const rs: ReceiveStream = {
-			read: spy(async () => [0, new EOFError()]),
+			read: spy(async (_p: Uint8Array): Promise<[number, Error | undefined]> => [0, new EOFError()]),
 			cancel: async (_code: number) => {},
 			closed: () => new Promise<void>(() => {}),
 		};

--- a/moq-web/src/session.ts
+++ b/moq-web/src/session.ts
@@ -619,6 +619,7 @@ export class Session {
 			const bitrate = stats.estimatedSendRate;
 			const now = Date.now();
 			if (bitrate != null) {
+				this.#estimatedBitrate = bitrate;
 				const shouldSend = !firstSent ||
 					now - lastSentAt >= this.#probeMaxAgeMs ||
 					(lastBitrate === 0
@@ -635,7 +636,6 @@ export class Session {
 					firstSent = true;
 					lastBitrate = bitrate;
 					lastSentAt = now;
-					this.#estimatedBitrate = bitrate;
 				}
 			}
 

--- a/moq-web/src/session.ts
+++ b/moq-web/src/session.ts
@@ -17,6 +17,7 @@ import {
 	StreamConnError,
 	StreamConnErrorInfo,
 } from "./internal/webtransport/mod.ts";
+import { Channel } from "@okdaichi/golikejs";
 import { background, withCancelCause } from "@okdaichi/golikejs/context";
 import type { CancelCauseFunc, Context } from "@okdaichi/golikejs/context";
 import { AnnouncementReader, AnnouncementWriter } from "./announce_stream.ts";
@@ -115,29 +116,27 @@ export class Session {
 		Queue<[ReceiveStream, GroupMessage]>
 	> = new Map();
 
-	#probeStream?: Stream;
-	#probeResponseQueue: Queue<ProbeResult> = new Queue();
-	#probeResponseGen?: AsyncGenerator<ProbeResult>;
-	#probeStreamClosed: boolean = false;
+	#outgoingProbeStream?: Stream;
+	#outgoingProbeStreamClosed: boolean = false;
+	#probeResponseChan: Channel<ProbeResult> = new Channel(1);
 
 	#incomingProbeStream?: Stream;
-	#probeTargetsQueue: Queue<ProbeResult> = new Queue();
-	#probeTargetsGen?: AsyncGenerator<ProbeResult>;
+	#probeTargetsChan: Channel<ProbeResult> = new Channel(1);
 
-	#probeIntervalMs: number;
-	#probeMaxAgeMs: number;
-	#probeMaxDelta: number;
-
-	#estimatedBitrate: number = 0;
+	#bitrateTracker: BitrateTracker;
 
 	constructor(options: SessionInit) {
 		this.#webtransport = options.transport;
 		this.mux = options.mux ?? DefaultTrackMux;
 		this.#fetchHandler = options.fetchHandler;
 		this.#onGoaway = options.onGoaway;
-		this.#probeIntervalMs = options.options?.probeIntervalMs ?? defaultProbeIntervalMs;
-		this.#probeMaxAgeMs = options.options?.probeMaxAgeMs ?? defaultProbeMaxAgeMs;
-		this.#probeMaxDelta = options.options?.probeMaxDelta ?? defaultProbeMaxDelta;
+
+		this.#bitrateTracker = new BitrateTracker({
+			intervalMs: options.options?.probeIntervalMs ?? defaultProbeIntervalMs,
+			maxAgeMs: options.options?.probeMaxAgeMs ?? defaultProbeMaxAgeMs,
+			maxDelta: options.options?.probeMaxDelta ?? defaultProbeMaxDelta,
+		});
+
 		const [ctx, cancel] = withCancelCause(background());
 		this.#ctx = ctx;
 		this.#cancelFunc = cancel;
@@ -173,6 +172,13 @@ export class Session {
 	async #setup(): Promise<void> {
 		await this.#webtransport.ready;
 
+		// Initialize bitrate tracker baseline after transport is ready
+		const transport = this.#webtransport as unknown as TransportStatsCapable;
+		if (transport.getStats) {
+			const stats = await transport.getStats();
+			this.#bitrateTracker.init(stats, Date.now());
+		}
+
 		// Start listening for incoming streams
 		this.#wg.push(this.#listenBiStreams());
 		this.#wg.push(this.#listenUniStreams());
@@ -199,14 +205,28 @@ export class Session {
 			return [undefined, new Error("session is closing")];
 		}
 
-		if (!this.#probeStream || this.#probeStreamClosed) {
-			const openErr = await this.#openProbeStream();
+		if (!this.#outgoingProbeStream || this.#outgoingProbeStreamClosed) {
+			const [stream, openErr] = await this.#webtransport.openStream();
 			if (openErr) {
+				console.error("moq: failed to open probe stream:", openErr);
 				return [undefined, openErr];
 			}
+
+			const [, err] = await writeVarint(stream.writable, BiStreamTypes.ProbeStreamType);
+			if (err) {
+				console.error("moq: failed to open probe stream:", err);
+				cancelStreamWithError(stream, ProbeErrorCode.Internal);
+				return [undefined, err];
+			}
+
+			this.#outgoingProbeStream = stream;
+			this.#outgoingProbeStreamClosed = false;
+			this.#readProbeResponses(stream).catch((err) => {
+				console.warn("moq: probe stream reader failed:", err);
+			});
 		}
 
-		const stream = this.#probeStream!;
+		const stream = this.#outgoingProbeStream!;
 		const req = new ProbeMessage({ bitrate: targetBitrate });
 		const err = await req.encode(stream.writable);
 		if (err) {
@@ -215,63 +235,21 @@ export class Session {
 			return [undefined, err];
 		}
 
-		if (!this.#probeResponseGen) {
-			this.#probeResponseGen = this.#makeProbeResponseGen();
-		}
-		return [this.#probeResponseGen, undefined];
-	}
-
-	async *#makeProbeResponseGen(): AsyncGenerator<ProbeResult> {
-		while (true) {
-			const result = await this.#probeResponseQueue.dequeue();
-			if (result === undefined) return;
-			yield result;
-		}
+		return [
+			this.#probeResponseChan[Symbol.asyncIterator]() as AsyncGenerator<ProbeResult>,
+			undefined,
+		];
 	}
 
 	/**
 	 * Returns a channel that yields the latest target bitrate hints sent by
 	 * the subscriber via PROBE messages.
-	 * The same {@link AsyncGenerator} is returned on every call.
 	 * The generator ends when the session terminates.
 	 *
 	 * Mirrors Go's `Session.ProbeTargets() <-chan ProbeResult`.
 	 */
 	probeTargets(): AsyncGenerator<ProbeResult> {
-		if (!this.#probeTargetsGen) {
-			this.#probeTargetsGen = this.#makeProbeTargetsGen();
-		}
-		return this.#probeTargetsGen;
-	}
-
-	async *#makeProbeTargetsGen(): AsyncGenerator<ProbeResult> {
-		while (true) {
-			const result = await this.#probeTargetsQueue.dequeue();
-			if (result === undefined) return;
-			yield result;
-		}
-	}
-
-	async #openProbeStream(): Promise<Error | undefined> {
-		const [stream, openErr] = await this.#webtransport.openStream();
-		if (openErr) {
-			console.error("moq: failed to open probe stream:", openErr);
-			return openErr;
-		}
-
-		const [, err] = await writeVarint(stream.writable, BiStreamTypes.ProbeStreamType);
-		if (err) {
-			console.error("moq: failed to open probe stream:", err);
-			cancelStreamWithError(stream, ProbeErrorCode.Internal);
-			return err;
-		}
-
-		this.#probeStream = stream;
-		this.#probeStreamClosed = false;
-		this.#readProbeResponses(stream).catch((err) => {
-			console.warn("moq: probe stream reader failed:", err);
-		});
-		return undefined;
+		return this.#probeTargetsChan[Symbol.asyncIterator]() as AsyncGenerator<ProbeResult>;
 	}
 
 	async #readProbeResponses(stream: Stream): Promise<void> {
@@ -286,8 +264,11 @@ export class Session {
 					throw err;
 				}
 
-				this.#estimatedBitrate = rsp.bitrate;
-				await this.#probeResponseQueue.enqueue({ bitrate: rsp.bitrate });
+				this.#bitrateTracker.record(rsp.bitrate, Date.now());
+
+				// Notify any active probe() calls of the new measurement result.
+				this.#probeResponseChan.tryReceive(); // drop old
+				this.#probeResponseChan.trySend({ bitrate: rsp.bitrate });
 			}
 		} catch (err) {
 			if (!this.#ctx.err()) {
@@ -295,9 +276,9 @@ export class Session {
 				cancelStreamWithError(stream, ProbeErrorCode.Internal);
 			}
 		} finally {
-			this.#probeStreamClosed = true;
-			if (this.#probeStream === stream) {
-				this.#probeStream = undefined;
+			this.#outgoingProbeStreamClosed = true;
+			if (this.#outgoingProbeStream === stream) {
+				this.#outgoingProbeStream = undefined;
 			}
 		}
 	}
@@ -549,9 +530,20 @@ export class Session {
 	async #handleProbeStream(stream: Stream): Promise<void> {
 		const quic = this.#webtransport as unknown as TransportStatsCapable;
 
-		this.#setIncomingProbeStream(stream);
+		if (this.#incomingProbeStream && this.#incomingProbeStream !== stream) {
+			cancelStreamWithError(this.#incomingProbeStream, ProbeErrorCode.Internal);
+		}
+		this.#incomingProbeStream = stream;
+
 		if (quic.getStats) {
-			this.#detectProbeStats(stream, quic).catch((err) => {
+			this.#bitrateTracker.monitor(this.#ctx, quic, async (bitrate, rtt) => {
+				const rsp = new ProbeMessage({ bitrate, rtt });
+				const err = await rsp.encode(stream.writable);
+				if (err) {
+					cancelStreamWithError(stream, ProbeErrorCode.Internal);
+					return;
+				}
+			}).catch((err) => {
 				console.warn(`moq: probe detection failed: ${err}`);
 			});
 		}
@@ -568,7 +560,8 @@ export class Session {
 				}
 
 				// Notify publisher-side consumers of the new target bitrate.
-				this.#probeTargetsQueue.enqueue({ bitrate: req.bitrate }).catch(() => {});
+				this.#probeTargetsChan.tryReceive(); // drop old
+				this.#probeTargetsChan.trySend({ bitrate: req.bitrate });
 
 				let bitrate = 0;
 				if (quic.getStats) {
@@ -588,58 +581,9 @@ export class Session {
 				cancelStreamWithError(stream, ProbeErrorCode.Internal);
 			}
 		} finally {
-			this.#clearIncomingProbeStream(stream);
-		}
-	}
-
-	#setIncomingProbeStream(stream: Stream): void {
-		if (this.#incomingProbeStream && this.#incomingProbeStream !== stream) {
-			cancelStreamWithError(this.#incomingProbeStream, ProbeErrorCode.Internal);
-		}
-		this.#incomingProbeStream = stream;
-	}
-
-	#clearIncomingProbeStream(stream: Stream): void {
-		if (this.#incomingProbeStream === stream) {
-			this.#incomingProbeStream = undefined;
-		}
-	}
-
-	async #detectProbeStats(stream: Stream, quic: TransportStatsCapable): Promise<void> {
-		let lastBitrate = 0;
-		let lastSentAt = 0;
-		let firstSent = false;
-
-		while (true) {
-			if (this.#ctx.err()) {
-				return;
+			if (this.#incomingProbeStream === stream) {
+				this.#incomingProbeStream = undefined;
 			}
-
-			const stats = await quic.getStats!();
-			const bitrate = stats.estimatedSendRate;
-			const now = Date.now();
-			if (bitrate != null) {
-				this.#estimatedBitrate = bitrate;
-				const shouldSend = !firstSent ||
-					now - lastSentAt >= this.#probeMaxAgeMs ||
-					(lastBitrate === 0
-						? bitrate !== 0
-						: Math.abs(bitrate - lastBitrate) / lastBitrate >= this.#probeMaxDelta);
-				if (shouldSend) {
-					const rsp = new ProbeMessage({ bitrate, rtt: 0 });
-					const err = await rsp.encode(stream.writable);
-					if (err) {
-						cancelStreamWithError(stream, ProbeErrorCode.Internal);
-						return;
-					}
-
-					firstSent = true;
-					lastBitrate = bitrate;
-					lastSentAt = now;
-				}
-			}
-
-			await new Promise((resolve) => setTimeout(resolve, this.#probeIntervalMs));
 		}
 	}
 
@@ -705,13 +649,10 @@ export class Session {
 			let err: Error | undefined;
 			while (true) {
 				const [stream, acceptErr] = await this.#webtransport.acceptStream();
-				// biStreams.releaseLock(); // Release the lock after reading
 				if (acceptErr) {
 					// Only log as error if session is not closing
 					if (!this.#ctx.err()) {
 						console.error("Bidirectional stream closed", acceptErr);
-					} else {
-						// debug log removed
 					}
 					break;
 				}
@@ -743,15 +684,13 @@ export class Session {
 				}
 			}
 		} catch (error) {
-			// "timed out" errors during connection close are expected
 			if (error instanceof Error && error.message === "timed out") {
-				// console.debug("listenBiStreams: connection closed (timed out)");
+				// expected
 			} else {
 				console.error("Error in listenBiStreams:", error);
 			}
 			return;
 		} finally {
-			// Wait for all pending handle operations to complete
 			if (pendingHandles.length > 0) {
 				await Promise.allSettled(pendingHandles);
 			}
@@ -766,11 +705,8 @@ export class Session {
 			while (true) {
 				const [stream, acceptErr] = await this.#webtransport.acceptUniStream();
 				if (acceptErr) {
-					// Only log as error if session is not closing
 					if (!this.#ctx.err()) {
 						console.error("Unidirectional stream closed", acceptErr);
-					} else {
-						// debug log removed
 					}
 					break;
 				}
@@ -787,21 +723,18 @@ export class Session {
 						pendingHandles.push(this.#handleGroupStream(stream));
 						break;
 					default:
-						// Unknown stream types are stream-local and non-fatal for extension probing.
 						stream.cancel(SessionErrorCode.InternalError).catch(() => {});
 						break;
 				}
 			}
 		} catch (error) {
-			// "timed out" errors during connection close are expected
 			if (error instanceof Error && error.message === "timed out") {
-				// console.debug("listenUniStreams: connection closed (timed out)");
+				// expected
 			} else {
 				console.error("Error in listenUniStreams:", error);
 			}
 			return;
 		} finally {
-			// Wait for all pending handle operations to complete
 			if (pendingHandles.length > 0) {
 				await Promise.allSettled(pendingHandles);
 			}
@@ -820,7 +753,7 @@ export class Session {
 	 */
 	async getStats(): Promise<SessionStats> {
 		const stats: SessionStats = {
-			estimatedBitrate: this.#estimatedBitrate,
+			estimatedBitrate: this.#bitrateTracker.estimatedBitrate,
 			rtt: 0,
 			bytesSent: 0,
 			bytesReceived: 0,
@@ -854,12 +787,12 @@ export class Session {
 		if (this.#incomingProbeStream) {
 			cancelStreamWithError(this.#incomingProbeStream, ProbeErrorCode.Internal);
 		}
-		if (this.#probeStream) {
-			cancelStreamWithError(this.#probeStream, ProbeErrorCode.Internal);
+		if (this.#outgoingProbeStream) {
+			cancelStreamWithError(this.#outgoingProbeStream, ProbeErrorCode.Internal);
 		}
 
-		this.#probeResponseQueue.close();
-		this.#probeTargetsQueue.close();
+		this.#probeResponseChan.close();
+		this.#probeTargetsChan.close();
 
 		try {
 			await Promise.allSettled(this.#wg);
@@ -890,12 +823,12 @@ export class Session {
 		if (this.#incomingProbeStream) {
 			cancelStreamWithError(this.#incomingProbeStream, ProbeErrorCode.Internal);
 		}
-		if (this.#probeStream) {
-			cancelStreamWithError(this.#probeStream, ProbeErrorCode.Internal);
+		if (this.#outgoingProbeStream) {
+			cancelStreamWithError(this.#outgoingProbeStream, ProbeErrorCode.Internal);
 		}
 
-		this.#probeResponseQueue.close();
-		this.#probeTargetsQueue.close();
+		this.#probeResponseChan.close();
+		this.#probeTargetsChan.close();
 
 		try {
 			await Promise.allSettled(this.#wg);
@@ -903,5 +836,140 @@ export class Session {
 			// ignore
 		}
 		this.#wg = [];
+	}
+}
+
+export interface BitrateTrackerConfig {
+	intervalMs: number;
+	maxAgeMs: number;
+	maxDelta: number;
+}
+
+class BitrateTracker {
+	#intervalMs: number;
+	#maxAgeMs: number;
+	#maxDelta: number;
+
+	#initialized = false;
+	#bytesSent = 0;
+	#sampleTime = 0;
+	#estimatedBitrate = 0;
+	#lastSentBitrate = 0;
+
+	#lastSentAt = 0;
+
+	constructor(config: BitrateTrackerConfig) {
+		this.#intervalMs = config.intervalMs;
+		this.#maxAgeMs = config.maxAgeMs;
+		this.#maxDelta = config.maxDelta;
+	}
+
+	get estimatedBitrate(): number {
+		return this.#estimatedBitrate;
+	}
+
+	set estimatedBitrate(value: number) {
+		this.#estimatedBitrate = value;
+	}
+
+	init(stats: TransportStats, now: number): void {
+		this.#initialized = true;
+		this.#bytesSent = stats.bytesSent ?? 0;
+		this.#sampleTime = now;
+		if (stats.estimatedSendRate != null) {
+			this.#estimatedBitrate = stats.estimatedSendRate;
+		}
+	}
+
+	record(bitrate: number, now: number): void {
+		this.#estimatedBitrate = bitrate;
+		this.#lastSentBitrate = bitrate;
+		this.#lastSentAt = now;
+	}
+
+	async monitor(
+		ctx: Context,
+		quic: TransportStatsCapable,
+		onProbe: (bitrate: number, rtt: number) => Promise<void>,
+	): Promise<void> {
+		if (!quic.getStats) return;
+
+		while (true) {
+			if (ctx.err()) {
+				return;
+			}
+
+			const stats = await quic.getStats();
+			const now = Date.now();
+			const [bitrate, ok] = this.next(stats, now);
+
+			if (ok) {
+				await onProbe(bitrate, stats.smoothedRtt ? Math.floor(stats.smoothedRtt) : 0);
+			}
+
+			await new Promise((resolve) => setTimeout(resolve, this.#intervalMs));
+		}
+	}
+
+	next(stats: TransportStats, now: number): [number, boolean] {
+		const bitrate = this.measureBitrate(stats, now);
+
+		if (this.#lastSentAt === 0) {
+			this.record(bitrate, now);
+			return [bitrate, true];
+		}
+
+		if (
+			now - this.#lastSentAt >= this.#maxAgeMs ||
+			this.#hasDelta(this.#lastSentBitrate, bitrate, this.#maxDelta)
+		) {
+			this.record(bitrate, now);
+			return [bitrate, true];
+		}
+
+		return [bitrate, false];
+	}
+
+	measureBitrate(stats: TransportStats, now: number): number {
+		// Prefer estimatedSendRate if provided (e.g. standard WebTransport)
+		if (stats.estimatedSendRate != null) {
+			this.#estimatedBitrate = stats.estimatedSendRate;
+		}
+
+		if (stats.bytesSent === undefined) {
+			return this.#estimatedBitrate;
+		}
+
+		if (!this.#initialized) {
+			this.init(stats, now);
+			return this.#estimatedBitrate;
+		}
+
+		const elapsed = (now - this.#sampleTime) / 1000;
+		if (elapsed <= 0) {
+			return this.#estimatedBitrate;
+		}
+
+		const bytesSent = stats.bytesSent;
+		let bytesDelta = 0;
+		if (bytesSent >= this.#bytesSent) {
+			bytesDelta = bytesSent - this.#bytesSent;
+		}
+		this.#bytesSent = bytesSent;
+		this.#sampleTime = now;
+
+		// Only update #estimatedBitrate from bytes delta if estimatedSendRate was NOT provided
+		if (stats.estimatedSendRate == null) {
+			this.#estimatedBitrate = Math.floor((bytesDelta * 8) / elapsed);
+		}
+		return this.#estimatedBitrate;
+	}
+
+	#hasDelta(oldVal: number, newVal: number, maxDelta: number): boolean {
+		if (oldVal === 0) {
+			return newVal !== 0;
+		}
+		const diff = Math.abs(newVal - oldVal);
+		return diff / oldVal >= maxDelta;
 	}
 }

--- a/moq-web/src/session.ts
+++ b/moq-web/src/session.ts
@@ -44,9 +44,31 @@ function cancelStreamWithError(stream: Stream, code: number): void {
 	stream.writable.cancel(code).catch(() => {});
 }
 
-type ProbeStatsCapable = {
-	getStats?: () => Promise<{ estimatedSendRate: number | null }>;
+type TransportStats = {
+	estimatedSendRate?: number | null;
+	smoothedRtt?: number;
+	bytesSent?: number;
+	bytesReceived?: number;
 };
+
+type TransportStatsCapable = {
+	getStats?: () => Promise<TransportStats>;
+};
+
+/**
+ * A snapshot of statistics for a {@link Session}.
+ * Fields are 0 when not yet measured or not available.
+ */
+export interface SessionStats {
+	/** Estimated outbound bitrate in bits per second (0 until measured via probe). */
+	estimatedBitrate: number;
+	/** Smoothed round-trip time in milliseconds (0 when not available). */
+	rtt: number;
+	/** Total bytes sent on the underlying connection (0 when not available). */
+	bytesSent: number;
+	/** Total bytes received on the underlying connection (0 when not available). */
+	bytesReceived: number;
+}
 
 /** Options for constructing a {@link Session}. */
 export interface SessionInit {
@@ -105,6 +127,8 @@ export class Session {
 	#probeIntervalMs: number;
 	#probeMaxAgeMs: number;
 	#probeMaxDelta: number;
+
+	#estimatedBitrate: number = 0;
 
 	constructor(options: SessionInit) {
 		this.#webtransport = options.transport;
@@ -262,6 +286,7 @@ export class Session {
 					throw err;
 				}
 
+				this.#estimatedBitrate = rsp.bitrate;
 				await this.#probeResponseQueue.enqueue({ bitrate: rsp.bitrate });
 			}
 		} catch (err) {
@@ -522,7 +547,7 @@ export class Session {
 	}
 
 	async #handleProbeStream(stream: Stream): Promise<void> {
-		const quic = this.#webtransport as unknown as ProbeStatsCapable;
+		const quic = this.#webtransport as unknown as TransportStatsCapable;
 
 		this.#setIncomingProbeStream(stream);
 		if (quic.getStats) {
@@ -580,7 +605,7 @@ export class Session {
 		}
 	}
 
-	async #detectProbeStats(stream: Stream, quic: ProbeStatsCapable): Promise<void> {
+	async #detectProbeStats(stream: Stream, quic: TransportStatsCapable): Promise<void> {
 		let lastBitrate = 0;
 		let lastSentAt = 0;
 		let firstSent = false;
@@ -610,6 +635,7 @@ export class Session {
 					firstSent = true;
 					lastBitrate = bitrate;
 					lastSentAt = now;
+					this.#estimatedBitrate = bitrate;
 				}
 			}
 
@@ -780,6 +806,35 @@ export class Session {
 				await Promise.allSettled(pendingHandles);
 			}
 		}
+	}
+
+	/**
+	 * Returns a snapshot of current session statistics.
+	 *
+	 * Mirrors Go's `Session.Stats() SessionStats`.
+	 * RTT, bytes sent/received are populated from the underlying transport's
+	 * `getStats()` when available (standard WebTransport API); all fields
+	 * default to `0` when not yet measured or not supported.
+	 *
+	 * @returns A {@link SessionStats} snapshot.
+	 */
+	async getStats(): Promise<SessionStats> {
+		const stats: SessionStats = {
+			estimatedBitrate: this.#estimatedBitrate,
+			rtt: 0,
+			bytesSent: 0,
+			bytesReceived: 0,
+		};
+
+		const transport = this.#webtransport as unknown as TransportStatsCapable;
+		if (transport.getStats) {
+			const wtStats = await transport.getStats();
+			stats.rtt = wtStats.smoothedRtt ?? 0;
+			stats.bytesSent = wtStats.bytesSent ?? 0;
+			stats.bytesReceived = wtStats.bytesReceived ?? 0;
+		}
+
+		return stats;
 	}
 
 	/** Gracefully close the session. */

--- a/moq-web/src/session_test.ts
+++ b/moq-web/src/session_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertExists, assertInstanceOf } from "@std/assert";
+import { assert, assertEquals, assertExists, assertInstanceOf } from "@std/assert";
 import { spy } from "@std/testing/mock";
 import { Session } from "./session.ts";
 import type { SessionStats } from "./session.ts";
@@ -1150,6 +1150,43 @@ Deno.test({
 				assertEquals(currentStats.estimatedBitrate, 8100);
 
 				await session.close();
+			},
+		);
+
+		await t.step(
+			"probe methods support concurrent access and splitting messages",
+			async () => {
+				const mock = new MockWebTransportSession({});
+				const session = new Session({ transport: mock });
+				await session.ready;
+
+				// Test probe() concurrency
+				const [gen1] = await session.probe(1000);
+				const [gen2] = await session.probe(2000);
+				assert(gen1 !== gen2, "each call should return a new iterator");
+
+				let count1 = 0;
+				let count2 = 0;
+
+				// Start two consumers
+				const p1 = (async () => {
+					for await (const _ of gen1!) count1++;
+				})();
+				const p2 = (async () => {
+					for await (const _ of gen2!) count2++;
+				})();
+
+				// Close the session to end the generators
+				await session.close();
+				await Promise.all([p1, p2]);
+
+				// Test probeTargets() concurrency
+				const session2 = new Session({ transport: new MockWebTransportSession({}) });
+				const tGen1 = session2.probeTargets();
+				const tGen2 = session2.probeTargets();
+				assert(tGen1 !== tGen2);
+
+				await session2.close();
 			},
 		);
 	},

--- a/moq-web/src/session_test.ts
+++ b/moq-web/src/session_test.ts
@@ -1111,5 +1111,46 @@ Deno.test({
 
 			await session.close();
 		});
+
+		await t.step(
+			"getStats reflects frequent estimatedBitrate updates even if delta is small",
+			async () => {
+				const req = new ProbeMessage({ bitrate: 1234 });
+				const reqBytes = await encodeMessageToUint8Array(async (w) => {
+					await writeVarint(w, BiStreamTypes.ProbeStreamType);
+					return await req.encode(w);
+				});
+
+				const stats = { estimatedSendRate: 8000 };
+				const mock = new MockWebTransportSession({
+					acceptStreamData: [{ type: BiStreamTypes.ProbeStreamType, data: reqBytes }],
+					stats,
+				});
+
+				const session = new Session({
+					transport: mock,
+					options: {
+						probeIntervalMs: 10,
+						probeMaxDelta: 1000.0, // huge delta
+					},
+				});
+				await session.ready;
+
+				// Wait for initial detection
+				await new Promise((resolve) => setTimeout(resolve, 50));
+				let currentStats = await session.getStats();
+				assertEquals(currentStats.estimatedBitrate, 8000);
+
+				// Update bitrate by a small amount
+				stats.estimatedSendRate = 8100; // 1.25% change, much smaller than 100000%
+
+				// Wait for next tick
+				await new Promise((resolve) => setTimeout(resolve, 50));
+				currentStats = await session.getStats();
+				assertEquals(currentStats.estimatedBitrate, 8100);
+
+				await session.close();
+			},
+		);
 	},
 });

--- a/moq-web/src/session_test.ts
+++ b/moq-web/src/session_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertExists, assertInstanceOf } from "@std/assert";
 import { spy } from "@std/testing/mock";
 import { Session } from "./session.ts";
+import type { SessionStats } from "./session.ts";
 import {
 	AnnounceInterestMessage,
 	FetchMessage,
@@ -52,11 +53,19 @@ interface MockWebTransportSessionInit {
 	acceptUniStreamData?: Array<{ type: number; data: Uint8Array }>;
 	closedPromise?: Promise<WebTransportCloseInfo>;
 	protocol?: string;
-	stats?: { estimatedSendRate: number | null };
+	stats?: {
+		estimatedSendRate?: number | null;
+		smoothedRtt?: number;
+		bytesSent?: number;
+		bytesReceived?: number;
+	};
 }
 
-type WebTransportProbeStats = {
-	estimatedSendRate: number | null;
+type MockTransportStats = {
+	estimatedSendRate?: number | null;
+	smoothedRtt?: number;
+	bytesSent?: number;
+	bytesReceived?: number;
 };
 
 class MockWebTransportSession implements StreamConn {
@@ -72,7 +81,7 @@ class MockWebTransportSession implements StreamConn {
 	#closedPromise: Promise<WebTransportCloseInfo>;
 	#closedResolve?: (info: WebTransportCloseInfo) => void;
 	#waitingAcceptResolvers: Array<() => void> = [];
-	#stats: WebTransportProbeStats = { estimatedSendRate: null };
+	#stats: MockTransportStats = {};
 
 	ready: Promise<void> = Promise.resolve();
 	readonly protocol: string;
@@ -82,7 +91,7 @@ class MockWebTransportSession implements StreamConn {
 		this.#acceptStreamData = options.acceptStreamData ?? [];
 		this.#acceptUniStreamData = options.acceptUniStreamData ?? [];
 		this.protocol = options.protocol ?? "";
-		this.#stats = options.stats ?? { estimatedSendRate: null };
+		this.#stats = options.stats ?? {};
 		if (options.stats !== undefined) {
 			Object.defineProperty(this, "getStats", {
 				value: async () => this.#stats,
@@ -1017,5 +1026,84 @@ Deno.test({
 				await session.close();
 			},
 		);
+
+		await t.step("getStats returns zero values when transport has no getStats", async () => {
+			const mock = new MockWebTransportSession({});
+
+			const session = new Session({ transport: mock });
+			await session.ready;
+
+			const stats: SessionStats = await session.getStats();
+			assertEquals(stats.estimatedBitrate, 0);
+			assertEquals(stats.rtt, 0);
+			assertEquals(stats.bytesSent, 0);
+			assertEquals(stats.bytesReceived, 0);
+
+			await session.close();
+		});
+
+		await t.step("getStats populates rtt, bytesSent, bytesReceived from transport getStats", async () => {
+			const mock = new MockWebTransportSession({
+				stats: {
+					smoothedRtt: 42,
+					bytesSent: 1000,
+					bytesReceived: 2000,
+				},
+			});
+
+			const session = new Session({ transport: mock });
+			await session.ready;
+
+			const stats: SessionStats = await session.getStats();
+			assertEquals(stats.rtt, 42);
+			assertEquals(stats.bytesSent, 1000);
+			assertEquals(stats.bytesReceived, 2000);
+			assertEquals(stats.estimatedBitrate, 0);
+
+			await session.close();
+		});
+
+		await t.step("getStats reflects estimatedBitrate after probe response received", async () => {
+			const rsp = new ProbeMessage({ bitrate: 5000 });
+			const rspBytes = await encodeMessageToUint8Array(async (w) => rsp.encode(w));
+
+			const mock = new MockWebTransportSession({
+				openStreamResponses: [rspBytes],
+			});
+
+			const session = new Session({ transport: mock });
+			await session.ready;
+
+			const [gen, err] = await session.probe(1234);
+			assertEquals(err, undefined);
+			await gen!.next();
+
+			const stats: SessionStats = await session.getStats();
+			assertEquals(stats.estimatedBitrate, 5000);
+
+			await session.close();
+		});
+
+		await t.step("getStats reflects estimatedBitrate set by detectProbeStats", async () => {
+			const req = new ProbeMessage({ bitrate: 1234 });
+			const reqBytes = await encodeMessageToUint8Array(async (w) => {
+				await writeVarint(w, BiStreamTypes.ProbeStreamType);
+				return await req.encode(w);
+			});
+			const mock = new MockWebTransportSession({
+				acceptStreamData: [{ type: BiStreamTypes.ProbeStreamType, data: reqBytes }],
+				stats: { estimatedSendRate: 7777 },
+			});
+
+			const session = new Session({ transport: mock });
+			await session.ready;
+
+			await new Promise((resolve) => setTimeout(resolve, 300));
+
+			const stats: SessionStats = await session.getStats();
+			assertEquals(stats.estimatedBitrate, 7777);
+
+			await session.close();
+		});
 	},
 });

--- a/moq-web/src/session_test.ts
+++ b/moq-web/src/session_test.ts
@@ -1042,47 +1042,53 @@ Deno.test({
 			await session.close();
 		});
 
-		await t.step("getStats populates rtt, bytesSent, bytesReceived from transport getStats", async () => {
-			const mock = new MockWebTransportSession({
-				stats: {
-					smoothedRtt: 42,
-					bytesSent: 1000,
-					bytesReceived: 2000,
-				},
-			});
+		await t.step(
+			"getStats populates rtt, bytesSent, bytesReceived from transport getStats",
+			async () => {
+				const mock = new MockWebTransportSession({
+					stats: {
+						smoothedRtt: 42,
+						bytesSent: 1000,
+						bytesReceived: 2000,
+					},
+				});
 
-			const session = new Session({ transport: mock });
-			await session.ready;
+				const session = new Session({ transport: mock });
+				await session.ready;
 
-			const stats: SessionStats = await session.getStats();
-			assertEquals(stats.rtt, 42);
-			assertEquals(stats.bytesSent, 1000);
-			assertEquals(stats.bytesReceived, 2000);
-			assertEquals(stats.estimatedBitrate, 0);
+				const stats: SessionStats = await session.getStats();
+				assertEquals(stats.rtt, 42);
+				assertEquals(stats.bytesSent, 1000);
+				assertEquals(stats.bytesReceived, 2000);
+				assertEquals(stats.estimatedBitrate, 0);
 
-			await session.close();
-		});
+				await session.close();
+			},
+		);
 
-		await t.step("getStats reflects estimatedBitrate after probe response received", async () => {
-			const rsp = new ProbeMessage({ bitrate: 5000 });
-			const rspBytes = await encodeMessageToUint8Array(async (w) => rsp.encode(w));
+		await t.step(
+			"getStats reflects estimatedBitrate after probe response received",
+			async () => {
+				const rsp = new ProbeMessage({ bitrate: 5000 });
+				const rspBytes = await encodeMessageToUint8Array(async (w) => rsp.encode(w));
 
-			const mock = new MockWebTransportSession({
-				openStreamResponses: [rspBytes],
-			});
+				const mock = new MockWebTransportSession({
+					openStreamResponses: [rspBytes],
+				});
 
-			const session = new Session({ transport: mock });
-			await session.ready;
+				const session = new Session({ transport: mock });
+				await session.ready;
 
-			const [gen, err] = await session.probe(1234);
-			assertEquals(err, undefined);
-			await gen!.next();
+				const [gen, err] = await session.probe(1234);
+				assertEquals(err, undefined);
+				await gen!.next();
 
-			const stats: SessionStats = await session.getStats();
-			assertEquals(stats.estimatedBitrate, 5000);
+				const stats: SessionStats = await session.getStats();
+				assertEquals(stats.estimatedBitrate, 5000);
 
-			await session.close();
-		});
+				await session.close();
+			},
+		);
 
 		await t.step("getStats reflects estimatedBitrate set by detectProbeStats", async () => {
 			const req = new ProbeMessage({ bitrate: 1234 });

--- a/moqt/mux_test.go
+++ b/moqt/mux_test.go
@@ -28,7 +28,7 @@ func TestNewTrackMux(t *testing.T) {
 func TestNewHopID_Fits62BitVarint(t *testing.T) {
 	const maxHopID uint64 = 0x3FFFFFFFFFFFFFFF
 
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		id := NewHopID()
 		assert.NotZero(t, id, "NewHopID should never return zero")
 		assert.LessOrEqual(t, id, maxHopID, "NewHopID should fit within 62-bit varint range")

--- a/moqt/session.go
+++ b/moqt/session.go
@@ -60,9 +60,7 @@ type Session struct {
 	incomingProbeStream transport.Stream
 	probeTargetsCh      chan ProbeResult
 
-	// estimatedBitrate is the most recently measured outbound bitrate in bps.
-	// Updated by detectBitrateChanges; zero until the first measurement.
-	estimatedBitrate atomic.Uint64
+	bitrateTracker bitrateTracker
 }
 
 func newSession(
@@ -90,8 +88,12 @@ func newSession(
 		trackReaders:    make(map[SubscribeID]*TrackReader),
 		trackWriters:    make(map[SubscribeID]*TrackWriter),
 		connManager:     manager,
-		probeResponseCh: make(chan ProbeResult),    // unbuffered channel for subscriber PROBE responses
-		probeTargetsCh:  make(chan ProbeResult, 1), // buffered channel for latest-value semantics
+		probeResponseCh: make(chan ProbeResult, 1), // latest-value semantics
+		probeTargetsCh:  make(chan ProbeResult, 1), // latest-value semantics
+		bitrateTracker: bitrateTracker{
+			maxAge:   config.probeMaxAge(),
+			maxDelta: config.probeMaxDelta(),
+		},
 	}
 
 	if manager != nil {
@@ -165,9 +167,8 @@ func (s *Session) RemoteAddr() net.Addr {
 // It never returns an error; fields that cannot be measured on the current
 // transport (e.g. RTT on a WebTransport/Browser session) are zero.
 func (s *Session) Stats() SessionStats {
-	stats := SessionStats{
-		EstimatedBitrate: s.estimatedBitrate.Load(),
-	}
+	var stats SessionStats
+	stats.EstimatedBitrate = s.bitrateTracker.getEstimatedBitrate()
 
 	if provider, ok := s.conn.(probeStatsProvider); ok {
 		cs := provider.ConnectionStats()
@@ -515,12 +516,22 @@ func (sess *Session) Probe(targetBitrate uint64) (<-chan ProbeResult, error) {
 					}
 					return
 				}
+				sess.bitrateTracker.record(pm.Bitrate, time.Now())
+
+				// Update the latest probe result, dropping it if the channel buffer is full (i.e. the previous value has not been consumed).
 				select {
-				case sess.probeResponseCh <- ProbeResult{
-					Bitrate: pm.Bitrate,
-				}:
+				case <-sess.probeResponseCh:
+				default:
+				}
+				select {
+				case sess.probeResponseCh <- ProbeResult{Bitrate: pm.Bitrate}:
+				default:
+				}
+
+				select {
 				case <-streamCtx.Done():
 					return
+				default:
 				}
 			}
 		})
@@ -784,72 +795,74 @@ func (sess *Session) handleProbeStream(stream transport.Stream) error {
 	}()
 
 	for {
-		var probe message.ProbeMessage
-		if err := probe.Decode(stream); err != nil {
+		var pm message.ProbeMessage
+		if err := pm.Decode(stream); err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil
 			}
 			return err
 		}
 
+		// Update the latest probe target, dropping it if the channel buffer is full (i.e. the previous value has not been consumed).
 		select {
 		case <-sess.probeTargetsCh:
 		default:
 		}
 		select {
-		case sess.probeTargetsCh <- ProbeResult{Bitrate: probe.Bitrate}:
+		case sess.probeTargetsCh <- ProbeResult{Bitrate: pm.Bitrate}:
 		default:
 		}
 	}
 }
 
+func (sess *Session) notifyResults(bitrate uint64) {
+	select {
+	case <-sess.probeResponseCh:
+	default:
+	}
+	select {
+	case sess.probeResponseCh <- ProbeResult{Bitrate: bitrate}:
+	default:
+	}
+}
+
+func (sess *Session) notifyTargets(bitrate uint64) {
+	select {
+	case <-sess.probeTargetsCh:
+	default:
+	}
+	select {
+	case sess.probeTargetsCh <- ProbeResult{Bitrate: bitrate}:
+	default:
+	}
+}
+
 func (sess *Session) detectBitrateChanges(provider probeStatsProvider) {
-	ticker := time.NewTicker(sess.config.probeInterval())
-	defer ticker.Stop()
-
-	maxAge := sess.config.probeMaxAge()
-	maxDelta := sess.config.probeMaxDelta()
-	tracker := &probeMeasurementTracker{maxAge: maxAge, maxDelta: maxDelta}
-
-	for {
-		select {
-		case <-sess.ctx.Done():
+	sess.bitrateTracker.monitor(sess.ctx, sess.config.probeInterval(), provider, func(bitrate, rtt uint64) {
+		sess.incomingProbeMu.Lock()
+		stream := sess.incomingProbeStream
+		sess.incomingProbeMu.Unlock()
+		if stream == nil {
 			return
-		case now := <-ticker.C:
-			stats := provider.ConnectionStats()
-			bitrate, ok := tracker.next(stats, now)
+		}
 
-			sess.estimatedBitrate.Store(bitrate)
-
-			if !ok {
-				continue
-			}
-
-			sess.incomingProbeMu.Lock()
-			stream := sess.incomingProbeStream
-			sess.incomingProbeMu.Unlock()
-			if stream == nil {
-				continue
-			}
-
-			err := message.ProbeMessage{
-				Bitrate: bitrate,
-				RTT:     uint64(stats.SmoothedRTT.Milliseconds()),
-			}.Encode(stream)
-			if err != nil {
-				if errors.Is(err, io.EOF) {
-					continue
-				}
+		err := message.ProbeMessage{
+			Bitrate: bitrate,
+			RTT:     rtt,
+		}.Encode(stream)
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				sess.logError("failed to send periodic probe", err)
 			}
 		}
-	}
+	})
 }
 
 type probeStatsProvider interface {
 	ConnectionStats() quic.ConnectionStats
 }
 
-type probeMeasurementTracker struct {
+type bitrateTracker struct {
 	maxAge   time.Duration
 	maxDelta float64
 
@@ -859,11 +872,35 @@ type probeMeasurementTracker struct {
 	sampleTime  time.Time
 
 	// throttle state
-	lastBitrate uint64
-	lastSentAt  time.Time
+	estimatedBitrate atomic.Uint64
+	lastSentBitrate  atomic.Uint64
+	lastSentAt       time.Time
 }
 
-func (t *probeMeasurementTracker) next(stats quic.ConnectionStats, now time.Time) (uint64, bool) {
+func (t *bitrateTracker) monitor(ctx context.Context, interval time.Duration, provider probeStatsProvider, onProbe func(bitrate, rtt uint64)) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			stats := provider.ConnectionStats()
+			bitrate, ok := t.next(stats, now)
+
+			if !ok {
+				continue
+			}
+
+			if onProbe != nil {
+				onProbe(bitrate, uint64(stats.SmoothedRTT.Milliseconds()))
+			}
+		}
+	}
+}
+
+func (t *bitrateTracker) next(stats quic.ConnectionStats, now time.Time) (uint64, bool) {
 	bitrate := t.measureBitrate(stats, now)
 
 	if t.lastSentAt.IsZero() {
@@ -871,8 +908,9 @@ func (t *probeMeasurementTracker) next(stats quic.ConnectionStats, now time.Time
 		return bitrate, true
 	}
 
+	lastSentBitrate := t.lastSentBitrate.Load()
 	if now.Sub(t.lastSentAt) >= t.maxAge ||
-		hasDelta(t.lastBitrate, bitrate, t.maxDelta) {
+		hasDelta(lastSentBitrate, bitrate, t.maxDelta) {
 		t.record(bitrate, now)
 		return bitrate, true
 	}
@@ -880,22 +918,23 @@ func (t *probeMeasurementTracker) next(stats quic.ConnectionStats, now time.Time
 	return bitrate, false
 }
 
-func (t *probeMeasurementTracker) record(bitrate uint64, now time.Time) {
-	t.lastBitrate = bitrate
+func (t *bitrateTracker) record(bitrate uint64, now time.Time) {
+	t.estimatedBitrate.Store(bitrate)
+	t.lastSentBitrate.Store(bitrate)
 	t.lastSentAt = now
 }
 
-func (t *probeMeasurementTracker) measureBitrate(stats quic.ConnectionStats, now time.Time) uint64 {
+func (t *bitrateTracker) measureBitrate(stats quic.ConnectionStats, now time.Time) uint64 {
 	if !t.initialized {
 		t.initialized = true
 		t.bytesSent = stats.BytesSent
 		t.sampleTime = now
-		return 0
+		return t.estimatedBitrate.Load()
 	}
 
 	elapsed := now.Sub(t.sampleTime)
 	if elapsed <= 0 {
-		return t.lastBitrate
+		return t.estimatedBitrate.Load()
 	}
 
 	bytesSent := stats.BytesSent
@@ -906,11 +945,13 @@ func (t *probeMeasurementTracker) measureBitrate(stats quic.ConnectionStats, now
 	t.bytesSent = bytesSent
 	t.sampleTime = now
 
-	if bytesDelta == 0 {
-		return 0
-	}
+	bitrate := uint64(float64(bytesDelta) * 8 / elapsed.Seconds())
+	t.estimatedBitrate.Store(bitrate)
+	return bitrate
+}
 
-	return uint64(float64(bytesDelta) * 8 / elapsed.Seconds())
+func (t *bitrateTracker) getEstimatedBitrate() uint64 {
+	return t.estimatedBitrate.Load()
 }
 
 func hasDelta(oldVal, newVal uint64, maxDelta float64) bool {

--- a/moqt/session.go
+++ b/moqt/session.go
@@ -818,11 +818,12 @@ func (sess *Session) detectBitrateChanges(provider probeStatsProvider) {
 		case now := <-ticker.C:
 			stats := provider.ConnectionStats()
 			bitrate, ok := tracker.next(stats, now)
+
+			sess.estimatedBitrate.Store(bitrate)
+
 			if !ok {
 				continue
 			}
-
-			sess.estimatedBitrate.Store(bitrate)
 
 			sess.incomingProbeMu.Lock()
 			stream := sess.incomingProbeStream
@@ -876,7 +877,7 @@ func (t *probeMeasurementTracker) next(stats quic.ConnectionStats, now time.Time
 		return bitrate, true
 	}
 
-	return 0, false
+	return bitrate, false
 }
 
 func (t *probeMeasurementTracker) record(bitrate uint64, now time.Time) {

--- a/moqt/session.go
+++ b/moqt/session.go
@@ -59,6 +59,10 @@ type Session struct {
 	incomingProbeMu     sync.Mutex
 	incomingProbeStream transport.Stream
 	probeTargetsCh      chan ProbeResult
+
+	// estimatedBitrate is the most recently measured outbound bitrate in bps.
+	// Updated by detectBitrateChanges; zero until the first measurement.
+	estimatedBitrate atomic.Uint64
 }
 
 func newSession(
@@ -155,6 +159,24 @@ func (s *Session) RemoteAddr() net.Addr {
 		return nil
 	}
 	return s.conn.RemoteAddr()
+}
+
+// Stats returns a point-in-time snapshot of the session's operational metrics.
+// It never returns an error; fields that cannot be measured on the current
+// transport (e.g. RTT on a WebTransport/Browser session) are zero.
+func (s *Session) Stats() SessionStats {
+	stats := SessionStats{
+		EstimatedBitrate: s.estimatedBitrate.Load(),
+	}
+
+	if provider, ok := s.conn.(probeStatsProvider); ok {
+		cs := provider.ConnectionStats()
+		stats.RTT = cs.SmoothedRTT
+		stats.BytesSent = cs.BytesSent
+		stats.BytesReceived = cs.BytesReceived
+	}
+
+	return stats
 }
 
 // CloseWithError closes the session with an error code and message.
@@ -418,6 +440,31 @@ func (sess *Session) AcceptAnnounce(prefix string) (*AnnouncementReader, error) 
 	return newAnnouncementReader(stream, prefix, nil), nil
 }
 
+// SessionStats is a point-in-time snapshot of a Session's operational metrics.
+// It is safe to copy by value and never returns an error.
+//
+// The design follows the NATS [nats.Statistics] pattern: a single flat struct
+// containing all observable values, with zero as the canonical "not available"
+// sentinel (e.g. RTT and byte counters are zero on WebTransport/Browser sessions
+// where the underlying transport does not expose them).
+type SessionStats struct {
+	// EstimatedBitrate is the most recently measured outbound bitrate in bits
+	// per second, derived from the Probe mechanism. Zero until the first
+	// measurement is available.
+	EstimatedBitrate uint64
+
+	// RTT is the smoothed round-trip time as reported by the QUIC congestion
+	// controller (RFC 9002 §5.3). Zero when the underlying transport does not
+	// expose RTT (e.g. WebTransport browser sessions).
+	RTT time.Duration
+	// BytesSent is the cumulative number of bytes sent on the underlying
+	// connection, excluding UDP framing. Zero when unavailable.
+	BytesSent uint64
+	// BytesReceived is the cumulative number of bytes received on the
+	// underlying connection, excluding UDP framing. Zero when unavailable.
+	BytesReceived uint64
+}
+
 // ProbeResult holds the result of a Probe request.
 type ProbeResult struct {
 	// Bitrate is the measured bitrate in bits per second. A value of 0 means unknown.
@@ -456,9 +503,29 @@ func (sess *Session) Probe(targetBitrate uint64) (<-chan ProbeResult, error) {
 			return nil, fmt.Errorf("failed to encode stream type message: %w", err)
 		}
 
-		probeStream = stream
+		sess.wg.Go(func() {
+			// Read PROBE responses until the stream is closed or an error occurs.
+			streamCtx := stream.Context()
+			for {
+				var pm message.ProbeMessage
+				if err := pm.Decode(stream); err != nil {
+					if !errors.Is(err, io.EOF) {
+						sess.logError("failed to decode PROBE message", err)
+						cancelStreamWithError(stream, transport.StreamErrorCode(ProbeErrorCodeInternal))
+					}
+					return
+				}
+				select {
+				case sess.probeResponseCh <- ProbeResult{
+					Bitrate: pm.Bitrate,
+				}:
+				case <-streamCtx.Done():
+					return
+				}
+			}
+		})
 
-		sess.wg.Go(func() { sess.readProbeResults(stream) })
+		probeStream = stream
 	}
 
 	// Send PROBE with the new target bitrate. Per draft4 the subscriber MAY send
@@ -480,26 +547,6 @@ func (sess *Session) Probe(targetBitrate uint64) (<-chan ProbeResult, error) {
 	sess.outgoingProbeStream = probeStream
 
 	return sess.probeResponseCh, nil
-}
-
-// readProbeResults reads publisher PROBE messages from stream and forwards them to
-// probeResponseCh. The channel is closed by CloseWithError after all wg goroutines finish.
-func (sess *Session) readProbeResults(stream transport.Stream) {
-	for {
-		var pm message.ProbeMessage
-		if err := pm.Decode(stream); err != nil {
-			if !errors.Is(err, io.EOF) {
-				sess.logError("failed to decode PROBE message", err)
-				cancelStreamWithError(stream, transport.StreamErrorCode(ProbeErrorCodeInternal))
-			}
-			return
-		}
-		select {
-		case sess.probeResponseCh <- ProbeResult{Bitrate: pm.Bitrate}:
-		case <-stream.Context().Done():
-			return
-		}
-	}
 }
 
 // ProbeTargets returns a channel that receives the latest target bitrate (bits
@@ -774,6 +821,8 @@ func (sess *Session) detectBitrateChanges(provider probeStatsProvider) {
 			if !ok {
 				continue
 			}
+
+			sess.estimatedBitrate.Store(bitrate)
 
 			sess.incomingProbeMu.Lock()
 			stream := sess.incomingProbeStream

--- a/moqt/session_test.go
+++ b/moqt/session_test.go
@@ -1641,7 +1641,7 @@ func TestSession_Probe_ChannelClosedOnSessionClose(t *testing.T) {
 	ch, err := session.Probe(1000000)
 	require.NoError(t, err)
 
-	// Close the session: cancels conn.Context() → probeStream.Context() → ReadFunc returns.
+	// Close the session: cancels conn.Context() -> probeStream.Context() -> ReadFunc returns.
 	_ = session.CloseWithError(NoError, "")
 
 	// The channel must be closed (range or two-value receive must see ok=false).
@@ -1919,7 +1919,7 @@ func TestSession_ProbeTargets_InitialMessageDelivered(t *testing.T) {
 
 	session := newTestSession(conn)
 
-	// Subscriber sends exactly ONE ProbeMessage — no further updates.
+	// Subscriber sends exactly ONE ProbeMessage -no further updates.
 	var incoming bytes.Buffer
 	require.NoError(t, message.StreamTypeProbe.Encode(&incoming))
 	require.NoError(t, message.ProbeMessage{Bitrate: 3_000_000}.Encode(&incoming))
@@ -2664,7 +2664,7 @@ func TestSession_Probe_EOFFromPublisher_NoStreamCancel(t *testing.T) {
 	for range ch {
 	}
 
-	// EOF is a normal close — CancelRead/CancelWrite must NOT be called.
+	// EOF is a normal close -CancelRead/CancelWrite must NOT be called.
 	select {
 	case code := <-cancelReadCalled:
 		t.Errorf("CancelRead must not be called on EOF (code %d)", code)
@@ -2780,7 +2780,7 @@ func TestSession_processBiStream_logError(t *testing.T) {
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
 
-	// Create a stream that returns an immediate read error → logError should fire
+	// Create a stream that returns an immediate read error ->logError should fire
 	mockStream := &FakeQUICStream{
 		ReadFunc: func(p []byte) (int, error) {
 			return 0, errors.New("broken stream")
@@ -2821,4 +2821,68 @@ func TestSession_processUniStream_logError(t *testing.T) {
 	assert.Contains(t, output, "broken uni stream")
 
 	_ = session.CloseWithError(NoError, "")
+}
+
+func TestSession_Stats_EstimatedBitrateUpdatedEveryInterval(t *testing.T) {
+	var mu sync.Mutex
+	var bytesSent uint64
+	delta := uint64(100_000)
+
+	conn := &FakeStreamConn{}
+	conn.ConnectionStatsFunc = func() quic.ConnectionStats {
+		mu.Lock()
+		defer mu.Unlock()
+		return quic.ConnectionStats{BytesSent: bytesSent}
+	}
+
+	// Set a very large MaxAge so it doesn't trigger by age.
+	// Set a huge MaxDelta so changes don't trigger a notification.
+	cfg := &Config{
+		ProbeInterval: 10 * time.Millisecond,
+		ProbeMaxAge:   1 * time.Hour,
+		ProbeMaxDelta: 1000.0, // 100000% change needed for notification
+	}
+	sess := newSession(conn, NewTrackMux(0), nil, cfg, nil, nil, nil)
+	t.Cleanup(func() { _ = sess.CloseWithError(NoError, "") })
+
+	// Initial tick to initialize tracker baseline
+	mu.Lock()
+	bytesSent = 100_000
+	mu.Unlock()
+
+	// Ensure bytesSent increases for the measurements
+	// We'll use a slower ticker to reduce jitter impact
+	go func() {
+		ticker := time.NewTicker(2 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				mu.Lock()
+				bytesSent += delta / 5 // Add 1/5 of delta every 2ms -> approx 1 delta every 10ms
+				mu.Unlock()
+			case <-time.After(500 * time.Millisecond):
+				return
+			}
+		}
+	}()
+
+	// Wait for first measurement (should be > 0)
+	assert.Eventually(t, func() bool {
+		return sess.Stats().EstimatedBitrate > 0
+	}, 300*time.Millisecond, 10*time.Millisecond)
+
+	firstBitrate := sess.Stats().EstimatedBitrate
+
+	// Now we want to check if it updates even if the change is small.
+	// We'll change the increment slightly.
+	mu.Lock()
+	delta = delta + 5_000 // 5% change
+	mu.Unlock()
+
+	// Wait for a few ticks
+	time.Sleep(100 * time.Millisecond)
+
+	secondBitrate := sess.Stats().EstimatedBitrate
+	assert.NotEqual(t, firstBitrate, secondBitrate, "EstimatedBitrate should update every interval even if change is small")
 }

--- a/moqt/session_test.go
+++ b/moqt/session_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -867,7 +868,7 @@ func TestSession_Stats_EstimatedBitrateUpdatedByDetectBitrateChanges(t *testing.
 	conn := &FakeStreamConn{}
 	conn.ConnectionStatsFunc = func() quic.ConnectionStats {
 		// Simulate ongoing traffic: each call advances BytesSent by 100 kB
-		// so that probeMeasurementTracker sees a non-zero byte delta.
+		// so that BitrateTracker sees a non-zero byte delta.
 		mu.Lock()
 		bytesSent += 100_000
 		n := bytesSent
@@ -2885,4 +2886,59 @@ func TestSession_Stats_EstimatedBitrateUpdatedEveryInterval(t *testing.T) {
 
 	secondBitrate := sess.Stats().EstimatedBitrate
 	assert.NotEqual(t, firstBitrate, secondBitrate, "EstimatedBitrate should update every interval even if change is small")
+}
+
+func TestSession_Probe_ConcurrentAccess(t *testing.T) {
+	session, _ := newTestSessionWithConn(t)
+	defer session.CloseWithError(NoError, "")
+
+	// Test concurrent access to Probe (receiving peer measurements)
+	results, _ := session.Probe(1000000)
+	results2, _ := session.Probe(2000000)
+
+	var count1, count2 atomic.Int32
+	ctx := t.Context()
+
+	consume := func(ch <-chan ProbeResult, counter *atomic.Int32) {
+		for {
+			select {
+			case <-ch:
+				counter.Add(1)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+
+	go consume(results, &count1)
+	go consume(results2, &count2)
+
+	// Simulate incoming peer measurements
+	for i := range 10 {
+		session.notifyResults(uint64(1000 + i))
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Because it's a channel, the 10 messages are split between the two consumers.
+	// We check that the sum of received messages is correct.
+	assert.Eventually(t, func() bool {
+		return count1.Load()+count2.Load() >= 10
+	}, 200*time.Millisecond, 10*time.Millisecond)
+
+	// Test concurrent access to ProbeTargets (receiving local target hints)
+	targets1 := session.ProbeTargets()
+	targets2 := session.ProbeTargets()
+
+	var tCount1, tCount2 atomic.Int32
+	go consume(targets1, &tCount1)
+	go consume(targets2, &tCount2)
+
+	for i := range 10 {
+		session.notifyTargets(uint64(2000 + i))
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	assert.Eventually(t, func() bool {
+		return tCount1.Load()+tCount2.Load() >= 10
+	}, 200*time.Millisecond, 10*time.Millisecond)
 }

--- a/moqt/session_test.go
+++ b/moqt/session_test.go
@@ -653,14 +653,14 @@ func TestSession_ConcurrentAccess(t *testing.T) {
 
 		go func() {
 			defer wg.Done()
-			for i := 0; i < 5; i++ {
+			for range 5 {
 				session.nextSubscribeID()
 			}
 		}()
 
 		go func() {
 			defer wg.Done()
-			for i := 0; i < 5; i++ {
+			for range 5 {
 				_ = session.Context()
 			}
 		}()
@@ -2889,22 +2889,41 @@ func TestSession_Stats_EstimatedBitrateUpdatedEveryInterval(t *testing.T) {
 }
 
 func TestSession_Probe_ConcurrentAccess(t *testing.T) {
-	session, _ := newTestSessionWithConn(t)
-	defer session.CloseWithError(NoError, "")
+	ctx := t.Context()
+
+	conn := &FakeStreamConn{
+		ParentCtx: ctx,
+	}
+
+	mockStream := &FakeQUICStream{
+		ParentCtx: conn.Context(),
+	}
+	mockStream.WriteFunc = func(p []byte) (int, error) { return len(p), nil }
+	mockStream.ReadFunc = func(p []byte) (int, error) {
+		<-mockStream.Context().Done()
+		return 0, io.EOF
+	}
+
+	conn.OpenStreamFunc = func() (transport.Stream, error) { return mockStream, nil }
+
+	session := newSession(conn, NewTrackMux(0), nil, nil, nil, nil, nil)
 
 	// Test concurrent access to Probe (receiving peer measurements)
 	results, _ := session.Probe(1000000)
 	results2, _ := session.Probe(2000000)
 
 	var count1, count2 atomic.Int32
-	ctx := t.Context()
+	consumeCtx, consumeCancel := context.WithCancel(context.Background())
 
 	consume := func(ch <-chan ProbeResult, counter *atomic.Int32) {
 		for {
 			select {
-			case <-ch:
+			case _, ok := <-ch:
+				if !ok {
+					return
+				}
 				counter.Add(1)
-			case <-ctx.Done():
+			case <-consumeCtx.Done():
 				return
 			}
 		}
@@ -2916,14 +2935,13 @@ func TestSession_Probe_ConcurrentAccess(t *testing.T) {
 	// Simulate incoming peer measurements
 	for i := range 10 {
 		session.notifyResults(uint64(1000 + i))
-		time.Sleep(5 * time.Millisecond)
+		time.Sleep(2 * time.Millisecond)
 	}
 
 	// Because it's a channel, the 10 messages are split between the two consumers.
-	// We check that the sum of received messages is correct.
 	assert.Eventually(t, func() bool {
 		return count1.Load()+count2.Load() >= 10
-	}, 200*time.Millisecond, 10*time.Millisecond)
+	}, 500*time.Millisecond, 10*time.Millisecond)
 
 	// Test concurrent access to ProbeTargets (receiving local target hints)
 	targets1 := session.ProbeTargets()
@@ -2935,10 +2953,14 @@ func TestSession_Probe_ConcurrentAccess(t *testing.T) {
 
 	for i := range 10 {
 		session.notifyTargets(uint64(2000 + i))
-		time.Sleep(5 * time.Millisecond)
+		time.Sleep(2 * time.Millisecond)
 	}
 
 	assert.Eventually(t, func() bool {
 		return tCount1.Load()+tCount2.Load() >= 10
-	}, 200*time.Millisecond, 10*time.Millisecond)
+	}, 500*time.Millisecond, 10*time.Millisecond)
+
+	// Clean shutdown: cancel consumers first, then close session
+	consumeCancel()
+	_ = session.CloseWithError(NoError, "")
 }

--- a/moqt/session_test.go
+++ b/moqt/session_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	quic "github.com/quic-go/quic-go"
@@ -65,7 +66,6 @@ func TestNewSession(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			conn := &FakeStreamConn{}
 			conn.TLSFunc = func() *tls.ConnectionState { return &tls.ConnectionState{NegotiatedProtocol: NextProtoMOQ} }
-			conn.OpenStreamFunc = func() (transport.Stream, error) { return nil, io.EOF }
 			conn.OpenStreamFunc = func() (transport.Stream, error) { return nil, io.EOF }
 
 			session := newSession(conn, tt.mux, nil, nil, nil, nil, nil)
@@ -605,17 +605,31 @@ func TestSession_HandleBiStreams_AcceptError(t *testing.T) {
 
 func TestSession_HandleUniStreamsAcceptError(t *testing.T) {
 	conn := &FakeStreamConn{}
-	conn.AcceptStreamFunc = func(context.Context) (transport.Stream, error) { return nil, errors.New("accept uni stream failed") }
+	acceptStreamCh := make(chan struct{}, 1)
+	conn.AcceptStreamFunc = func(context.Context) (transport.Stream, error) {
+		select {
+		case acceptStreamCh <- struct{}{}:
+		default:
+		}
+		return nil, errors.New("accept uni stream failed")
+	}
 	conn.AcceptUniStreamFunc = func(context.Context) (transport.ReceiveStream, error) {
+		select {
+		case acceptStreamCh <- struct{}{}:
+		default:
+		}
 		return nil, errors.New("accept uni stream failed")
 	}
 
 	session := newTestSession(conn)
 
-	// Wait a bit for the background goroutine to try accepting
-	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-acceptStreamCh:
+		// ok
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("AcceptStream/AcceptUniStream not called by background goroutine")
+	}
 
-	// The session should handle the error gracefully
 	assert.NotNil(t, session)
 
 	// Cleanup
@@ -623,49 +637,35 @@ func TestSession_HandleUniStreamsAcceptError(t *testing.T) {
 }
 
 func TestSession_ConcurrentAccess(t *testing.T) {
-	mockStream := &FakeQUICStream{}
-	mockStream.WriteFunc = func(p []byte) (int, error) { return 0, nil }
-	conn := &FakeStreamConn{}
-	conn.OpenStreamFunc = func() (transport.Stream, error) { return mockStream, nil }
-	conn.OpenUniStreamFunc = func() (transport.SendStream, error) { return &FakeQUICSendStream{}, nil }
+	synctest.Test(t, func(t *testing.T) {
+		mockStream := &FakeQUICStream{}
+		mockStream.WriteFunc = func(p []byte) (int, error) { return 0, nil }
+		conn := &FakeStreamConn{}
+		conn.OpenStreamFunc = func() (transport.Stream, error) { return mockStream, nil }
+		conn.OpenUniStreamFunc = func() (transport.SendStream, error) { return &FakeQUICSendStream{}, nil }
 
-	session := newTestSession(conn)
+		session := newTestSession(conn)
+		defer func() { _ = session.CloseWithError(NoError, "") }()
 
-	// Test concurrent access
-	done := make(chan struct{})
-	var operations int
+		var wg sync.WaitGroup
+		wg.Add(2)
 
-	// Concurrent nextSubscribeID calls
-	go func() {
-		for range 5 {
-			session.nextSubscribeID()
-		}
-		operations++
-		if operations == 2 {
-			close(done)
-		}
-	}()
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 5; i++ {
+				session.nextSubscribeID()
+			}
+		}()
 
-	// Concurrent Context calls
-	go func() {
-		for range 5 {
-			session.Context()
-		}
-		operations++
-		if operations == 2 {
-			close(done)
-		}
-	}()
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 5; i++ {
+				_ = session.Context()
+			}
+		}()
 
-	select {
-	case <-done:
-		// Success
-	case <-time.After(time.Second):
-		t.Error("Concurrent operations timed out")
-	}
-
-	// Cleanup
-	_ = session.CloseWithError(NoError, "")
+		wg.Wait()
+	})
 }
 
 func TestSession_ContextCancellation(t *testing.T) {
@@ -820,6 +820,83 @@ func TestCancelStreamWithError(t *testing.T) {
 	var cancelReadErr *transport.StreamError
 	require.ErrorAs(t, readErr, &cancelReadErr)
 	assert.Equal(t, transport.StreamErrorCode(1), cancelReadErr.ErrorCode)
+}
+
+func TestSession_Stats_NoTransport(t *testing.T) {
+	// noStatsConn does not implement probeStatsProvider.
+	// Transport-derived fields must be zero values.
+	conn := noStatsConn{}
+	sess := newSession(conn, NewTrackMux(0), nil, nil, nil, nil, nil)
+	t.Cleanup(func() { _ = sess.CloseWithError(NoError, "") })
+
+	stats := sess.Stats()
+
+	assert.Equal(t, time.Duration(0), stats.RTT)
+	assert.Equal(t, uint64(0), stats.BytesSent)
+	assert.Equal(t, uint64(0), stats.BytesReceived)
+}
+
+func TestSession_Stats_WithTransport(t *testing.T) {
+	sess, _ := newTestSessionWithConn(t, func(c *FakeStreamConn) {
+		c.ConnectionStatsFunc = func() quic.ConnectionStats {
+			return quic.ConnectionStats{
+				SmoothedRTT:   50 * time.Millisecond,
+				BytesSent:     1_000,
+				BytesReceived: 2_000,
+			}
+		}
+	})
+
+	stats := sess.Stats()
+
+	assert.Equal(t, 50*time.Millisecond, stats.RTT)
+	assert.Equal(t, uint64(1_000), stats.BytesSent)
+	assert.Equal(t, uint64(2_000), stats.BytesReceived)
+}
+
+func TestSession_Stats_EstimatedBitrateZeroBeforeProbe(t *testing.T) {
+	sess, _ := newTestSessionWithConn(t)
+
+	stats := sess.Stats()
+	assert.Equal(t, uint64(0), stats.EstimatedBitrate)
+}
+
+func TestSession_Stats_EstimatedBitrateUpdatedByDetectBitrateChanges(t *testing.T) {
+	var mu sync.Mutex
+	var bytesSent uint64
+	conn := &FakeStreamConn{}
+	conn.ConnectionStatsFunc = func() quic.ConnectionStats {
+		// Simulate ongoing traffic: each call advances BytesSent by 100 kB
+		// so that probeMeasurementTracker sees a non-zero byte delta.
+		mu.Lock()
+		bytesSent += 100_000
+		n := bytesSent
+		mu.Unlock()
+		return quic.ConnectionStats{BytesSent: n}
+	}
+	// Pass config at creation time so the Ticker in detectBitrateChanges
+	// picks up the short interval (it is captured at goroutine start).
+	cfg := &Config{ProbeInterval: 5 * time.Millisecond, ProbeMaxAge: 10 * time.Millisecond}
+	sess := newSession(conn, NewTrackMux(0), nil, cfg, nil, nil, nil)
+	t.Cleanup(func() { _ = sess.CloseWithError(NoError, "") })
+
+	// Allow detectBitrateChanges at least two ticks: first initializes, second measures.
+	assert.Eventually(t, func() bool {
+		return sess.Stats().EstimatedBitrate > 0
+	}, 200*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestSession_Stats_ReflectsRemovals(t *testing.T) {
+	sess, _ := newTestSessionWithConn(t)
+
+	sess.addTrackReader(SubscribeID(1), &TrackReader{})
+	sess.addTrackReader(SubscribeID(2), &TrackReader{})
+	sess.removeTrackReader(SubscribeID(1))
+
+	stats := sess.Stats()
+	assert.Equal(t, time.Duration(0), stats.RTT)
+	assert.Equal(t, uint64(0), stats.BytesSent)
+	assert.Equal(t, uint64(0), stats.BytesReceived)
 }
 
 func TestSession_AddTrackReader(t *testing.T) {


### PR DESCRIPTION
## Description

Introduce a new `Session.Stats()` method to provide session statistics, including estimated bitrate, round-trip time (RTT), bytes sent, and bytes received. Update documentation to reflect these changes.

## Related Issue

Closes #

## Changes

- Added `Session.Stats()` method for retrieving session statistics.
- Enhanced documentation to include details about the new statistics.
- Improved tests for session statistics, focusing on estimated bitrate and transport metrics.

## Testing

Tested by adding new unit tests to validate the functionality of `Session.Stats()` and its integration with transport statistics.

## Checklist

- [ ] Comments added for complex logic
- [ ] Documentation updated if needed
- [ ] Tests added/updated

