### PR TITLE
🔒 Security Fix: Replace panic with error in message reader functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **moqt:** Fixed panic vulnerabilities in `moqt/internal/message/message_reader.go` caused by excessively large varints in byte slices and string array parsing, replacing panics with proper errors to mitigate DoS threats.
+
 ## [v0.15.0] - 2026-04-26
 
 ### Added

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"errors"
 	"io"
 	"math"
 )
@@ -66,7 +67,7 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 	}
 	b = b[n:]
 	if num > math.MaxInt {
-		panic("byte slice too large")
+		return nil, 0, errors.New("byte slice too large")
 	}
 
 	if uint64(len(b)) < num {
@@ -91,10 +92,14 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 	}
 
 	if count > math.MaxInt {
-		panic("string array too large")
+		return nil, 0, errors.New("string array too large")
 	}
 
 	b = b[total:]
+
+	if count > uint64(len(b)) {
+		return nil, 0, io.EOF
+	}
 
 	arr := make([]string, 0, count)
 	for range count {

--- a/moqt/internal/message/message_reader_test.go
+++ b/moqt/internal/message/message_reader_test.go
@@ -184,6 +184,10 @@ func TestReadBytes(t *testing.T) {
 			input:   []byte{},
 			wantErr: true,
 		},
+		"too large varint": {
+			input:   []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, // 8-byte max value, exceeds math.MaxInt
+			wantErr: true,
+		},
 	}
 
 	for name, tt := range tests {
@@ -270,6 +274,10 @@ func TestReadStringArray(t *testing.T) {
 		},
 		"invalid count": {
 			input:   []byte{},
+			wantErr: true,
+		},
+		"too large varint": {
+			input:   []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, // 8-byte max value, exceeds math.MaxInt
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Denial of Service (DoS) due to unhandled panics when processing exceptionally large string array sizes and byte slice sizes in QUIC varint decoders (`ReadStringArray` and `ReadBytes`). 

⚠️ **Risk:** The potential impact if left unfixed
A maliciously crafted message containing an unusually large varint size could intentionally trigger a `panic`, causing the application process to crash and producing a Denial of Service. Another similar vulnerability is a large slice size allocation resulting in Out-Of-Memory crashes, or slice max range panics. 

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced `panic("string array too large")` and `panic("byte slice too large")` with proper Go errors (`errors.New`). Further, in `ReadStringArray`, checking the capacity against the available length of the payload using `if count > uint64(len(b)) { return nil, 0, io.EOF }` effectively mitigates OOM vulnerabilities by preventing arbitrarily large allocations on `make([]string, 0, count)`. These safety bounds successfully neutralize the DoS threat while preserving the existing message-parsing logic.

---
*PR created automatically by Jules for task [811143850732563106](https://jules.google.com/task/811143850732563106) started by @okdaichi*