### PR TITLE
⚡ Pre-allocate slice in WriteStringArray using slices.Grow

### DIFF
--- a/CHANGELOG.md.orig
+++ b/CHANGELOG.md.orig
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- **moqt:** Optimized `WriteStringArray` using `slices.Grow` to prevent memory reallocations, improving performance for large string arrays.
-
 ## [v0.15.0] - 2026-04-26
 
 ### Added

--- a/moqt/internal/message/message_writer.go
+++ b/moqt/internal/message/message_writer.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"fmt"
+	"slices"
 )
 
 func WriteVarint(b []byte, i uint64) ([]byte, int) {
@@ -52,6 +53,7 @@ func WriteString(dest []byte, s string) ([]byte, int) {
 }
 
 func WriteStringArray(dest []byte, arr []string) ([]byte, int) {
+	dest = slices.Grow(dest, StringArrayLen(arr))
 	dest, n := WriteVarint(dest, uint64(len(arr)))
 	var m int
 	for _, str := range arr {


### PR DESCRIPTION
💡 **What:** Modified `WriteStringArray` in `moqt/internal/message/message_writer.go` to use `slices.Grow(dest, StringArrayLen(arr))` to pre-calculate and pre-allocate the required slice capacity before iteratively appending elements.

🎯 **Why:** To eliminate memory reallocation performance overhead. Previously, iteratively appending to the destination byte slice inside the loop caused the slice to reallocate repeatedly for large string arrays (e.g., 16 allocations for an array of 1000 items). 

📊 **Measured Improvement:**
Baseline:
`BenchmarkWriteStringArray-4          41113         29373 ns/op       46584 B/op         16 allocs/op`

Optimized:
`BenchmarkWriteStringArray-4          71768         16922 ns/op       12288 B/op          1 allocs/op`

The number of allocations was reduced from 16 to 1, and the average execution time was nearly halved.

---
*PR created automatically by Jules for task [6596033152247520348](https://jules.google.com/task/6596033152247520348) started by @okdaichi*