### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability in message parser

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - [DoS via Untrusted Payload Length Limits]
+**Vulnerability:** Found `panic("byte slice too large")` and `panic("string array too large")` being thrown when processing potentially untrusted incoming data.
+**Learning:** Returning a `panic` acts as a fast path for Denial of Service if the application doesn't catch it properly at the transport boundary. Also found potential for memory exhaustion attacks where `make([]string, 0, count)` blindly allocated capacity based on parsed user data before checking if `b` has enough elements.
+**Prevention:** Handlers for untrusted input should return `error` types rather than panicking. Always validate requested array counts/sizes against buffer sizes (`len(b) < count`) prior to array allocations.

--- a/CHANGELOG.md.orig
+++ b/CHANGELOG.md.orig
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **moqt:** 🛡️ Sentinel: [HIGH] Fixed DoS and memory exhaustion vulnerabilities in `moqt/internal/message` parsers by removing `panic()` calls on untrusted byte payloads and validating array counts before allocating them.
-
 ## [v0.15.0] - 2026-04-26
 
 ### Added

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"errors"
 	"io"
 	"math"
 )
@@ -66,7 +67,7 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 	}
 	b = b[n:]
 	if num > math.MaxInt {
-		panic("byte slice too large")
+		return nil, 0, errors.New("byte slice too large")
 	}
 
 	if uint64(len(b)) < num {
@@ -91,10 +92,14 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 	}
 
 	if count > math.MaxInt {
-		panic("string array too large")
+		return nil, 0, errors.New("string array too large")
 	}
 
 	b = b[total:]
+
+	if uint64(len(b)) < count {
+		return nil, 0, io.EOF
+	}
 
 	arr := make([]string, 0, count)
 	for range count {

--- a/patch_changelog.diff
+++ b/patch_changelog.diff
@@ -1,0 +1,13 @@
+--- CHANGELOG.md
++++ CHANGELOG.md
+@@ -6,6 +6,10 @@
+
+ ## [Unreleased]
+
++### Fixed
++
++- **moqt:** 🛡️ Sentinel: [HIGH] Fixed DoS and memory exhaustion vulnerabilities in `moqt/internal/message` parsers by removing `panic()` calls on untrusted byte payloads and validating array counts before allocating them.
++
+ ## [v0.15.0] - 2026-04-26
+
+ ### Added


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix DoS vulnerability in message parser

Severity: HIGH
Vulnerability: `panic()` was called directly on untrusted incoming byte payloads in `moqt/internal/message/message_reader.go` leading to straightforward DoS. Also, slice allocations occurred before bound checking the parsed count size leading to memory exhaustion vulnerability.
Impact: Attackers can crash the server and consume an unbounded amount of memory with specially crafted payloads.
Fix: Converted panic calls to standard `errors.New` returns. Implemented a bounds check prior to `make([]string, 0, count)` to prevent Out-Of-Memory (OOM) crashing.
Verification: Ran `go test ./...` and `go vet ./...` to verify fix does not break functionality.

---
*PR created automatically by Jules for task [7865500920401748134](https://jules.google.com/task/7865500920401748134) started by @okdaichi*