### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix DoS via panic on large payloads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Replacing panics with errors on malicious size limits
+**Vulnerability:** Use of `panic` to handle unexpectedly large length fields (such as varints exceeding max integer values or string bounds checks) when parsing user input.
+**Learning:** `panic` crashes the program entirely. An attacker who sends a deliberately malformed payload with an enormous length prefix can easily trigger this panic and crash the service, leading to a Denial of Service (DoS).
+**Prevention:** Never use `panic` on bounds/size checks when parsing unvalidated input. Always return standard `errors.New(...)` so the error propagates and the malicious connection/stream can be closed gracefully without affecting the whole server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,3 +356,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core `moqt` package with session, track, group, and frame handling.
 - Basic examples: broadcast, echo, relay.
 - Mage build system integration.
+
+## [Unreleased]
+
+### Fixed
+- **moqt:** Replaced panics with errors in `message_reader.go` when parsing maliciously large varint lengths for byte slices and string arrays, mitigating a potential DoS vulnerability.

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -3,6 +3,7 @@ package message
 import (
 	"io"
 	"math"
+	"errors"
 )
 
 func ReadVarint(b []byte) (uint64, int, error) {
@@ -66,7 +67,7 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 	}
 	b = b[n:]
 	if num > math.MaxInt {
-		panic("byte slice too large")
+		return nil, 0, errors.New("byte slice too large")
 	}
 
 	if uint64(len(b)) < num {
@@ -91,7 +92,7 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 	}
 
 	if count > math.MaxInt {
-		panic("string array too large")
+		return nil, 0, errors.New("string array too large")
 	}
 
 	b = b[total:]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `ReadBytes` and `ReadStringArray` functions in `moqt/internal/message/message_reader.go` use `panic()` when decoding varints that exceed maximum limits (`math.MaxInt`).
🎯 Impact: An attacker can send deliberately malformed payloads with excessively large length fields. When parsed, this will crash the program (Denial of Service - DoS) instead of safely returning an error for the connection stream.
🔧 Fix: Replaced `panic("byte slice too large")` and `panic("string array too large")` with standard `return nil, 0, errors.New(...)` values, enabling caller code to handle the error properly and shut down the invalid connection.
✅ Verification: `go test ./...` has successfully executed to verify that standard message processing logic hasn't fundamentally changed, and tests pass with the new error returns.

---
*PR created automatically by Jules for task [10018362772661899802](https://jules.google.com/task/10018362772661899802) started by @okdaichi*