### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerability via panic and slice allocation OOM in message reader

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-25 - [Panic on Malformed Message Size]
+**Vulnerability:** Denial of Service (DoS) vulnerability via runtime panic (`panic("byte slice too large")` and `panic("string array too large")`) in `moqt/internal/message/message_reader.go` and slice allocation exhaustion vulnerabilities.
+**Learning:** Go applications should not `panic()` when encountering malformed data from untrusted network connections. The message reader was not checking lengths appropriately against `math.MaxInt` or checking slice allocations against the total available buffer length.
+**Prevention:** Always return standard errors (e.g. `errors.New`, `io.EOF`) to safely handle failure states from untrusted data. Validate slice allocations size fields (`count`) against the available remaining length of the payload (`len(b)`) before allocating slices (`make()`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **moqt:** Replaced panics in `message_reader` with error returns and added slice allocation bounds checking to prevent Denial of Service (DoS) and Out-Of-Memory (OOM) vulnerabilities on malformed data.
+
 ## [v0.15.0] - 2026-04-26
 
 ### Added

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"errors"
 	"io"
 	"math"
 )
@@ -66,7 +67,7 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 	}
 	b = b[n:]
 	if num > math.MaxInt {
-		panic("byte slice too large")
+		return nil, 0, errors.New("byte slice too large")
 	}
 
 	if uint64(len(b)) < num {
@@ -91,7 +92,10 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 	}
 
 	if count > math.MaxInt {
-		panic("string array too large")
+		return nil, 0, errors.New("string array too large")
+	}
+	if count > uint64(len(b)) {
+		return nil, 0, io.EOF
 	}
 
 	b = b[total:]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Denial of Service (DoS) vulnerability via runtime panic (`panic("byte slice too large")` and `panic("string array too large")`) in `moqt/internal/message/message_reader.go` and slice allocation OOM vulnerabilities.
🎯 Impact: An attacker could crash the server (or client) by sending a malformed message containing an enormous varint value that triggers a panic, or causes the server to go OOM allocating a giant slice.
🔧 Fix: Replaced `panic()` with returning an `error`, specifically `errors.New("byte slice too large")` and `errors.New("string array too large")`. Added length checking bounds (`count > uint64(len(b))`) before allocating string slices to avoid OOM.
✅ Verification: Ran `go test ./...` and `go vet` and no regressions were detected. Verified that errors are returned natively instead of panicking.

---
*PR created automatically by Jules for task [16951476192565408389](https://jules.google.com/task/16951476192565408389) started by @okdaichi*