### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerability in message parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Fix DoS Panics in Message Length Parsing
+**Vulnerability:** A denial-of-service vulnerability where maliciously crafted messages containing excessively large varint lengths (e.g. for `ReadBytes` and `ReadStringArray`) trigger a runtime `panic` during processing, crashing the host program. Preallocation based solely on untrusted lengths can also lead to out-of-memory errors ("cap out of range").
+**Learning:** `panic` should never be used as a general control flow mechanism when reading untrusted input payloads, as malformed lengths bypass typical safety checks. `count` parsed from unverified varint must be strictly bounded against the remaining buffer length.
+**Prevention:** Always return standard Go errors (`errors.New`, `io.EOF`, etc.) instead of panicking on invalid lengths, and ensure slice capacities are bound-checked against payload sizes before allocation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,3 +356,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core `moqt` package with session, track, group, and frame handling.
 - Basic examples: broadcast, echo, relay.
 - Mage build system integration.
+
+## [Unreleased]
+### Security
+- **moqt:** Fixed Denial of Service (DoS) vulnerability in message reading triggered by large untrusted lengths or allocation counts exceeding buffer limits.

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"errors"
 	"io"
 	"math"
 )
@@ -66,7 +67,7 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 	}
 	b = b[n:]
 	if num > math.MaxInt {
-		panic("byte slice too large")
+		return nil, 0, errors.New("byte slice too large")
 	}
 
 	if uint64(len(b)) < num {
@@ -91,10 +92,14 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 	}
 
 	if count > math.MaxInt {
-		panic("string array too large")
+		return nil, 0, errors.New("string array too large")
 	}
 
 	b = b[total:]
+
+	if count > uint64(len(b)) {
+		return nil, 0, io.ErrUnexpectedEOF
+	}
 
 	arr := make([]string, 0, count)
 	for range count {


### PR DESCRIPTION
## Severity
CRITICAL

## Vulnerability
The payload decoding functions `ReadBytes` and `ReadStringArray` relied on `panic` for bounds violations when parsing large variable integers (varints) from unauthenticated messages. Additionally, `ReadStringArray` pre-allocated array capacities using unvalidated untrusted sizes.

## Impact
A malicious actor could send a payload with an intentionally massive payload length varint. This would trigger the `panic("byte slice too large")` logic and immediately crash the service, enabling a trivial Denial-of-Service (DoS) attack. Additionally, an untrusted `count` variable bypassed validation before a `make` allocation, meaning a malicious small payload could allocate huge capacities, triggering out-of-memory "cap out of range" panics.

## Fix
- Replaced the panics with standard error propagation `errors.New("byte slice too large")` and `errors.New("string array too large")`.
- Added bounds verification limiting array allocation to the remaining payload length: `if count > uint64(len(b)) { return nil, 0, io.ErrUnexpectedEOF }`.
- Created a Sentinel journal entry documenting this DoS vector.

## Verification
- Wrote and passed localized Go unit tests simulating the large payloads and confirming they return errors and not panics.
- Ran the full `go test ./...` test suite which confirms correct execution.

---
*PR created automatically by Jules for task [14848687079942912918](https://jules.google.com/task/14848687079942912918) started by @okdaichi*