### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix OOM DoS via Untrusted Slice Allocation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-06-01 - [CRITICAL] Untrusted Input OOM DoS via Slice Pre-allocation
+**Vulnerability:** In `moqt/internal/message/message_reader.go`, `ReadStringArray` allocated a string slice using an untrusted input `count` without verifying if enough bytes remained in the buffer (`arr := make([]string, 0, count)`). This allows an attacker to send a malicious `count` causing an Out-Of-Memory (OOM) panic, resulting in a Denial of Service.
+**Learning:** Network protocols that decode arrays or strings from untrusted input must not blindly trust the provided length prefixes for memory allocation.
+**Prevention:** Always validate size/count prefixes against the remaining buffer length (`uint64(len(b))`) or a strict maximum limit *before* making any allocations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,3 +356,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core `moqt` package with session, track, group, and frame handling.
 - Basic examples: broadcast, echo, relay.
 - Mage build system integration.
+
+## [Unreleased]
+### Security
+- **moqt:** Fixed an out-of-memory denial of service vulnerability in `message_reader` caused by unchecked string array lengths.

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -2,7 +2,6 @@ package message
 
 import (
 	"io"
-	"math"
 )
 
 func ReadVarint(b []byte) (uint64, int, error) {
@@ -65,9 +64,6 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 		return nil, 0, err
 	}
 	b = b[n:]
-	if num > math.MaxInt {
-		panic("byte slice too large")
-	}
 
 	if uint64(len(b)) < num {
 		return b, n + len(b), io.EOF
@@ -90,11 +86,11 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 		return nil, 0, err
 	}
 
-	if count > math.MaxInt {
-		panic("string array too large")
-	}
-
 	b = b[total:]
+
+	if count > uint64(len(b)) {
+		return nil, total, io.EOF
+	}
 
 	arr := make([]string, 0, count)
 	for range count {

--- a/moqt/internal/message/message_reader_test.go
+++ b/moqt/internal/message/message_reader_test.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"bytes"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -284,6 +285,28 @@ func TestReadStringArray(t *testing.T) {
 				assert.Equal(t, tt.expected, result)
 				assert.Equal(t, tt.n, n)
 			}
+		})
+	}
+}
+
+func TestReadStringArray_OutOfBounds(t *testing.T) {
+	tests := map[string]struct {
+		input    []byte
+		expected []string
+		n        int
+		wantErr  bool
+	}{
+		"too large count": {
+			// This represents a count of 5 strings (0x05 varint), but only 2 bytes follow, not enough to even cover 5 varint string lengths
+			input:   []byte{0x05, 0x01, 0x02},
+			wantErr: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := ReadStringArray(tt.input)
+			assert.Error(t, err)
+			assert.Equal(t, io.EOF, err)
 		})
 	}
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** When decoding string arrays from network input, `ReadStringArray` allocated a slice `make([]string, 0, count)` using the untrusted `count` from the payload without verifying that the network payload even contained enough data for that many items. Additionally, `ReadBytes` and `ReadStringArray` used `panic` on large lengths instead of returning an error, causing intentional server crashes upon parsing invalid/malicious input.
🎯 **Impact:** Denial of Service (DoS) - A remote attacker could send a tiny payload with a massive `count` variable, forcing the server to crash by causing an Out-Of-Memory (OOM) panic via a massive slice allocation or by triggering explicit `panic` paths.
🔧 **Fix:** 
1. Replaced the `panic` calls with boundary checks that natively handle bounds via `io.EOF`.
2. Added `if count > uint64(len(b)) { return nil, total, io.EOF }` to `ReadStringArray` prior to allocation. This bounds-check is mathematically sound since each string in the array uses at minimum a 1-byte varint length prefix, meaning the buffer *must* have at least `count` bytes remaining.
✅ **Verification:** Verified fixes pass all decoding parsing tests correctly and run codecov metrics locally.

---
*PR created automatically by Jules for task [18107795378781147417](https://jules.google.com/task/18107795378781147417) started by @okdaichi*