### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service via panic in varint parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2025-05-24 - DoS Vulnerability via panic on Untrusted Sizes
+
+**Vulnerability:** A Denial of Service (DoS) vulnerability was present in the network protocol reader `moqt/internal/message/message_reader.go`. It used `panic` to reject payloads or array counts encoded with varints that exceed `math.MaxInt`.
+**Learning:** `panic` is fundamentally unsafe for validation of externally untrusted network inputs in Go, especially when the input dictates size allocation bounds. A malicious actor could construct a packet with arbitrary 8-byte varints to force a hard crash. Even if bounded by `math.MaxInt`, memory limits should be enforced relative to available bytes.
+**Prevention:** Never use `panic` to enforce length constraints on untrusted network packets. Always compare the requested lengths against the `len()` of remaining buffered bytes. If the request size exceeds available bytes, securely return a standard Go error like `io.EOF` so the session terminates or re-buffers appropriately.

--- a/CHANGELOG.md.orig
+++ b/CHANGELOG.md.orig
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **moqt:** Fixed Denial of Service (DoS) vulnerability caused by `panic` when parsing untrusted large array counts or byte lengths in the message reader. Replaced `panic` with length validation and `io.EOF` errors.
-
 ## [v0.15.0] - 2026-04-26
 
 ### Added

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -2,7 +2,6 @@ package message
 
 import (
 	"io"
-	"math"
 )
 
 func ReadVarint(b []byte) (uint64, int, error) {
@@ -65,9 +64,6 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 		return nil, 0, err
 	}
 	b = b[n:]
-	if num > math.MaxInt {
-		panic("byte slice too large")
-	}
 
 	if uint64(len(b)) < num {
 		return b, n + len(b), io.EOF
@@ -90,8 +86,11 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 		return nil, 0, err
 	}
 
-	if count > math.MaxInt {
-		panic("string array too large")
+	// Prevent DoS: count cannot exceed the number of remaining bytes
+	// since each string requires at least 1 byte (varint length).
+	remaining := len(b) - total
+	if remaining < 0 || count > uint64(remaining) {
+		return nil, 0, io.EOF
 	}
 
 	b = b[total:]

--- a/moqt/internal/message/message_reader_test.go
+++ b/moqt/internal/message/message_reader_test.go
@@ -272,6 +272,10 @@ func TestReadStringArray(t *testing.T) {
 			input:   []byte{},
 			wantErr: true,
 		},
+		"dos test: max int array size": {
+			input:   []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00},
+			wantErr: true,
+		},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION
**Severity:** CRITICAL
**Vulnerability:** Denial of Service (DoS) vulnerability in the network protocol reader `moqt/internal/message/message_reader.go` where parsing untrusted length prefixes or array counts could trigger a `panic` if they exceed `math.MaxInt`.
**Impact:** A malicious actor could construct a packet with arbitrary 8-byte varints to force a hard crash in the server, making it unavailable.
**Fix:** Removed the unsafe `panic` calls. Instead, bounds checking against the actual length of the incoming byte slice (`len(b)`) is performed. The application now fails securely by returning standard Go errors (`io.EOF`).
**Verification:**
1. Ran all tests `go test ./...` which pass.
2. Included a specific test case `dos test: max int array size` in `moqt/internal/message/message_reader_test.go` to ensure `ReadStringArray` correctly returns an error and does not panic when provided an extremely large array count.

---
*PR created automatically by Jules for task [11127555846356855435](https://jules.google.com/task/11127555846356855435) started by @okdaichi*