### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service (DoS) vulnerability via untrusted payload panic

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-18 - Denial of Service (DoS) Risk via Untrusted Payload Parsing
+**Vulnerability:** The application used `panic()` when parsing message types containing variable-length array payloads or byte arrays if the lengths provided in the network message were suspiciously large (e.g., greater than `math.MaxInt`).
+**Learning:** `panic()` terminates the application loop, turning a malformed network packet directly into an exploitable DoS vulnerability. Moreover, the bounds-checking logic using `math.MaxInt` becomes a problem because the expected types don't inherently constrain data safely on their own when used directly in panic. By explicitly allocating huge buffers using network-provided strings sizes, it could out-of-memory.
+**Prevention:** Always validate size values explicitly against the available capacity/remaining length of the buffer. Never use `panic()` to handle invalid data parsing lengths or boundaries constraints on untrusted network packets. Instead, return appropriate errors (such as `io.EOF`) to safely abort request parsing and properly support incomplete bounds/streams.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **moqt:** Removed `panic()` calls when parsing untrusted payload sizes in `ReadBytes` and `ReadStringArray` to prevent Denial of Service (DoS) and excessive memory allocation vulnerabilities.
+
 ## [v0.15.0] - 2026-04-26
 
 ### Added

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -2,7 +2,6 @@ package message
 
 import (
 	"io"
-	"math"
 )
 
 func ReadVarint(b []byte) (uint64, int, error) {
@@ -65,9 +64,6 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 		return nil, 0, err
 	}
 	b = b[n:]
-	if num > math.MaxInt {
-		panic("byte slice too large")
-	}
 
 	if uint64(len(b)) < num {
 		return b, n + len(b), io.EOF
@@ -90,11 +86,11 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 		return nil, 0, err
 	}
 
-	if count > math.MaxInt {
-		panic("string array too large")
-	}
-
 	b = b[total:]
+
+	if count > uint64(len(b)) {
+		return nil, 0, io.EOF
+	}
 
 	arr := make([]string, 0, count)
 	for range count {

--- a/moqt/internal/message/message_reader_test.go
+++ b/moqt/internal/message/message_reader_test.go
@@ -184,6 +184,10 @@ func TestReadBytes(t *testing.T) {
 			input:   []byte{},
 			wantErr: true,
 		},
+		"size exceeds buffer": {
+			input:   []byte{0x40, 0x80, 0x01, 0x02}, // size 128, only 2 bytes data
+			wantErr: true,
+		},
 	}
 
 	for name, tt := range tests {
@@ -270,6 +274,10 @@ func TestReadStringArray(t *testing.T) {
 		},
 		"invalid count": {
 			input:   []byte{},
+			wantErr: true,
+		},
+		"count exceeds remaining buffer length": {
+			input:   []byte{0x40, 0x05, 0x05, 0x68}, // count 5, buffer remaining len 2
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application used `panic()` when parsing message types containing variable-length array payloads or byte arrays if the lengths provided in the network message were suspiciously large (e.g., greater than `math.MaxInt`). This could be triggered by any unauthenticated payload.
🎯 Impact: An attacker could crash the server (Denial of Service) or cause Out-of-Memory (OOM) errors by sending a maliciously crafted payload with an artificially large variable-length integer.
🔧 Fix: Removed `panic()` calls in `ReadBytes` and `ReadStringArray`. Added explicit size validation against the actual available length of the remaining buffer, returning `io.EOF` if the size exceeds the buffer length. Also cleaned up the now-unused `math` import.
✅ Verification: Ran `go test ./moqt/internal/message/...` and `go test -coverprofile=coverage.out ./...` to verify functionality is preserved and no regressions were introduced. Coverage is robust.
📖 Journal: Added an entry to `.jules/sentinel.md` documenting this pattern.

---
*PR created automatically by Jules for task [8788188834895205508](https://jules.google.com/task/8788188834895205508) started by @okdaichi*