### PR TITLE
⚡ Bolt: [performance improvement] Preallocate string array with length to avoid append overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **moqt:** Optimized string array allocation performance.
+
 ## [v0.15.0] - 2026-04-26
 
 ### Added

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -96,13 +96,13 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 
 	b = b[total:]
 
-	arr := make([]string, 0, count)
-	for range count {
+	arr := make([]string, count)
+	for i := uint64(0); i < count; i++ {
 		str, n, err := ReadString(b)
 		if err != nil {
 			return nil, 0, err
 		}
-		arr = append(arr, str)
+		arr[i] = str
 		b = b[n:]
 		total += n
 	}


### PR DESCRIPTION
💡 **What:**
Optimized `ReadStringArray` in `moqt/internal/message/message_reader.go`. The function used to allocate the slice capacity beforehand (`arr := make([]string, 0, count)`) but still relied on `append` inside a loop. The new implementation allocates the exact length immediately (`arr := make([]string, count)`) and performs a direct index assignment (`arr[i] = str`).

🎯 **Why:**
Even when capacity is known, `append` introduces minor overhead to check capacity against bounds before assignment. Since the loop bounds are exactly known (`count`), assigning by index avoids both `append` overhead and subsequent boundary checks, leading to faster execution times.

📊 **Measured Improvement:**
A dedicated micro-benchmark `BenchmarkReadStringArray` was used to evaluate parsing arrays of 100 random strings.
- **Baseline**: ~5177 ns/op
- **Optimized**: ~5055 ns/op
This change resulted in ~100ns faster operations per 100 elements. Both maintained identically low heap allocations since the primary arrays were sized adequately from the beginning.

🔬 **Measurement:**
We used Go's standard benchmark suite. Results:
**Baseline**
```
goos: linux
goarch: amd64
pkg: github.com/qumo-dev/gomoqt/moqt/internal/message
cpu: Intel(R) Xeon(R) Processor @ 2.30GHz
BenchmarkReadStringArray-4   	  208923	      5177 ns/op	    3392 B/op	     101 allocs/op
```

**Optimized**
```
goos: linux
goarch: amd64
pkg: github.com/qumo-dev/gomoqt/moqt/internal/message
cpu: Intel(R) Xeon(R) Processor @ 2.30GHz
BenchmarkReadStringArray-4   	  218004	      5055 ns/op	    3392 B/op	     101 allocs/op
```

---
*PR created automatically by Jules for task [11220868000740350046](https://jules.google.com/task/11220868000740350046) started by @okdaichi*