### PR TITLE
⚡ Bolt: Replace time.Sleep with deterministic synchronization in ReceiveSubscribeStream tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+## [Unreleased]
+
+### Changed
+- **moqt:** Replaced arbitrary `time.Sleep` with deterministic synchronization in `ReceiveSubscribeStream` tests to eliminate test flakiness and significantly improve execution speed.
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/moqt/receive_subscribe_stream.go
+++ b/moqt/receive_subscribe_stream.go
@@ -13,10 +13,12 @@ func newReceiveSubscribeStream(id SubscribeID, stream transport.Stream, config *
 		config:      config,
 		stream:      stream,
 		updatedCh:   make(chan struct{}, 1),
+		doneCh:      make(chan struct{}),
 	}
 
 	// Listen for updates in a separate goroutine
 	go func() {
+		defer close(substr.doneCh)
 		var updateMsg message.SubscribeUpdateMessage
 		var err error
 
@@ -57,6 +59,7 @@ type receiveSubscribeStream struct {
 
 	config          *SubscribeConfig
 	updatedCh       chan struct{}
+	doneCh          chan struct{}
 	responseStarted bool
 }
 

--- a/moqt/receive_subscribe_stream_test.go
+++ b/moqt/receive_subscribe_stream_test.go
@@ -51,7 +51,7 @@ func TestNewReceiveSubscribeStream(t *testing.T) {
 			assert.NotNil(t, rss, "newReceiveSubscribeStream should not return nil")
 			assert.Equal(t, tt.subscribeID, rss.SubscribeID(), "SubscribeID should match")
 			assert.NotNil(t, rss.Updated(), "Updated channel should not be nil") // Wait for goroutine to process EOF and close
-			time.Sleep(10 * time.Millisecond)
+			<-rss.doneCh
 		})
 	}
 }
@@ -90,7 +90,7 @@ func TestReceiveSubscribeStream_SubscribeID(t *testing.T) {
 			result := rss.SubscribeID()
 			assert.Equal(t, tt.subscribeID, result, "SubscribeID should match expected value")
 
-			time.Sleep(10 * time.Millisecond)
+			<-rss.doneCh
 		})
 	}
 }
@@ -128,7 +128,7 @@ func TestReceiveSubscribeStream_TrackConfig(t *testing.T) {
 				assert.Equal(t, tt.config.Priority, resultConfig.Priority, "TrackPriority should match")
 			}
 
-			time.Sleep(10 * time.Millisecond)
+			<-rss.doneCh
 		})
 	}
 }
@@ -146,12 +146,10 @@ func TestReceiveSubscribeStream_Updated(t *testing.T) {
 	updatedCh := rss.Updated()
 	assert.NotNil(t, updatedCh, "Updated channel should not be nil")
 
-	// EOF stops the background goroutine; it does not close Updated().
-	time.Sleep(10 * time.Millisecond)
-	assert.NotNil(t, updatedCh)
+	<-rss.doneCh
 
-	// Give some time for the goroutine to complete
-	time.Sleep(10 * time.Millisecond)
+	// EOF stops the background goroutine; it does not close Updated().
+	assert.NotNil(t, updatedCh)
 }
 
 func TestReceiveSubscribeStream_ListenUpdates_WithSubscribeUpdateMessage(t *testing.T) {
@@ -190,8 +188,7 @@ func TestReceiveSubscribeStream_ListenUpdates_WithSubscribeUpdateMessage(t *test
 		assert.Equal(t, TrackPriority(5), updatedConfig.Priority, "TrackPriority should be updated")
 	}
 
-	// Give some time for the goroutine to complete
-	time.Sleep(10 * time.Millisecond)
+	<-rss.doneCh
 }
 
 func TestReceiveSubscribeStream_CloseWithError(t *testing.T) {
@@ -321,9 +318,7 @@ func TestReceiveSubscribeStream_ConcurrentAccess(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 	}
 
-	// Give some time for the goroutine to complete
-	time.Sleep(10 * time.Millisecond)
-
+	<-rss.doneCh
 }
 
 func TestReceiveSubscribeStream_Close_DoesNotCancelReadOnGracefulClose(t *testing.T) {
@@ -351,10 +346,11 @@ func TestReceiveSubscribeStream_UpdateChannelBehavior(t *testing.T) {
 
 		rss := newReceiveSubscribeStream(subscribeID, mockStream, config)
 
-		// Wait for the goroutine to handle EOF and close the channel
-		time.Sleep(50 * time.Millisecond)
+		// Wait for the goroutine to handle EOF
+		<-rss.doneCh
 
-		// Verify channel is closed by trying to receive
+		// Verify channel is NOT explicitly closed by EOF, but the test ensures stability.
+		// Tests here verify that it doesn't crash or behave improperly when the loop ends.
 		select {
 		case _, ok := <-rss.Updated():
 			if ok {
@@ -362,13 +358,9 @@ func TestReceiveSubscribeStream_UpdateChannelBehavior(t *testing.T) {
 			} else {
 				t.Log("Channel is properly closed")
 			}
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(10 * time.Millisecond):
 			t.Log("Channel should be closed and ready to receive")
 		}
-
-		// Give some time for the goroutine to complete
-		time.Sleep(10 * time.Millisecond)
-
 	})
 
 	t.Run("multiple updates sent to channel", func(t *testing.T) {
@@ -418,7 +410,6 @@ func TestReceiveSubscribeStream_UpdateChannelBehavior(t *testing.T) {
 		// We received at least the minimum expected updates
 		assert.GreaterOrEqual(t, updateCount, expectedUpdates, "Should receive at least expected number of updates")
 
-		// Give some time for the goroutine to complete
-		time.Sleep(10 * time.Millisecond)
+		<-rss.doneCh
 	})
 }


### PR DESCRIPTION
**💡 What**
Added a `doneCh` (a `chan struct{}`) to the `receiveSubscribeStream` struct. This channel is closed via a `defer` block when the background goroutine (which listens for updates from the stream) finishes execution. Consequently, all arbitrary `time.Sleep` calls in `moqt/receive_subscribe_stream_test.go` were replaced with deterministic `<-rss.doneCh` blocking reads.

**🎯 Why**
The test suite for `ReceiveSubscribeStream` previously relied on arbitrary `time.Sleep(10 * time.Millisecond)` calls (totaling over 10 separate sleep statements) to wait for background goroutines to handle stream updates and exit. This led to slower test execution times and the potential for flaky tests, particularly on slower CI environments.

**📊 Impact**
Replaced all timing-based sleeps with precise, deterministic synchronization. This guarantees that the test always waits exactly as long as needed for the goroutine to finish, completely removing flakiness related to timing constraints. Test suite execution is tangibly faster and more reliable.

**🔬 Measurement**
Executed `go test ./moqt -v -run TestReceiveSubscribeStream` with the `-race` flag. Tests execute instantly without any race conditions, maintaining full test coverage while vastly improving runtime reliability.

---
*PR created automatically by Jules for task [10809085489273886692](https://jules.google.com/task/10809085489273886692) started by @okdaichi*