### PR TITLE
refactor: remove unused Parameters type and helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **moqt:** Removed the unused `Parameters` type and its `ParametersLen` / `WriteParameters` helpers from the internal `message` package; they had no production callers.
+
 ## [v0.15.0] - 2026-04-26
 
 ### Added

--- a/moqt/internal/message/message.go
+++ b/moqt/internal/message/message.go
@@ -35,11 +35,3 @@ func StringArrayLen(arr []string) int {
 	}
 	return total
 }
-
-func ParametersLen(params map[uint64][]byte) int {
-	total := VarintLen(uint64(len(params)))
-	for key, value := range params {
-		total += VarintLen(uint64(key)) + BytesLen(value)
-	}
-	return total
-}

--- a/moqt/internal/message/message_test.go
+++ b/moqt/internal/message/message_test.go
@@ -91,25 +91,3 @@ func TestStringArrayLen(t *testing.T) {
 		})
 	}
 }
-
-func TestParametersLen(t *testing.T) {
-	tests := map[string]struct {
-		input    map[uint64][]byte
-		expected int
-	}{
-		"empty parameters": {map[uint64][]byte{}, VarintLen(0)},
-		"single parameter": {map[uint64][]byte{1: []byte("value")}, VarintLen(1) + VarintLen(1) + BytesLen([]byte("value"))},
-		"multiple parameters": {map[uint64][]byte{
-			1: []byte("value1"),
-			2: []byte("value2"),
-		}, VarintLen(2) + VarintLen(1) + BytesLen([]byte("value1")) + VarintLen(2) + BytesLen([]byte("value2"))},
-		"empty value": {map[uint64][]byte{1: {}}, VarintLen(1) + VarintLen(1) + BytesLen([]byte{})},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			result := ParametersLen(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}

--- a/moqt/internal/message/message_writer.go
+++ b/moqt/internal/message/message_writer.go
@@ -61,18 +61,6 @@ func WriteStringArray(dest []byte, arr []string) ([]byte, int) {
 	return dest, n
 }
 
-func WriteParameters(dest []byte, params map[uint64][]byte) ([]byte, int) {
-	dest, n := WriteVarint(dest, uint64(len(params)))
-	var m int
-	for key, value := range params {
-		dest, m = WriteVarint(dest, uint64(key))
-		n += m
-		dest, m = WriteBytes(dest, value)
-		n += m
-	}
-	return dest, n
-}
-
 const (
 	maxVarInt1 = 1<<(8-2) - 1
 	maxVarInt2 = 1<<(16-2) - 1

--- a/moqt/internal/message/message_writer_test.go
+++ b/moqt/internal/message/message_writer_test.go
@@ -107,25 +107,3 @@ func TestWriteStringArray(t *testing.T) {
 		}
 	}
 }
-
-func TestWriteParameters(t *testing.T) {
-	tests := []struct {
-		dest     []byte
-		params   map[uint64][]byte
-		expected []byte
-		n        int
-	}{
-		{[]byte{}, map[uint64][]byte{}, []byte{0}, 1},
-		{[]byte{}, map[uint64][]byte{1: {1, 2}}, []byte{1, 1, 2, 1, 2}, 5},
-	}
-
-	for _, tt := range tests {
-		result, n := WriteParameters(tt.dest, tt.params)
-		if n != tt.n {
-			t.Errorf("WriteParameters n = %d, want %d", n, tt.n)
-		}
-		if !reflect.DeepEqual(result, tt.expected) {
-			t.Errorf("WriteParameters = %v, want %v", result, tt.expected)
-		}
-	}
-}

--- a/moqt/internal/message/parameters.go
+++ b/moqt/internal/message/parameters.go
@@ -1,6 +1,0 @@
-package message
-
-/*
-* Parameters
- */
-type Parameters map[uint64][]byte


### PR DESCRIPTION
## Summary

Removes the dead `Parameters` type and its helpers from `moqt/internal/message`, which were no longer used anywhere in production code.

## Changes

- Delete `moqt/internal/message/parameters.go` (the `Parameters` type alias)
- Remove `ParametersLen` from `message.go`
- Remove `WriteParameters` from `message_writer.go`
- Remove the corresponding `TestParametersLen` and `TestWriteParameters` tests

These symbols were only referenced by each other and their own tests — no production callers. The unrelated `ParameterLengthMismatchErrorCode` (`moqt/errors.go`) and `TransportParameterError` (`transport/error.go`) are different concepts and are left untouched.

## Verification

- `go build ./...` — clean
- `go vet ./moqt/internal/message/...` — clean
- `go test ./moqt/internal/message/...` — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)