### PR TITLE
fix(session): synchronize trackReaders read on group-dispatch path (data race)

### DIFF
--- a/moqt/session.go
+++ b/moqt/session.go
@@ -729,7 +729,9 @@ func (sess *Session) processUniStream(stream transport.ReceiveStream) {
 			return
 		}
 
+		sess.trackReaderMapLocker.RLock()
 		track, ok := sess.trackReaders[SubscribeID(gm.SubscribeID)]
+		sess.trackReaderMapLocker.RUnlock()
 		if !ok {
 			stream.CancelRead(transport.StreamErrorCode(InvalidSubscribeIDErrorCode))
 			return

--- a/moqt/session_test.go
+++ b/moqt/session_test.go
@@ -2964,3 +2964,82 @@ func TestSession_Probe_ConcurrentAccess(t *testing.T) {
 	consumeCancel()
 	_ = session.CloseWithError(NoError, "")
 }
+
+// TestSession_ProcessUniStream_TrackReadersRace exercises the group-dispatch path
+// (processUniStream reading sess.trackReaders at session.go:732) concurrently with
+// addTrackReader/removeTrackReader (which write sess.trackReaders under
+// trackReaderMapLocker). Run with -race to detect the missing lock on the read
+// path; without synchronization Go also panics with "concurrent map read and map
+// write" when the overlap is hit.
+func TestSession_ProcessUniStream_TrackReadersRace(t *testing.T) {
+	const iterations = 200
+
+	for range iterations {
+		conn := &FakeStreamConn{}
+
+		// acceptStreamCh feeds exactly one GROUP uni stream per session.
+		acceptStreamCh := make(chan transport.ReceiveStream, 1)
+		conn.AcceptUniStreamFunc = func(ctx context.Context) (transport.ReceiveStream, error) {
+			select {
+			case s := <-acceptStreamCh:
+				return s, nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+
+		session := newTestSession(conn)
+		t.Cleanup(func() { _ = session.CloseWithError(NoError, "") })
+
+		// A barrier the GROUP stream's Read blocks on until released; this lets us
+		// force processUniStream to reach the trackReaders read at :732 while the
+		// writer goroutine below is concurrently mutating the map.
+		releaseRead := make(chan struct{})
+		decodeDone := make(chan struct{})
+
+		mockRecvStream := &FakeQUICReceiveStream{}
+		var buf bytes.Buffer
+		_ = message.StreamTypeGroup.Encode(&buf)
+		gm := message.GroupMessage{SubscribeID: 1, GroupSequence: 0}
+		_ = gm.Encode(&buf)
+		payload := buf.Bytes()
+
+		mockRecvStream.ReadFunc = func(p []byte) (int, error) {
+			// Block the very first Read (stream-type decode) until the writer is
+			// ramping up, then serve all bytes in one shot.
+			<-releaseRead
+			n := copy(p, payload)
+			payload = payload[n:]
+			if len(payload) == 0 {
+				close(decodeDone)
+				return n, io.EOF
+			}
+			return n, nil
+		}
+
+		// Hand the stream to handleUniStreams -> processUniStream (real goroutine).
+		acceptStreamCh <- mockRecvStream
+
+		// Mutate trackReaders from another goroutine, overlapping the read at :732.
+		writerDone := make(chan struct{})
+		go func() {
+			defer close(writerDone)
+			mockTrackStream := &FakeQUICStream{}
+			mockTrackStream.WriteFunc = func(p []byte) (int, error) { return 0, nil }
+			substr := newTestSendSubscribeStreamFromStream(mockTrackStream, &SubscribeConfig{})
+			reader := newTrackReader("/test", "video", substr, func() {})
+			// Add then repeatedly remove/re-add the same id to maximize write
+			// activity during the contended read window.
+			session.addTrackReader(SubscribeID(1), reader)
+			for range 8 {
+				session.removeTrackReader(SubscribeID(1))
+				session.addTrackReader(SubscribeID(1), reader)
+			}
+		}()
+
+		// Release the blocked read so processUniStream's read races the writer.
+		close(releaseRead)
+		<-decodeDone
+		<-writerDone
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a **data race that is a live crash** on the subscriber-side group-dispatch path — not a performance change.

## The bug

`Session.processUniStream` reads the `trackReaders` map **without holding `trackReaderMapLocker`**:

- Unlocked read: `moqt/session.go:732` — `sess.trackReaders[SubscribeID(gm.SubscribeID)]`
- Locked writers: `addTrackReader` / `removeTrackReader` (`session.go:763–773`) take `trackReaderMapLocker.Lock()`

A concurrent map read + write is **undefined behavior and an unconditional fatal runtime error** in Go.

## Evidence

This is stronger than a `-race` finding — Go's own runtime caught it as a guaranteed crash (no detector needed):

```
fatal error: concurrent map read and map write
github.com/qumo-dev/gomoqt/moqt.(*Session).processUniStream(...)
    moqt/session.go:732
```

A regression test `TestSession_ProcessUniStream_TrackReadersRace` is added:
- **Before fix:** `FAIL` — `fatal error: concurrent map read and map write` at `session.go:732`.
- **After fix:** `ok`.
- Full `go test ./moqt/...` green; `go vet` clean.

## The fix

Two lines, mirroring the read-lock pattern already used in `session_benchmark_test.go:214–216`:

```diff
+		sess.trackReaderMapLocker.RLock()
 		track, ok := sess.trackReaders[SubscribeID(gm.SubscribeID)]
+		sess.trackReaderMapLocker.RUnlock()
```

`track.enqueueGroup(...)` is deliberately kept **outside** the critical section — the map lock guards the live set, not the referenced `*TrackReader`; the pointer stays valid after `RUnlock`.

## Reproduction

`go test -race ./moqt/...` (CI `ubuntu-latest` has gcc; some local machines lack a C compiler and cannot run `-race`, but the regression test trips Go's built-in concurrent-map detection regardless).

## Notes

- Correctness fix only — no other behavior changes, no optimization.
- Part of a manual performance-discovery effort (not an automated micro-optimization PR). Sibling PRs add the measurement infrastructure this work surfaced the need for.

## Checklist
- [x] Tests pass (`go test ./moqt/...`)
- [x] No regressions; `go vet` clean
- [x] Minimal, targeted diff (2 production lines + 1 regression test)
