### PR TITLE
test(moqt): add stream-throughput benchmark and write-count instrumentation

### DIFF
--- a/moqt/counting_send_stream_test.go
+++ b/moqt/counting_send_stream_test.go
@@ -1,0 +1,236 @@
+package moqt
+
+import (
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/qumo-dev/gomoqt/transport"
+)
+
+// CountingSendStream wraps a transport.SendStream to instrument Write calls
+// without changing write/buffering behavior. It counts the number of Write
+// calls and buckets them by payload size, and tracks total bytes written.
+//
+// This is a measurement/instrumentation helper. It performs NO buffering,
+// NO batching, and NO change to the wrapped stream's behavior beyond routing
+// each Write through a counter. It is safe for concurrent use because
+// transport.SendStream implementations are expected to be safe for concurrent
+// Write calls (mirroring quic-go semantics).
+//
+// Size buckets (power-of-two) give a coarse write-size histogram:
+//
+//	0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1K, 2K, 4K, 8K, 16K, 32K,
+//	64K, 128K, 256K, 512K, 1M, 2M, 4M, 8M+
+//
+// Usage from tests:
+//
+//	cs := NewCountingSendStream(realStream)
+//	gw := newGroupWriter(cs, GroupSequence(0), nil)
+//	_ = gw.WriteFrame(frame)
+//	cs.Snapshot() // -> {WriteCalls, BytesWritten, Buckets}
+type CountingSendStream struct {
+	inner transport.SendStream
+
+	writeCalls  atomic.Int64
+	bytesWitten atomic.Int64
+
+	mu      sync.Mutex
+	buckets []int64 // indexed by floor(log2(size+1))
+}
+
+// compile-time interface check
+var _ transport.SendStream = (*CountingSendStream)(nil)
+
+// NewCountingSendStream wraps the given SendStream with write instrumentation.
+func NewCountingSendStream(inner transport.SendStream) *CountingSendStream {
+	return &CountingSendStream{inner: inner}
+}
+
+// bucketIndex returns the histogram bucket index for a write of n bytes.
+// Bucket k covers sizes in (2^(k-1), 2^k]. size 0 -> bucket 0.
+func bucketIndex(n int) int {
+	if n <= 0 {
+		return 0
+	}
+	k := 0
+	v := 1
+	for v < n {
+		v <<= 1
+		k++
+	}
+	// Guard against pathological growth beyond the slice; we grow lazily.
+	return k
+}
+
+func (c *CountingSendStream) growBucketsLocked(idx int) {
+	for len(c.buckets) <= idx {
+		c.buckets = append(c.buckets, 0)
+	}
+}
+
+// Write counts the call and delegates to the wrapped stream. It does not
+// alter the byte slice or split the write.
+func (c *CountingSendStream) Write(p []byte) (int, error) {
+	n, err := c.inner.Write(p)
+	c.writeCalls.Add(1)
+	c.bytesWitten.Add(int64(n))
+
+	idx := bucketIndex(n)
+	c.mu.Lock()
+	c.growBucketsLocked(idx)
+	c.buckets[idx]++
+	c.mu.Unlock()
+
+	return n, err
+}
+
+// CancelWrite delegates to the wrapped stream.
+func (c *CountingSendStream) CancelWrite(code transport.StreamErrorCode) {
+	c.inner.CancelWrite(code)
+}
+
+// SetWriteDeadline delegates to the wrapped stream.
+func (c *CountingSendStream) SetWriteDeadline(t time.Time) error {
+	return c.inner.SetWriteDeadline(t)
+}
+
+// Close delegates to the wrapped stream.
+func (c *CountingSendStream) Close() error {
+	return c.inner.Close()
+}
+
+// Context returns the wrapped stream's context.
+func (c *CountingSendStream) Context() context.Context {
+	return c.inner.Context()
+}
+
+// Inner returns the wrapped SendStream.
+func (c *CountingSendStream) Inner() transport.SendStream { return c.inner }
+
+// WriteCounters is an immutable snapshot of the counting stream's state.
+type WriteCounters struct {
+	WriteCalls  int64   // total number of Write calls observed
+	BytesWritten int64  // total bytes successfully written
+	Buckets     []int64 // write-size histogram (index = floor(log2(size)), size 0 -> 0)
+}
+
+// Snapshot returns a consistent point-in-time view of the counters.
+// The returned Buckets slice is a copy and may be freely mutated.
+func (c *CountingSendStream) Snapshot() WriteCounters {
+	c.mu.Lock()
+	buckets := make([]int64, len(c.buckets))
+	copy(buckets, c.buckets)
+	c.mu.Unlock()
+
+	return WriteCounters{
+		WriteCalls:   c.writeCalls.Load(),
+		BytesWritten: c.bytesWitten.Load(),
+		Buckets:      buckets,
+	}
+}
+
+// Reset zeroes all counters. Useful between benchmark iterations.
+func (c *CountingSendStream) Reset() {
+	c.writeCalls.Store(0)
+	c.bytesWitten.Store(0)
+	c.mu.Lock()
+	for i := range c.buckets {
+		c.buckets[i] = 0
+	}
+	c.mu.Unlock()
+}
+
+// BucketLabel returns a human-readable label for the given bucket index
+// (e.g. "64", "1K", "64K"), matching the power-of-two boundaries used by
+// bucketIndex.
+func BucketLabel(idx int) string {
+	if idx <= 0 {
+		return "0"
+	}
+	v := 1 << idx
+	switch {
+	case v >= 1<<20:
+		return formatBytesLabel(v, 1<<20, "M")
+	case v >= 1<<10:
+		return formatBytesLabel(v, 1<<10, "K")
+	default:
+		return itoa(v)
+	}
+}
+
+func formatBytesLabel(v, unit int, suffix string) string {
+	if v%unit == 0 {
+		return itoa(v/unit) + suffix
+	}
+	return itoa(v) // fall back to raw bytes for non-round sizes
+}
+
+// itoa is a small, allocation-free int->string helper to avoid pulling in fmt
+// in hot reporting paths.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// BytesWriterSink is an io.Writer backed by a growable *bytes.Buffer-compatible
+// sink that performs a REAL memcpy on every Write (unlike io.Discard, which is
+// a no-op). It is used as the destination for measurement when standing up a
+// real QUIC server/client pair is impractical.
+//
+// The buffer grows without bound by design; benchmarks reset it per iteration
+// or use it for short, bounded runs.
+type BytesWriterSink struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+// NewBytesWriterSink returns a sink with the given initial capacity.
+func NewBytesWriterSink(cap int) *BytesWriterSink {
+	return &BytesWriterSink{buf: make([]byte, 0, cap)}
+}
+
+// Write performs an actual copy of p into the growable buffer and returns
+// len(p), nil. The copy is the measured work.
+func (s *BytesWriterSink) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	s.buf = append(s.buf, p...)
+	s.mu.Unlock()
+	return len(p), nil
+}
+
+// Len returns the current number of buffered bytes.
+func (s *BytesWriterSink) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.buf)
+}
+
+// Reset clears the buffer while retaining its capacity.
+func (s *BytesWriterSink) Reset() {
+	s.mu.Lock()
+	s.buf = s.buf[:0]
+	s.mu.Unlock()
+}
+
+// Compile-time check that BytesWriterSink is an io.Writer.
+var _ io.Writer = (*BytesWriterSink)(nil)

--- a/moqt/stream_io_benchmark_test.go
+++ b/moqt/stream_io_benchmark_test.go
@@ -1,0 +1,302 @@
+package moqt
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/qumo-dev/gomoqt/moqt/internal/message"
+	"github.com/qumo-dev/gomoqt/transport"
+)
+
+// This file adds REAL-stream and memcpy-backed throughput benchmarks plus
+// write-count instrumentation. It deliberately does NOT change any production
+// write/buffering behavior — it only adds measurement scaffolding.
+//
+// Background (why this exists):
+// Every I/O benchmark except broadcast_benchmark_test.go writes to io.Discard,
+// whose Write is a no-op. BenchmarkGroupWriter_WriteFrame/size-65536 on main
+// reports ~4.8M MB/s because the Write under test does zero work. These
+// benchmarks make the real Write cost visible.
+
+// ---------------------------------------------------------------------------
+// Real-QUIC single-stream throughput benchmark
+// ---------------------------------------------------------------------------
+
+// BenchmarkStreamIo_RealQUIC measures end-to-end throughput of frame writes
+// over a real local QUIC connection, reusing the proven broadcast harness
+// (setupBroadcastServerWithFrameSize, generateTestCert) from
+// broadcast_benchmark_test.go. The server opens one fresh unidirectional QUIC
+// stream per group and writes a frame; a single client subscribes and reads
+// b.N frames. b.SetBytes is the frame payload size, so the reported MB/s
+// reflects real stream Write cost (encode + QUIC framing + transport), not a
+// no-op sink.
+//
+// CAVEAT: the reused harness paces the publisher at ~30fps via a ticker, so
+// absolute MB/s here is publisher-paced, not transport-limited. It still
+// exercises a REAL QUIC stream and is the right place to compare payload
+// sizes. For unpaced Write-side throughput see BenchmarkWriteThroughput_Memcpy
+// (memcpy-backed fallback).
+//
+// Note: ns/op and MB/s are PRELIMINARY — concurrent worktrees may perturb
+// timing. Treat numbers as comparative across payload sizes within one run.
+func BenchmarkStreamIo_RealQUIC(b *testing.B) {
+	sizes := []int{1 << 10, 16 << 10, 64 << 10} // 1K 16K 64K (harness cap at ~30fps makes 256K/1M slow)
+
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("payload-%s", humanSize(size)), func(b *testing.B) {
+			ctx := b.Context()
+
+			// Reuse the proven server-setup helper from broadcast_benchmark_test.go.
+			srv, addr := setupBroadcastServerWithFrameSize(b, ctx, size)
+			defer srv.Close()
+
+			client := Dialer{
+				Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+				TLSConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			}
+
+			sess, err := client.Dial(ctx, addr, nil)
+			if err != nil {
+				// Real-QUIC WebTransport upgrade is broken in this worktree:
+				// the dial returns HTTP 404 because the Server's HTTP/3 handler
+				// is nil (Server.init defaults WebTransportServer to
+				// NewWebTransportServer(nil)). The existing
+				// BenchmarkBroadcastServer_HighLoad exhibits the same failure
+				// (it reports N errors/op and 0 frames/op but does not
+				// b.Fatal). Skip rather than fail, and rely on
+				// BenchmarkWriteThroughput_Memcpy for real-write throughput.
+				b.Skipf("real-QUIC WebTransport dial failed in this environment (the existing broadcast harness has the same issue): %v", err)
+			}
+			defer sess.CloseWithError(NoError, "done")
+
+			annRecv, err := sess.AcceptAnnounce("/")
+			if err != nil {
+				b.Fatalf("accept announce: %v", err)
+			}
+			defer annRecv.Close()
+
+			ann, err := annRecv.ReceiveAnnouncement(ctx)
+			if err != nil {
+				b.Fatalf("receive announcement: %v", err)
+			}
+			if !ann.IsActive() {
+				b.Fatal("announcement not active")
+			}
+
+			tr, err := sess.Subscribe(ctx, ann.BroadcastPath(), TrackName("index"), nil)
+			if err != nil {
+				b.Fatalf("subscribe: %v", err)
+			}
+			defer tr.Close()
+
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			// Read b.N frames from the single subscribed stream.
+			frame := NewFrame(size)
+			read := 0
+			for read < b.N {
+				gr, err := tr.AcceptGroup(ctx)
+				if err != nil {
+					if ctx.Err() != nil {
+						break
+					}
+					b.Fatalf("accept group: %v", err)
+				}
+				for {
+					if err := gr.ReadFrame(frame); err != nil {
+						if err == io.EOF {
+							break
+						}
+						b.Fatalf("read frame: %v", err)
+					}
+					read++
+					if read >= b.N {
+						break
+					}
+				}
+			}
+
+			b.StopTimer()
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Memcpy-backed throughput + write-count instrumentation
+// ---------------------------------------------------------------------------
+
+// BenchmarkWriteThroughput_Memcpy measures GroupWriter.WriteFrame throughput
+// against a REAL-memcpy sink (growing BytesWriterSink) instead of io.Discard.
+// This is the documented FALLBACK path: it exercises the real encode + a real
+// byte copy, but not QUIC framing/transport. It is far better than io.Discard
+// (Write does real work) but is NOT real-QUIC throughput.
+//
+// The counting wrapper is interposed between the GroupWriter and the sink so
+// that write-count per frame and the write-size histogram are reported as
+// custom metrics. This characterizes the one-stream-per-group and
+// two-header-writes hypotheses:
+//
+//   - group open = 2 separate Write calls (stream-type varint + group message),
+//     observed here only when counting around OpenGroup; WriteFrame itself
+//     performs exactly 1 Write per frame (varint length + payload together).
+func BenchmarkWriteThroughput_Memcpy(b *testing.B) {
+	sizes := []int{1 << 10, 16 << 10, 64 << 10, 256 << 10, 1 << 20} // 1K 16K 64K 256K 1M
+
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("payload-%s", humanSize(size)), func(b *testing.B) {
+			payload := make([]byte, size)
+			for i := range payload {
+				payload[i] = byte(i % 256)
+			}
+
+			sink := NewBytesWriterSink(size + 16)
+			counting := NewCountingSendStream(&sinkWriterSendStream{w: sink})
+
+			// NOTE: a new GroupWriter is created per iteration to mirror the
+			// one-stream-per-group production behavior. Each OpenGroup would
+			// allocate a fresh stream; here we model one group per iteration.
+			gw := newGroupWriter(counting, GroupSequence(1), nil)
+
+			frame := NewFrame(size)
+			frame.Write(payload)
+
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				sink.Reset()
+				if err := gw.WriteFrame(frame); err != nil {
+					b.Fatalf("WriteFrame: %v", err)
+				}
+			}
+
+			b.StopTimer()
+
+			snap := counting.Snapshot()
+			// WriteFrame issues exactly one stream Write per frame (varint
+			// length prefix + payload are concatenated in encode and written
+			// in a single Write call). Report it as a custom metric.
+			if b.N > 0 {
+				b.ReportMetric(float64(snap.WriteCalls)/float64(b.N), "writes/frame")
+				b.ReportMetric(float64(snap.BytesWritten)/float64(b.N), "bytes/write")
+			}
+		})
+	}
+}
+
+// BenchmarkWriteCount_GroupHeader counts the Write calls performed while
+// opening a group and writing a single frame, to characterize the
+// "two-header-writes per group" hypothesis. It uses a counting wrapper around
+// a FakeQUICSendStream and reproduces the EXACT OpenGroup write sequence from
+// track_writer.go:
+//
+//  1. message.StreamTypeGroup.Encode(stream)   -> 1 Write (1 byte)
+//  2. message.GroupMessage{...}.Encode(stream) -> 1 Write (varint length +
+//     subscribe-id + group-seq, typically 3-5 bytes)
+//  3. newGroupWriter(stream, ...)              -> stores stream, no writes
+//  4. groupWriter.WriteFrame(frame)            -> 1 Write (varint length +
+//     payload, single concatenated buffer)
+//
+// So one group containing one frame = 3 Write calls. The benchmark reports
+// writes/group-header (steps 1+2) and writes/frame (step 4) separately so the
+// two hypotheses can be read directly off the output.
+func BenchmarkWriteCount_GroupHeader(b *testing.B) {
+	sizes := []int{1 << 10, 16 << 10, 64 << 10}
+
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("payload-%s", humanSize(size)), func(b *testing.B) {
+			payload := make([]byte, size)
+			for i := range payload {
+				payload[i] = byte(i % 256)
+			}
+
+			// Discard-backed fake so we isolate WRITE-COUNT, not throughput.
+			fake := &FakeQUICSendStream{WriteFunc: io.Discard.Write}
+			counting := NewCountingSendStream(fake)
+
+			// Pre-build the frame once; payload is fixed across iterations.
+			frame := NewFrame(size)
+			frame.Write(payload)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			var headerWrites, frameWrites int64
+			for i := 0; i < b.N; i++ {
+				counting.Reset()
+
+				// Step 1 + 2: the two group-header writes that OpenGroup
+				// performs on the freshly-opened uni stream.
+				if err := message.StreamTypeGroup.Encode(counting); err != nil {
+					b.Fatalf("encode stream type: %v", err)
+				}
+				if err := (message.GroupMessage{
+					SubscribeID:   0,
+					GroupSequence: uint64(i),
+				}).Encode(counting); err != nil {
+					b.Fatalf("encode group message: %v", err)
+				}
+				hw := counting.Snapshot().WriteCalls
+
+				// Step 3 + 4: construct the group writer (no writes) and
+				// write exactly one frame through it.
+				gw := newGroupWriter(counting, GroupSequence(1), nil)
+				if err := gw.WriteFrame(frame); err != nil {
+					b.Fatalf("WriteFrame: %v", err)
+				}
+				fw := counting.Snapshot().WriteCalls - hw
+
+				headerWrites += hw
+				frameWrites += fw
+			}
+
+			b.StopTimer()
+
+			if b.N > 0 {
+				b.ReportMetric(float64(headerWrites)/float64(b.N), "writes/group-header")
+				b.ReportMetric(float64(frameWrites)/float64(b.N), "writes/frame")
+				snap := counting.Snapshot()
+				b.ReportMetric(float64(snap.BytesWritten)/float64(b.N), "bytes/op")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// sinkWriterSendStream adapts an io.Writer (the BytesWriterSink) to the
+// transport.SendStream interface for the counting-wrapper benchmark. Only
+// Write needs to do real work; the rest are inert stubs.
+type sinkWriterSendStream struct {
+	w io.Writer
+}
+
+func (s *sinkWriterSendStream) Write(p []byte) (int, error) { return s.w.Write(p) }
+func (s *sinkWriterSendStream) CancelWrite(transport.StreamErrorCode) {}
+func (s *sinkWriterSendStream) SetWriteDeadline(time.Time) error    { return nil }
+func (s *sinkWriterSendStream) Close() error                        { return nil }
+func (s *sinkWriterSendStream) Context() context.Context            { return context.Background() }
+
+// humanSize returns a short label (1K, 16K, 64K, 256K, 1M) for a byte size.
+func humanSize(n int) string {
+	switch {
+	case n >= 1<<20 && n%(1<<20) == 0:
+		return fmt.Sprintf("%dM", n>>20)
+	case n >= 1<<10 && n%(1<<10) == 0:
+		return fmt.Sprintf("%dK", n>>10)
+	default:
+		return fmt.Sprintf("%d", n)
+	}
+}


### PR DESCRIPTION
## Summary

Adds write-count instrumentation and a stream-throughput benchmark, addressing the fact that **every I/O benchmark except `broadcast_benchmark_test.go` writes to `io.Discard`** — proven on `main`:

```
BenchmarkGroupWriter_WriteFrame/size-65536   0 allocs/op   4,816,520 MB/s
```

4.8 TB/s is impossible; it confirms `Write` is a no-op, so real write cost is invisible. Measurement/instrumentation only; no production changes.

## What's added

- `moqt/counting_send_stream_test.go` — `CountingSendStream` wraps any `transport.SendStream`, counting `Write` calls (atomic) + a write-size histogram; `Snapshot()` / `Reset()`. Performs **no buffering/batching** — pure instrumentation. Plus a growing-buffer `BytesWriterSink` (real memcpy) fallback sink.
- `moqt/stream_io_benchmark_test.go`:
  - `BenchmarkWriteThroughput_Memcpy` — memcpy-backed sink, `b.SetBytes`, sweep 1K/16K/64K/256K/1M.
  - `BenchmarkWriteCount_GroupHeader` — reports `writes/group-header` and `writes/frame`.
  - `BenchmarkStreamIo_RealQUIC` — reuses the broadcast harness; currently `b.Skipf`s (see blocker).

## Confirmed empirically

- **`1.000 writes/frame`** — `Frame.encode` concatenates length-varint + payload into one buffer and writes once.
- **`2.000 writes/group-header`** — `StreamTypeGroup.Encode` (1 byte) + `GroupMessage.Encode` (varint len + subscribe-id + group-seq) each issue a separate `stream.Write`.
- Net: a group containing N frames costs **`2 + N` stream.Write calls**, and `OpenGroup` opens a **fresh uni stream per group** (`track_writer.go:301`).

## ⚠️ Blocker discovered (not fixed here — production change, out of scope)

The **real-QUIC WebTransport path is broken repo-wide**: `Server.init()` hands the HTTP/3 server a nil handler, so `/broadcast` returns HTTP 404. The existing `BenchmarkBroadcastServer_HighLoad` (the *one* "real I/O" benchmark) silently reports **0 frames/op and 10 errors/op without `b.Fatal`** — it has been falsely "passing." This PR's `BenchmarkStreamIo_RealQUIC` therefore skips rather than fail, and the throughput numbers above are memcpy-backed (real encode + real byte copy, not `io.Discard`). Worth a separate bug PR.

## Notes

- Measurement / instrumentation only — no production write/buffering behavior changed (no bufio, no batching).
- Part of a coordinated performance-measurement effort.
