### PR TITLE
test(moqt): correct misleading mux/track benchmarks to exercise real paths

### DIFF
--- a/moqt/mux_benchmark_test.go
+++ b/moqt/mux_benchmark_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/qumo-dev/gomoqt/transport"
@@ -107,7 +108,25 @@ func BenchmarkTrackMux_ServeTrack(b *testing.B) {
 	}
 }
 
-// BenchmarkTrackMux_ServeAnnouncements benchmarks announcement setup overhead
+// BenchmarkTrackMux_ServeAnnouncements measures the real announcement fan-out
+// pipeline end to end: each iteration Publishes a new track whose path matches
+// a registered AnnouncementWriter's prefix, which triggers
+// Announce -> announcement-tree walk -> per-node subscription snapshot ->
+// channel send -> SendAnnouncement -> AnnounceMessage encode on the writer's
+// stream.
+//
+// The previous version constructed an AnnouncementWriter per iteration but
+// never invoked Announce/Publish, so it measured only allocation and none of
+// the fan-out.
+//
+// A long-lived AnnouncementWriter is registered via serveAnnouncements (run in
+// a background goroutine). serveAnnouncements' subscription channel has a
+// fixed buffer of 8 and, when full, the production code drops the subscription
+// and closes the writer. To measure the steady-state fan-out (channel send
+// succeeding) rather than the drop/close path, each iteration waits for the
+// consumer to acknowledge delivery (via a WriteFunc signal) before publishing
+// the next announcement. This yields a stable per-operation latency for the
+// full relay forwarding path.
 func BenchmarkTrackMux_ServeAnnouncements(b *testing.B) {
 	sizes := []int{100, 1000, 10000}
 
@@ -117,21 +136,62 @@ func BenchmarkTrackMux_ServeAnnouncements(b *testing.B) {
 			ctx := context.Background()
 			handler := TrackHandlerFunc(func(tw *TrackWriter) {})
 
-			// Pre-populate with handlers under /room/ prefix
+			// Pre-populate with handlers under /room/ prefix so the tree has depth.
 			for i := range size {
 				path := BroadcastPath(fmt.Sprintf("/room/user%d", i))
 				mux.Publish(ctx, path, handler)
 			}
 
+			awCtx, cancelAW := context.WithCancel(ctx)
+			// delivered is signaled on every Write to the writer's stream (during
+			// init AND on each forwarded announcement). Used both to wait for
+			// init completion before timing and to acknowledge each fan-out.
+			delivered := make(chan struct{}, 1)
+			mockStream := &FakeQUICStream{
+				ParentCtx: awCtx,
+				WriteFunc: func(p []byte) (int, error) {
+					select {
+					case delivered <- struct{}{}:
+					default:
+					}
+					return len(p), nil
+				},
+			}
+			aw := newAnnouncementWriter(mockStream, "/room/", 0, 0, nil)
+
+			var awWG sync.WaitGroup
+			awWG.Add(1)
+			go func() {
+				defer awWG.Done()
+				mux.serveAnnouncements(aw)
+			}()
+
+			// Block until init has fully completed. The fan-out path in
+			// Announce does a non-blocking channel send and, on overflow, closes
+			// the writer (setting aw.actives = nil); if a Publish raced init's
+			// registerEndHandler it would nil-deref. initDone is closed at the
+			// end of the writer's one-shot init, so waiting on it guarantees no
+			// concurrent Publish until init is done.
+			select {
+			case <-aw.initDone:
+			case <-awCtx.Done():
+			}
+
+			b.Cleanup(func() {
+				cancelAW()
+				awWG.Wait()
+			})
+
 			b.ReportAllocs()
 			b.ResetTimer()
 
-			// Benchmark announcement writer creation (not the blocking operation)
-			for b.Loop() {
-				mockStream := &FakeQUICStream{
-					ParentCtx: ctx,
-				}
-				_ = newAnnouncementWriter(mockStream, "/room/", 0, 0, nil)
+			// Each iteration Publishes a new matching track and waits for the
+			// consumer to encode the forwarded announcement, measuring one full
+			// announce -> deliver round trip.
+			for i := 0; b.Loop(); i++ {
+				path := BroadcastPath(fmt.Sprintf("/room/bench%d", i))
+				mux.Publish(ctx, path, handler)
+				<-delivered
 			}
 		})
 	}
@@ -412,6 +472,10 @@ func BenchmarkTrackMux_LockContention(b *testing.B) {
 		})
 	})
 
+	// write-heavy exercises concurrent Publish calls against the SAME shared
+	// TrackMux (mux above), so the mux.mu write lock is genuinely contended.
+	// The previous version constructed a fresh mux per iteration, measuring
+	// allocation/initialization cost rather than lock contention.
 	b.Run("write-heavy", func(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -419,9 +483,8 @@ func BenchmarkTrackMux_LockContention(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			i := 0
 			for pb.Next() {
-				newMux := NewTrackMux(0)
 				path := BroadcastPath(fmt.Sprintf("/new/%d", i))
-				newMux.Publish(ctx, path, handler)
+				mux.Publish(ctx, path, handler)
 				i++
 			}
 		})
@@ -449,7 +512,12 @@ func BenchmarkTrackMux_LockContention(b *testing.B) {
 	})
 }
 
-// BenchmarkTrackMux_AnnouncementTree benchmarks the announcement tree operations
+// BenchmarkTrackMux_AnnouncementTree measures the announcement-tree fan-out
+// across a deep tree. A writer is registered at a shallow prefix ("/level1/")
+// so each Publish of a deeply-nested track must add the announcement to every
+// node along the root->leaf path and send to the subscriber snapshot at each
+// node. The previous version only constructed an AnnouncementWriter and never
+// exercised Announce/Publish, so the per-node walk was never measured.
 func BenchmarkTrackMux_AnnouncementTree(b *testing.B) {
 	sizes := []int{100, 1000, 10000}
 
@@ -459,19 +527,58 @@ func BenchmarkTrackMux_AnnouncementTree(b *testing.B) {
 			ctx := context.Background()
 			handler := TrackHandlerFunc(func(tw *TrackWriter) {})
 
-			// Create a deep tree structure
+			// Create a deep tree structure.
 			for i := range size {
 				path := BroadcastPath(fmt.Sprintf("/level1/level2/level3/track%d", i))
 				mux.Publish(ctx, path, handler)
 			}
 
+			// Register a writer at the shallow "/level1/" prefix so each new
+			// deeply-nested Publish walks root -> level1 -> level2 -> level3 ->
+			// leaf and fans out at each node. delivered acknowledges every
+			// Write so the benchmark can wait for init to flush and then
+			// synchronize each fan-out round trip (see ServeAnnouncements for
+			// why this avoids the overflow -> drop/close path).
+			awCtx, cancelAW := context.WithCancel(ctx)
+			delivered := make(chan struct{}, 1)
+			mockStream := &FakeQUICStream{
+				ParentCtx: awCtx,
+				WriteFunc: func(p []byte) (int, error) {
+					select {
+					case delivered <- struct{}{}:
+					default:
+					}
+					return len(p), nil
+				},
+			}
+			aw := newAnnouncementWriter(mockStream, "/level1/", 0, 0, nil)
+
+			var awWG sync.WaitGroup
+			awWG.Add(1)
+			go func() {
+				defer awWG.Done()
+				mux.serveAnnouncements(aw)
+			}()
+
+			// Block until init completes; see ServeAnnouncements for why this
+			// prevents a Publish from racing init's registerEndHandler.
+			select {
+			case <-aw.initDone:
+			case <-awCtx.Done():
+			}
+
+			b.Cleanup(func() {
+				cancelAW()
+				awWG.Wait()
+			})
+
 			b.ReportAllocs()
 			b.ResetTimer()
 
-			// Benchmark announcement writer creation and tree structure access
-			for b.Loop() {
-				mockStream := &FakeQUICStream{}
-				_ = newAnnouncementWriter(mockStream, "/level1/", 0, 0, nil)
+			for i := 0; b.Loop(); i++ {
+				path := BroadcastPath(fmt.Sprintf("/level1/level2/level3/bench%d", i))
+				mux.Publish(ctx, path, handler)
+				<-delivered
 			}
 		})
 	}

--- a/moqt/track_benchmark_test.go
+++ b/moqt/track_benchmark_test.go
@@ -155,7 +155,15 @@ func BenchmarkTrackWriter_OpenGroup(b *testing.B) {
 	}
 }
 
-// BenchmarkTrackWriter_ConcurrentOpenGroup benchmarks concurrent group opening
+// BenchmarkTrackWriter_ConcurrentOpenGroup benchmarks concurrent group opening.
+//
+// The openUniStreamFunc stand-in allocates a fresh FakeQUICSendStream per call
+// WITHOUT taking a shared mutex. Production's OpenUniStream (quic-go) draws a
+// stream from a connection-wide pool and does not serialize callers on a single
+// global lock, so the previous version's artificial streamMu inflated lock
+// contention beyond what the real transport imposes. This version measures only
+// the contention that TrackWriter itself introduces (groupManager.mu and the
+// writer's RWMutex during OpenGroup/Close).
 func BenchmarkTrackWriter_ConcurrentOpenGroup(b *testing.B) {
 	concurrency := []int{2, 10, 50}
 
@@ -165,11 +173,9 @@ func BenchmarkTrackWriter_ConcurrentOpenGroup(b *testing.B) {
 
 			substr := newReceiveSubscribeStream(SubscribeID(1), mockStream, &SubscribeConfig{})
 
-			var streamMu sync.Mutex
+			// No shared lock: each call returns an independent send stream,
+			// matching quic-go's non-serializing OpenUniStream semantics.
 			openUniStreamFunc := func() (transport.SendStream, error) {
-				streamMu.Lock()
-				defer streamMu.Unlock()
-
 				mockSendStream := &FakeQUICSendStream{}
 				mockSendStream.WriteFunc = func(p []byte) (int, error) {
 					return len(p), nil


### PR DESCRIPTION
## Summary

Corrects four benchmarks that did **not measure what their names claim**, so their numbers can inform decisions instead of giving false confidence. Test-only; no production changes.

## The problems and fixes

| Benchmark | Was | Now |
|---|---|---|
| `TrackMux_LockContention/write-heavy` | Created a **new `TrackMux` per iteration** → zero shared contention | Operates on a **shared** `TrackMux` across iterations |
| `TrackMux_ServeAnnouncements` | Only constructed an `AnnouncementWriter`; never called the pipeline | Invokes the real `Announce → tree walk → channel send → SendAnnouncement → Encode` |
| `TrackMux_AnnouncementTree` | Same — writer construction only | Real fan-out across a 4-level-deep tree |
| `TrackWriter_ConcurrentOpenGroup` | Mock `openUniStreamFunc` held an **artificial mutex**, inflating contention | Non-serializing stand-in matching quic-go's concurrent `OpenUniStream` |

## Before → after (smoke; `allocs/op` reliable, `ns/op` preliminary)

- `ServeAnnouncements`: ~270 ns / **7 allocs** (no work) → ~3300 ns / **17 allocs** (real fan-out).
- `AnnouncementTree` (4-level): ~530–780 ns / 7 allocs → ~4500 ns / 17 allocs — higher than the 2-level case, reflecting the deeper walk.
- `write-heavy`: now reflects genuine `mux.mu` write-lock contention (allocs dropped because `NewTrackMux` is no longer in the loop).

## ⚠️ Production hazard discovered (not fixed here — out of scope)

While correcting the fan-out benchmarks, a real concurrency hazard was found in the **production** path: `Announce`'s non-blocking `select`/`default` (`mux.go:196–210`) closes the writer on channel overflow via `CloseWithError`, which sets `aw.actives = nil`; a concurrent `SendAnnouncement` (or `init`'s `registerEndHandler` at `announcement_writer.go:169`) then nil-dereferences. The benchmarks are structured to avoid triggering it (init barrier + per-iteration delivery rendezvous). Worth a separate bug PR.

## Notes

- Test-only (`mux_benchmark_test.go`, `track_benchmark_test.go`). No production code changed, no optimization.
- Part of a coordinated performance-measurement effort.
