### PR TITLE
ci: skip Require CHANGELOG check when the no-changelog label is present

### DIFF
--- a/.github/workflows/require-changelog.yml
+++ b/.github/workflows/require-changelog.yml
@@ -2,7 +2,7 @@ name: "Require CHANGELOG Update"
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   check-changelog:
@@ -14,13 +14,18 @@ jobs:
         with:
           fetch-depth: 0 # full history
 
+      - name: Skip CHANGELOG check (no-changelog label)
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+        run: echo "Skipping CHANGELOG requirement: 'no-changelog' label is present."
+
       - name: Verify CHANGELOG.md modification
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
         run: |
           # look for any diff lines affecting CHANGELOG.md
           if git diff --name-only "origin/${{ github.base_ref }}"...HEAD | grep -q '^CHANGELOG\.md$'; then
             echo "CHANGELOG.md has been updated."
           else
             echo "::error file=CHANGELOG.md::Pull request must include a change to CHANGELOG.md" \
-                 "(add a new entry or note the reason for omission).";
+                 "(add a new entry, or apply the 'no-changelog' label for small/non-feature tasks).";
             exit 1
           fi


### PR DESCRIPTION
## Summary

When a PR carries the `no-changelog` label, the "Require CHANGELOG Update" check now **passes without a CHANGELOG.md edit** — for small/non-feature tasks (tests, CI, docs, refactor). The job still runs on every event, so it always reports a status (compatible with required-checks in branch protection).

## Changes to `.github/workflows/require-changelog.yml`

1. Added `labeled, unlabeled` to the `pull_request` trigger types — essential, so adding/removing the label re-runs the check (otherwise labeling a blocked PR wouldn't clear it).
2. Added a "Skip CHANGELOG check" step that runs and logs when `no-changelog` is present.
3. Guarded the "Verify CHANGELOG.md modification" step with `if: !contains(... 'no-changelog')`, so it is **skipped, not failed**, when the label is present.
4. Updated the failure message to point users at the `no-changelog` label.

## Why step-level `if:` (not job-level)

Skipping at the **job** level reports `skipped`, which can block merging when the check is required in branch protection. Skipping at the **step** level keeps the job running and reporting `success`, which works whether or not the check is required.

## Self-test

This PR is itself a small CI/tooling change with no user-facing feature impact, so it carries the `no-changelog` label — exercising the new behavior end-to-end. (With the label absent it would correctly fail until `CHANGELOG.md` is updated.)

## Notes
- No production code changed.
- Related: PRs #172–#175 are now labeled `no-changelog` and will benefit from this once merged.
