### PR TITLE
test(bench): remove fmt.Sprintf noise from concurrent benchmark loops

### DIFF
--- a/moqt/mux_benchmark_test.go
+++ b/moqt/mux_benchmark_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -451,11 +452,14 @@ func BenchmarkTrackMux_LockContention(b *testing.B) {
 	ctx := context.Background()
 	handler := TrackHandlerFunc(func(tw *TrackWriter) {})
 
-	// Pre-populate with handlers
+	// Pre-populate handlers and a matching read-path pool. Path strings are
+	// built ONCE here (outside every measured loop) so alloc/CPU/GC profiles
+	// reflect mux cost, not fmt.Sprintf string construction in the hot loop.
 	const numPaths = 1000
+	readPaths := make([]BroadcastPath, numPaths)
 	for i := range numPaths {
-		path := BroadcastPath(fmt.Sprintf("/path/%d", i))
-		mux.Publish(ctx, path, handler)
+		readPaths[i] = BroadcastPath("/path/" + strconv.Itoa(i))
+		mux.Publish(ctx, readPaths[i], handler)
 	}
 
 	b.Run("read-heavy", func(b *testing.B) {
@@ -465,32 +469,41 @@ func BenchmarkTrackMux_LockContention(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			i := 0
 			for pb.Next() {
-				path := BroadcastPath(fmt.Sprintf("/path/%d", i%numPaths))
-				mux.TrackHandler(path)
+				mux.TrackHandler(readPaths[i%numPaths])
 				i++
 			}
 		})
 	})
 
 	// write-heavy exercises concurrent Publish calls against the SAME shared
-	// TrackMux (mux above), so the mux.mu write lock is genuinely contended.
-	// The previous version constructed a fresh mux per iteration, measuring
-	// allocation/initialization cost rather than lock contention.
+	// TrackMux so the mux.mu write lock is genuinely contended. Paths cycle
+	// through a fixed pool (re-registration is safe: registerHandler replaces
+	// the indexed handler and ends the previous one), keeping the measured
+	// loop allocation-free so it reports pure lock+map cost.
 	b.Run("write-heavy", func(b *testing.B) {
+		const writePool = 8192
+		writePaths := make([]BroadcastPath, writePool)
+		for i := range writePaths {
+			writePaths[i] = BroadcastPath("/new/" + strconv.Itoa(i))
+		}
 		b.ReportAllocs()
 		b.ResetTimer()
 
 		b.RunParallel(func(pb *testing.PB) {
 			i := 0
 			for pb.Next() {
-				path := BroadcastPath(fmt.Sprintf("/new/%d", i))
-				mux.Publish(ctx, path, handler)
+				mux.Publish(ctx, writePaths[i%writePool], handler)
 				i++
 			}
 		})
 	})
 
 	b.Run("mixed-contention", func(b *testing.B) {
+		const writePool = 8192
+		writePaths := make([]BroadcastPath, writePool)
+		for i := range writePaths {
+			writePaths[i] = BroadcastPath("/contention/" + strconv.Itoa(i))
+		}
 		b.ReportAllocs()
 		b.ResetTimer()
 
@@ -499,12 +512,10 @@ func BenchmarkTrackMux_LockContention(b *testing.B) {
 			for pb.Next() {
 				if i%20 == 0 {
 					// 5% writes
-					path := BroadcastPath(fmt.Sprintf("/contention/%d", i))
-					mux.Publish(ctx, path, handler)
+					mux.Publish(ctx, writePaths[i%writePool], handler)
 				} else {
 					// 95% reads
-					path := BroadcastPath(fmt.Sprintf("/path/%d", i%numPaths))
-					mux.TrackHandler(path)
+					mux.TrackHandler(readPaths[i%numPaths])
 				}
 				i++
 			}

--- a/moqt/session_benchmark_test.go
+++ b/moqt/session_benchmark_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -102,15 +103,26 @@ func BenchmarkSession_ConcurrentSubscribe(b *testing.B) {
 
 			session := newTestSession(conn)
 
+			// Pre-compute path/name pairs ONCE so the measured loop does not
+			// allocate path/name strings via fmt.Sprintf (which would pollute
+			// the alloc/CPU profile with formatting noise instead of the real
+			// subscribe cost). Subscribe IDs still advance per call, matching
+			// the original behavior.
+			const subPool = 8192
+			subPaths := make([]BroadcastPath, subPool)
+			subNames := make([]TrackName, subPool)
+			for i := range subPaths {
+				subPaths[i] = BroadcastPath("/broadcast/" + strconv.Itoa(i))
+				subNames[i] = TrackName("track_" + strconv.Itoa(i))
+			}
+
 			b.ReportAllocs()
 			b.ResetTimer()
 
 			b.RunParallel(func(pb *testing.PB) {
 				i := 0
 				for pb.Next() {
-					path := BroadcastPath(fmt.Sprintf("/broadcast/%d", i))
-					name := TrackName(fmt.Sprintf("track_%d", i))
-					_, _ = session.Subscribe(context.Background(), path, name, nil)
+					_, _ = session.Subscribe(context.Background(), subPaths[i%subPool], subNames[i%subPool], nil)
 					i++
 				}
 			})


### PR DESCRIPTION
## Summary

`BenchmarkTrackMux_LockContention` and `BenchmarkSession_ConcurrentSubscribe` built path/name strings with `fmt.Sprintf` **inside the measured loop** (after `b.ResetTimer`). That formatting dominated the alloc/CPU/GC profile — `fmt.Sprintf` was the #1 allocator (~20%) under concurrency, and GC ate ~43% of CPU — which masked the real cost of the code under test and made the concurrent path look allocation-heavy when it isn't.

Path/name pools are now pre-computed once in setup (`strconv`, outside the loop) and indexed. Re-registration in `write-heavy` is safe (`registerHandler` replaces the indexed handler and ends the previous one).

## Measured impact (count=4)

| Benchmark | Before | After |
|---|---|---|
| `LockContention/read-heavy` | 50.7 ns, **1 alloc, 21 B** | 29.0 ns, **0 allocs, 0 B** |
| `LockContention/mixed` | 451.7 ns, 2 allocs | 236 ns, ~0.45 allocs/op |
| `LockContention/write-heavy` | 2188 ns, 11 allocs | 1570 ns, **9 allocs** (real Publish cost) |
| `ConcurrentSubscribe` | ~1420 ns, 38 allocs | ~1180 ns, **34 allocs** (real subscribe cost) |

This **proves the steady-state mux read path (`TrackHandler`) is allocation-free** — the earlier "1 alloc / 21 B" was 100% path-string noise. The remaining 9/34 allocs are genuine *setup-time* production cost (Publish/Subscribe), not steady-state streaming cost.

## Notes
- Test-only; no production code changed.
- Validation: `go test ./moqt/` green, `go vet` clean, gofmt clean.
- Part of a performance-measurement accuracy effort.