### PR TITLE
fix(server): wire WebTransportHandler as default (WebTransport path was 404'ing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **moqt:** Removed the unused `Parameters` type and its `ParametersLen` / `WriteParameters` helpers from the internal `message` package; they had no production callers.
 
+### Fixed
+
+- **moqt:** `Server` now wires a `WebTransportHandler` (built from the Server's `Handler` / `TrackMux` / `Config`) as the default WebTransport handler. Previously `Server.init()` passed a nil HTTP handler, so every WebTransport request fell through to `http.DefaultServeMux` (no MOQ route) and 404'd — the Server's default WebTransport path was non-functional, and `BenchmarkBroadcastServer_HighLoad` silently reported 0 frames/op.
+
 ## [v0.15.0] - 2026-04-26
 
 ### Added

--- a/moqt/broadcast_benchmark_test.go
+++ b/moqt/broadcast_benchmark_test.go
@@ -324,8 +324,8 @@ func runBroadcastClient(ctx context.Context, serverAddr string, framesReceived, 
 	}
 }
 
-func generateTestCert(b *testing.B) tls.Certificate {
-	b.Helper()
+func generateTestCert(tb testing.TB) tls.Certificate {
+	tb.Helper()
 
 	// Use in-memory self-signed certificate for testing
 	certPEM := []byte(`-----BEGIN CERTIFICATE-----
@@ -348,7 +348,7 @@ EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
 
 	cert, err := tls.X509KeyPair(certPEM, keyPEM)
 	if err != nil {
-		b.Fatalf("failed to load test certificate: %v", err)
+		tb.Fatalf("failed to load test certificate: %v", err)
 	}
 	return cert
 }

--- a/moqt/server.go
+++ b/moqt/server.go
@@ -106,9 +106,30 @@ func (s *Server) init() {
 		s.listeners = make(map[QUICListener]struct{})
 		s.connManager = newConnManager()
 		if s.WebTransportServer == nil {
-			s.WebTransportServer = NewWebTransportServer(nil)
+			// Wire a WebTransportHandler built from the Server's fields so that,
+			// out of the box, incoming WebTransport requests upgrade to MOQ
+			// sessions and dispatch to s.Handler. Passing nil here previously
+			// fell back to http.DefaultServeMux (via webtransportgo.Server),
+			// which serves no MOQ route, so every WebTransport request 404'd.
+			s.WebTransportServer = NewWebTransportServer(s.defaultWebTransportHandler())
 		}
 	})
+}
+
+// defaultWebTransportHandler builds the http.Handler used by the default
+// WebTransportServer to upgrade incoming WebTransport requests to MOQ sessions.
+// It is wired with the Server's Config, TrackMux, Handler, FetchHandler, and
+// Logger. If Handler is nil, the returned handler falls back for every request
+// (no session is created), matching the native-QUIC "no handler configured"
+// behavior.
+func (s *Server) defaultWebTransportHandler() http.Handler {
+	return &WebTransportHandler{
+		Config:       s.Config,
+		TrackMux:     s.TrackMux,
+		Handler:      s.Handler,
+		FetchHandler: s.FetchHandler,
+		Logger:       s.Logger,
+	}
 }
 
 type serverContextKeyType struct{}
@@ -277,6 +298,12 @@ func (u *WebTransportHandler) upgradeWebTransport(w http.ResponseWriter, r *http
 // dispatches it to the configured handler. If the upgrade fails, it falls back
 // to FallbackHandler or returns a 400 response.
 func (u *WebTransportHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if u.Handler == nil {
+		// No MOQ handler configured; do not upgrade a session we cannot serve.
+		u.fallback(w, r)
+		return
+	}
+
 	conn, err := u.upgradeWebTransport(w, r)
 	if err != nil {
 		u.fallback(w, r)

--- a/moqt/server_test.go
+++ b/moqt/server_test.go
@@ -89,7 +89,7 @@ func TestServer_WebTransportDial_UpgradesSession(t *testing.T) {
 	addr := pc.LocalAddr().String()
 	_ = pc.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	var handlerCalled atomic.Bool
@@ -122,19 +122,31 @@ func TestServer_WebTransportDial_UpgradesSession(t *testing.T) {
 		select {
 		case <-done:
 		case <-time.After(3 * time.Second):
+			t.Log("server.Close() did not complete in 3s (connManager drain race; see #181)")
 		}
 	}()
-
-	// Allow the QUIC listener to bind.
-	time.Sleep(100 * time.Millisecond)
 
 	client := &Dialer{
 		TLSConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 
-	sess, err := client.Dial(ctx, "https://"+addr+"/moqt", nil)
-	require.NoError(t, err, "dial should upgrade to a MOQ session, not 404 (regression)")
-	defer sess.CloseWithError(NoError, "test done")
+	// Retry the dial until the QUIC listener is ready (it binds asynchronously
+	// in the ListenAndServe goroutine) or the window expires. A fixed sleep
+	// here would race with listener startup under CI load.
+	var sess *Session
+	require.Eventually(t, func() bool {
+		s, err := client.Dial(ctx, "https://"+addr+"/moqt", nil)
+		if err != nil {
+			return false
+		}
+		sess = s
+		return true
+	}, 5*time.Second, 50*time.Millisecond, "dial should upgrade to a MOQ session once the listener is ready")
+	defer func() {
+		if sess != nil {
+			sess.CloseWithError(NoError, "test done")
+		}
+	}()
 
 	require.Eventually(t, handlerCalled.Load, time.Second, 10*time.Millisecond,
 		"server Handler must be invoked for the upgraded session")

--- a/moqt/server_test.go
+++ b/moqt/server_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -34,6 +35,44 @@ func TestServer_Init(t *testing.T) {
 	assert.NotNil(t, s.listeners)
 	assert.NotNil(t, s.connManager)
 	assert.NotNil(t, s.WebTransportServer)
+}
+
+// TestServer_defaultWebTransportHandler_WiresServerFields guards against the
+// regression where Server.init() passed a nil HTTP handler to
+// NewWebTransportServer, causing every WebTransport request to 404. The default
+// handler must now carry the Server's Handler so upgraded sessions dispatch.
+func TestServer_defaultWebTransportHandler_WiresServerFields(t *testing.T) {
+	h := HandleFunc(func(*Session) {})
+	cfg := &Config{}
+	mux := NewTrackMux(0)
+
+	s := &Server{Config: cfg, TrackMux: mux, Handler: h}
+	got := s.defaultWebTransportHandler()
+
+	wth, ok := got.(*WebTransportHandler)
+	require.True(t, ok, "default handler must be a *WebTransportHandler")
+	assert.NotNil(t, wth.Handler, "Handler must be wired (was nil -> 404 before the fix)")
+	_, isHandleFunc := wth.Handler.(HandleFunc)
+	assert.True(t, isHandleFunc, "Handler must be the Server's HandleFunc")
+	assert.Equal(t, cfg, wth.Config)
+	assert.Equal(t, mux, wth.TrackMux)
+}
+
+// TestWebTransportHandler_ServeHTTP_NilHandlerFallsBack ensures a
+// WebTransportHandler with no configured Handler does not panic (the previous
+// path called u.Handler.ServeMOQ unconditionally) and instead falls back.
+func TestWebTransportHandler_ServeHTTP_NilHandlerFallsBack(t *testing.T) {
+	u := &WebTransportHandler{} // Handler and FallbackHandler are both nil
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodConnect, "/broadcast", nil)
+
+	require.NotPanics(t, func() {
+		u.ServeHTTP(rr, req)
+	})
+
+	// With no Handler and no FallbackHandler, the fallback returns 400.
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
 func TestServer_connContext_AppliesCustomAndInjectsServer(t *testing.T) {

--- a/moqt/server_test.go
+++ b/moqt/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -73,6 +74,70 @@ func TestWebTransportHandler_ServeHTTP_NilHandlerFallsBack(t *testing.T) {
 
 	// With no Handler and no FallbackHandler, the fallback returns 400.
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+// TestServer_WebTransportDial_UpgradesSession is an end-to-end regression
+// test. Before the fix, Server.init() wired a nil HTTP handler, so a
+// WebTransport dial to the server 404'd (see BenchmarkStreamIo_RealQUIC's
+// b.Skipf and BenchmarkBroadcastServer_HighLoad reporting 0 frames/op).
+// After the fix, the default WebTransportHandler upgrades the request and
+// dispatches the upgraded session to the Server's Handler.
+func TestServer_WebTransportDial_UpgradesSession(t *testing.T) {
+	// Grab a free UDP port for the QUIC listener.
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := pc.LocalAddr().String()
+	_ = pc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var handlerCalled atomic.Bool
+	server := &Server{
+		Addr: addr,
+		TLSConfig: &tls.Config{
+			NextProtos:         []string{NextProtoH3, NextProtoMOQ},
+			Certificates:       []tls.Certificate{generateTestCert(t)},
+			InsecureSkipVerify: true,
+		},
+		Handler: HandleFunc(func(sess *Session) {
+			handlerCalled.Store(true)
+			<-sess.Context().Done()
+		}),
+	}
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, ErrServerClosed) {
+			t.Logf("server ListenAndServe: %v", err)
+		}
+	}()
+	// Close the server with a bounded wait. Server.Close() blocks on
+	// <-connManager.Done(), and a peer connection closed immediately before
+	// Close is not always removed from the connManager in time, so an
+	// unbounded Close would hang the test. That drain race is tracked
+	// separately; here we just keep the test from hanging.
+	defer func() {
+		done := make(chan struct{})
+		go func() { _ = server.Close(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+		}
+	}()
+
+	// Allow the QUIC listener to bind.
+	time.Sleep(100 * time.Millisecond)
+
+	client := &Dialer{
+		TLSConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	sess, err := client.Dial(ctx, "https://"+addr+"/moqt", nil)
+	require.NoError(t, err, "dial should upgrade to a MOQ session, not 404 (regression)")
+	defer sess.CloseWithError(NoError, "test done")
+
+	require.Eventually(t, handlerCalled.Load, time.Second, 10*time.Millisecond,
+		"server Handler must be invoked for the upgraded session")
 }
 
 func TestServer_connContext_AppliesCustomAndInjectsServer(t *testing.T) {


### PR DESCRIPTION
## Problem

`Server.init()` passed a **nil** HTTP handler to `NewWebTransportServer`, so `webtransportgo.Server` fell back to `http.DefaultServeMux` — which serves no MOQ route. Every WebTransport request to a `Server` **404'd**. The fully-implemented `WebTransportHandler` (which upgrades requests → MOQ sessions) was never wired as the default; it was only used when constructed manually in the examples. As a result:
- The Server's default WebTransport path was non-functional.
- `BenchmarkBroadcastServer_HighLoad` silently reported **0 frames/op** (no \`b.Fatal\`).
- \`BenchmarkStreamIo_RealQUIC\` \`b.Skipf\`'d on dial failure.

## Fix

`init()` now builds a \`WebTransportHandler\` from the Server's \`Config\`/\`TrackMux\`/\`Handler\`/\`FetchHandler\`/\`Logger\` and passes it to \`NewWebTransportServer\`. \`WebTransportHandler.ServeHTTP\` also guards against a nil \`Handler\` (falls back instead of panicking), matching the native-QUIC \"no handler configured\" behavior.

The context flow was already correct: \`ServeQUICConn\` → \`connContext\` injects the \`connManager\` into the conn context, \`webtransportgo.Server\` propagates it via \`H3.ConnContext\`, and \`WebTransportHandler.ServeHTTP\` reads it — so upgraded sessions are tracked properly.

## Validation

- **Unit:** \`TestServer_defaultWebTransportHandler_WiresServerFields\` (handler wired with the Server's Handler), \`TestWebTransportHandler_ServeHTTP_NilHandlerFallsBack\` (no panic on nil Handler).
- **End-to-end:** \`TestServer_WebTransportDial_UpgradesSession\` — a real-QUIC dial against \`Server.ListenAndServe()\` now upgrades to a MOQ session and invokes the Handler (passes reliably, ~3.2s). This was impossible before the fix.
- \`go test ./moqt/\` green; \`go vet\` clean; gofmt clean.

## Follow-ups found (not in this PR)

1. **\`Server.Close()\` can hang** on \`<-connManager.Done()\` when a peer connection closed immediately before \`Close\` isn't drained in time. The integration test bounds it with a timeout; a real fix to the drain race is separate.
2. **\`BenchmarkBroadcastServer_HighLoad\` / \`BenchmarkStreamIo_RealQUIC\`** still need their setup rewritten (the \`setupBroadcastServerWithFrameSize\` helper builds a useless \`net/http\` server and never sets \`moqtServer.Handler\`). Now that the dial works, a benchmark can be written against the fixed path — separate PR.

## Notes
- Real behavior fix; CHANGELOG entry added under \`### Fixed\`.