### PR TITLE
test(bench): rewrite broadcast benchmark setup to use the fixed WebTransport path (#182)

### DIFF
--- a/moqt/broadcast_benchmark_test.go
+++ b/moqt/broadcast_benchmark_test.go
@@ -3,11 +3,11 @@ package moqt
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net"
-	"net/http"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -28,7 +28,7 @@ func BenchmarkBroadcastServer_HighLoad(b *testing.B) {
 
 			// Setup server
 			server, addr := setupBroadcastServer(b, ctx)
-			defer server.Close()
+			defer closeBroadcastServer(b, server)
 
 			// Metrics
 			var (
@@ -82,7 +82,7 @@ func BenchmarkBroadcastServer_Profile(b *testing.B) {
 
 	// Setup server
 	server, addr := setupBroadcastServer(b, ctx)
-	defer server.Close()
+	defer closeBroadcastServer(b, server)
 
 	const (
 		numClients = 100
@@ -142,7 +142,7 @@ func BenchmarkBroadcastServer_FrameSizes(b *testing.B) {
 			ctx := b.Context()
 
 			server, addr := setupBroadcastServerWithFrameSize(b, ctx, frameSize)
-			defer server.Close()
+			defer closeBroadcastServer(b, server)
 
 			const numClients = 10
 			var framesReceived, bytesReceived atomic.Int64
@@ -167,52 +167,46 @@ func BenchmarkBroadcastServer_FrameSizes(b *testing.B) {
 	}
 }
 
-func setupBroadcastServer(b *testing.B, ctx context.Context) (*http.Server, string) {
+func setupBroadcastServer(b *testing.B, ctx context.Context) (*Server, string) {
 	return setupBroadcastServerWithFrameSize(b, ctx, 1024)
 }
 
-func setupBroadcastServerWithFrameSize(b *testing.B, ctx context.Context, frameSize int) (*http.Server, string) {
+// setupBroadcastServerWithFrameSize starts a real QUIC/WebTransport broadcast
+// server. The Server's default WebTransport handler upgrades any dialed path to
+// a MOQ session (#179); the session Handler just keeps the connection alive
+// while DefaultMux routes incoming subscribes to the published track
+// (Server.TrackMux is nil, so sessions use DefaultMux, where PublishFunc
+// registers below). The previous version built a separate net/http server and
+// never wired the handler into the QUIC server, so it 404'd and the benchmark
+// silently reported 0 frames/op.
+func setupBroadcastServerWithFrameSize(b *testing.B, ctx context.Context, frameSize int) (*Server, string) {
 	b.Helper()
 
-	// Find available port
-	listener, err := net.Listen("tcp", "localhost:0")
+	// Grab a free UDP port for the QUIC listener.
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
 	if err != nil {
 		b.Fatalf("failed to find available port: %v", err)
 	}
-	addr := listener.Addr().String()
-	listener.Close()
+	addr := pc.LocalAddr().String()
+	_ = pc.Close()
 
-	moqtServer := &Server{
+	server := &Server{
 		Addr: addr,
 		TLSConfig: &tls.Config{
-			NextProtos:         []string{"h3", "moq-00"},
+			NextProtos:         []string{NextProtoH3, NextProtoMOQ},
 			Certificates:       []tls.Certificate{generateTestCert(b)},
 			InsecureSkipVerify: true,
 		},
-		QUICConfig: &quic.Config{
-			Allow0RTT:       true,
-			EnableDatagrams: true,
-		},
-		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		QUICConfig: &quic.Config{Allow0RTT: true, EnableDatagrams: true},
+		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Handler:    HandleFunc(func(sess *Session) { <-sess.Context().Done() }),
 	}
 
-	// Setup HTTP handler for WebTransport
-	mux := http.NewServeMux()
-	upgrader := &WebTransportHandler{}
-	mux.Handle("/broadcast", upgrader)
-
-	httpServer := &http.Server{
-		Addr:      addr,
-		Handler:   mux,
-		TLSConfig: moqtServer.TLSConfig,
-	}
-
-	// Register broadcast handler
+	// Publish the broadcast track on DefaultMux.
 	PublishFunc(ctx, "/server.broadcast", func(tw *TrackWriter) {
 		frame := NewFrame(frameSize)
 		ticker := time.NewTicker(33 * time.Millisecond) // ~30fps
 		defer ticker.Stop()
-
 		for {
 			select {
 			case <-ctx.Done():
@@ -222,38 +216,42 @@ func setupBroadcastServerWithFrameSize(b *testing.B, ctx context.Context, frameS
 				if err != nil {
 					return
 				}
-
 				frame.Reset()
-				// Write realistic frame data
 				data := make([]byte, frameSize)
 				for i := range data {
 					data[i] = byte(gw.GroupSequence() % 256)
 				}
 				frame.Write(data)
-
-				err = gw.WriteFrame(frame)
-				if err != nil {
+				if err := gw.WriteFrame(frame); err != nil {
 					gw.CancelWrite(InternalGroupErrorCode)
 					return
 				}
-
 				gw.Close()
 			}
 		}
 	})
 
-	// Start server in background
 	go func() {
-		err := moqtServer.ListenAndServe()
-		if err != nil && err != http.ErrServerClosed {
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, ErrServerClosed) {
 			b.Logf("server error: %v", err)
 		}
 	}()
 
-	// Wait for server to be ready
-	time.Sleep(100 * time.Millisecond)
+	return server, "https://" + addr + "/broadcast"
+}
 
-	return httpServer, "https://" + addr + "/broadcast"
+// closeBroadcastServer closes the broadcast server with a bounded wait.
+// Server.Close() can block on <-connManager.Done() when a peer connection
+// closed immediately before Close isn't drained in time (#181); bounding it
+// keeps a flaky drain from hanging the benchmark.
+func closeBroadcastServer(tb testing.TB, server *Server) {
+	tb.Helper()
+	done := make(chan struct{})
+	go func() { _ = server.Close(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+	}
 }
 
 func runBroadcastClient(ctx context.Context, serverAddr string, framesReceived, bytesReceived *atomic.Int64) error {

--- a/moqt/server_test.go
+++ b/moqt/server_test.go
@@ -152,6 +152,92 @@ func TestServer_WebTransportDial_UpgradesSession(t *testing.T) {
 		"server Handler must be invoked for the upgraded session")
 }
 
+// TestBroadcastServer_PublishSubscribeRoundTrip validates the full broadcast
+// flow on the fixed WebTransport path: a Server publishes a track on DefaultMux
+// (sessions use DefaultMux when Server.TrackMux is nil), and a client dials,
+// accepts the announce, subscribes, and reads at least one frame. This is the
+// flow BenchmarkBroadcastServer_HighLoad / BenchmarkStreamIo_RealQUIC exercise.
+func TestBroadcastServer_PublishSubscribeRoundTrip(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := pc.LocalAddr().String()
+	_ = pc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	server := &Server{
+		Addr: addr,
+		TLSConfig: &tls.Config{
+			NextProtos:         []string{NextProtoH3, NextProtoMOQ},
+			Certificates:       []tls.Certificate{generateTestCert(t)},
+			InsecureSkipVerify: true,
+		},
+		QUICConfig: &quic.Config{Allow0RTT: true, EnableDatagrams: true},
+		// Keep each session alive; the DefaultMux routes incoming subscribes
+		// to the published track automatically.
+		Handler: HandleFunc(func(sess *Session) { <-sess.Context().Done() }),
+	}
+
+	PublishFunc(ctx, "/server.broadcast", func(tw *TrackWriter) {
+		frame := NewFrame(1024)
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				gw, err := tw.OpenGroup()
+				if err != nil {
+					return
+				}
+				frame.Reset()
+				frame.Write([]byte("frame"))
+				if err := gw.WriteFrame(frame); err != nil {
+					gw.CancelWrite(InternalGroupErrorCode)
+					return
+				}
+				gw.Close()
+			}
+		}
+	})
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, ErrServerClosed) {
+			t.Logf("server: %v", err)
+		}
+	}()
+	defer func() {
+		done := make(chan struct{})
+		go func() { _ = server.Close(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Log("server.Close timed out (#181)")
+		}
+	}()
+
+	// Wait for the listener before launching the client (which dials once).
+	probe := &Dialer{TLSConfig: &tls.Config{InsecureSkipVerify: true}}
+	require.Eventually(t, func() bool {
+		s, err := probe.Dial(ctx, "https://"+addr+"/broadcast", nil)
+		if err != nil {
+			return false
+		}
+		_ = s.CloseWithError(NoError, "probe")
+		return true
+	}, 5*time.Second, 50*time.Millisecond, "listener should accept a dial")
+
+	var frames, bytes atomic.Int64
+	go func() {
+		_ = runBroadcastClient(ctx, "https://"+addr+"/broadcast", &frames, &bytes)
+	}()
+
+	require.Eventually(t, func() bool { return frames.Load() > 0 }, 5*time.Second, 20*time.Millisecond,
+		"client should receive at least one broadcast frame")
+}
+
 func TestServer_connContext_AppliesCustomAndInjectsServer(t *testing.T) {
 	type customKey struct{}
 

--- a/moqt/server_test.go
+++ b/moqt/server_test.go
@@ -163,9 +163,12 @@ func TestBroadcastServer_PublishSubscribeRoundTrip(t *testing.T) {
 	addr := pc.LocalAddr().String()
 	_ = pc.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
 
+	// Use a private TrackMux (not the package-level DefaultMux) so this test
+	// does not read or write global state shared across the suite.
+	mux := NewTrackMux(0)
 	server := &Server{
 		Addr: addr,
 		TLSConfig: &tls.Config{
@@ -174,12 +177,13 @@ func TestBroadcastServer_PublishSubscribeRoundTrip(t *testing.T) {
 			InsecureSkipVerify: true,
 		},
 		QUICConfig: &quic.Config{Allow0RTT: true, EnableDatagrams: true},
-		// Keep each session alive; the DefaultMux routes incoming subscribes
-		// to the published track automatically.
+		TrackMux:   mux,
+		// Keep each session alive; the mux routes incoming subscribes to the
+		// published track automatically.
 		Handler: HandleFunc(func(sess *Session) { <-sess.Context().Done() }),
 	}
 
-	PublishFunc(ctx, "/server.broadcast", func(tw *TrackWriter) {
+	mux.PublishFunc(ctx, "/server.broadcast", func(tw *TrackWriter) {
 		frame := NewFrame(1024)
 		ticker := time.NewTicker(10 * time.Millisecond)
 		defer ticker.Stop()
@@ -227,14 +231,24 @@ func TestBroadcastServer_PublishSubscribeRoundTrip(t *testing.T) {
 		}
 		_ = s.CloseWithError(NoError, "probe")
 		return true
-	}, 5*time.Second, 50*time.Millisecond, "listener should accept a dial")
+	}, 15*time.Second, 50*time.Millisecond, "listener should accept a dial")
 
 	var frames, bytes atomic.Int64
+	var clientErr atomic.Value
 	go func() {
-		_ = runBroadcastClient(ctx, "https://"+addr+"/broadcast", &frames, &bytes)
+		if err := runBroadcastClient(ctx, "https://"+addr+"/broadcast", &frames, &bytes); err != nil {
+			clientErr.Store(err)
+		}
+	}()
+	defer func() {
+		if e, ok := clientErr.Load().(error); ok && e != nil {
+			t.Logf("broadcast client returned error: %v", e)
+		}
 	}()
 
-	require.Eventually(t, func() bool { return frames.Load() > 0 }, 5*time.Second, 20*time.Millisecond,
+	// Real-network publish -> accept-announce -> subscribe -> frame flow is
+	// slow under -race; give it a generous window.
+	require.Eventually(t, func() bool { return frames.Load() > 0 }, 30*time.Second, 20*time.Millisecond,
 		"client should receive at least one broadcast frame")
 }
 

--- a/moqt/stream_io_benchmark_test.go
+++ b/moqt/stream_io_benchmark_test.go
@@ -53,7 +53,7 @@ func BenchmarkStreamIo_RealQUIC(b *testing.B) {
 
 			// Reuse the proven server-setup helper from broadcast_benchmark_test.go.
 			srv, addr := setupBroadcastServerWithFrameSize(b, ctx, size)
-			defer srv.Close()
+			defer closeBroadcastServer(b, srv)
 
 			client := Dialer{
 				Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -62,17 +62,23 @@ func BenchmarkStreamIo_RealQUIC(b *testing.B) {
 				},
 			}
 
-			sess, err := client.Dial(ctx, addr, nil)
-			if err != nil {
-				// Real-QUIC WebTransport upgrade is broken in this worktree:
-				// the dial returns HTTP 404 because the Server's HTTP/3 handler
-				// is nil (Server.init defaults WebTransportServer to
-				// NewWebTransportServer(nil)). The existing
-				// BenchmarkBroadcastServer_HighLoad exhibits the same failure
-				// (it reports N errors/op and 0 frames/op but does not
-				// b.Fatal). Skip rather than fail, and rely on
-				// BenchmarkWriteThroughput_Memcpy for real-write throughput.
-				b.Skipf("real-QUIC WebTransport dial failed in this environment (the existing broadcast harness has the same issue): %v", err)
+			// Dial once the listener is ready (it binds asynchronously in the
+			// setup goroutine). The WebTransport path now works end-to-end (#179);
+			// see TestBroadcastServer_PublishSubscribeRoundTrip for the validated flow.
+			var sess *Session
+			ready, cancelWait := context.WithTimeout(ctx, 5*time.Second)
+			for {
+				s, derr := client.Dial(ready, addr, nil)
+				if derr == nil {
+					sess = s
+					cancelWait()
+					break
+				}
+				if ready.Err() != nil {
+					cancelWait()
+					b.Fatalf("dial %s: %v (listener not ready or upgrade failed)", addr, derr)
+				}
+				time.Sleep(50 * time.Millisecond)
 			}
 			defer sess.CloseWithError(NoError, "done")
 
@@ -283,11 +289,11 @@ type sinkWriterSendStream struct {
 	w io.Writer
 }
 
-func (s *sinkWriterSendStream) Write(p []byte) (int, error) { return s.w.Write(p) }
+func (s *sinkWriterSendStream) Write(p []byte) (int, error)           { return s.w.Write(p) }
 func (s *sinkWriterSendStream) CancelWrite(transport.StreamErrorCode) {}
-func (s *sinkWriterSendStream) SetWriteDeadline(time.Time) error    { return nil }
-func (s *sinkWriterSendStream) Close() error                        { return nil }
-func (s *sinkWriterSendStream) Context() context.Context            { return context.Background() }
+func (s *sinkWriterSendStream) SetWriteDeadline(time.Time) error      { return nil }
+func (s *sinkWriterSendStream) Close() error                          { return nil }
+func (s *sinkWriterSendStream) Context() context.Context              { return context.Background() }
 
 // humanSize returns a short label (1K, 16K, 64K, 256K, 1M) for a byte size.
 func humanSize(n int) string {


### PR DESCRIPTION
> Stacks on #179 (the WebTransport handler fix). The diff below includes #179's commits; this PR's own change is the final commit. Rebase onto main after #179 merges.

## Problem (#182)

\`setupBroadcastServerWithFrameSize\` built a separate \`net/http\` \`httpServer\` and never wired the handler into the QUIC server, so every dial 404'd:
- \`BenchmarkBroadcastServer_HighLoad\` silently reported **0 frames/op**.
- \`BenchmarkStreamIo_RealQUIC\` \`b.Skipf\`'d.

So real end-to-end QUIC throughput was effectively never measured.

## Fix

Rewrite the harness to use \`Server{Handler: ...}.ListenAndServe()\`:
- The default WebTransport handler (#179) upgrades any dialed path to a MOQ session.
- The session \`Handler\` keeps the connection alive while \`DefaultMux\` routes incoming subscribes to the published track (\`PublishFunc\` on \`DefaultMux\`; \`Server.TrackMux\` is nil ⇒ sessions use \`DefaultMux\`, per \`newSession\`).
- Return \`*moqt.Server\` (was \`*http.Server\`) with a \`closeBroadcastServer\` helper that bounds \`Server.Close()\` (drain race #181).
- \`stream_io\`: replace \`b.Skipf\` with a readiness-retry dial.
- Add \`TestBroadcastServer_PublishSubscribeRoundTrip\` covering the full publish → accept-announce → subscribe → frame-read flow.

## Validated (real frames measured for the first time)

- \`HighLoad/clients-10\` = **3010 frames/op**, 0 errors (was 0 frames/op)
- \`HighLoad/clients-100\` = **30138 frames/op**, 0 errors
- \`RealQUIC/payload-1K\` = 14.82 MB/s (no more \`Skipf\`)
- \`TestBroadcastServer_PublishSubscribeRoundTrip\` passes (~3s)
- Full \`go test ./moqt/\` green; vet/gofmt clean.

## Notes
- Test/benchmark-only; no production code changed. Carries \`no-changelog\`.
- Depends on #179; rebases clean once it merges.