### PR TITLE
fix(server): Server.Close() no longer hangs with active connections (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **moqt:** `Server` now wires a `WebTransportHandler` (built from the Server's `Handler` / `TrackMux` / `Config`) as the default WebTransport handler. Previously `Server.init()` passed a nil HTTP handler, so every WebTransport request fell through to `http.DefaultServeMux` (no MOQ route) and 404'd — the Server's default WebTransport path was non-functional, and `BenchmarkBroadcastServer_HighLoad` silently reported 0 frames/op.
+- **moqt:** `Server.Close()` no longer hangs when connections are active. Previously the "terminate sessions" loop had an empty body (active connections were never closed) and sessions were removed from the connection manager only on an explicit, successful `CloseWithError` — so peer-/force-closed sessions leaked and `Server.Close()`/`Shutdown()` blocked forever on `<-connManager.Done()`. `Server.Close()` now closes active connections, the serving paths (`WebTransportHandler.ServeHTTP`, `handleNativeQUIC`) clean up the session when the Handler returns, and `Session.CloseWithError` always removes the connection from the manager.
 
 ## [v0.15.0] - 2026-04-26
 

--- a/moqt/conn_manager.go
+++ b/moqt/conn_manager.go
@@ -56,6 +56,20 @@ func (s *connManager) countSessions() int {
 	return len(s.connections)
 }
 
+// conns returns a snapshot of the current connections. The returned slice may
+// be iterated while connections are concurrently added or removed (e.g. during
+// Server.Close/Shutdown, where closing a connection triggers removeConn on the
+// live map); iterating the map directly in those paths is a data race.
+func (s *connManager) conns() []StreamConn {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	conns := make([]StreamConn, 0, len(s.connections))
+	for c := range s.connections {
+		conns = append(conns, c)
+	}
+	return conns
+}
+
 func (s *connManager) Done() <-chan struct{} {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/moqt/server.go
+++ b/moqt/server.go
@@ -318,6 +318,10 @@ func (u *WebTransportHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 
 	sess := newSession(conn, u.TrackMux, manager, u.Config, u.FetchHandler, nil, u.Logger)
+	// Ensure the session is cleaned up (conn removed from the manager) when
+	// the Handler returns, even if it did not call CloseWithError itself (e.g.
+	// the peer closed the connection). Idempotent.
+	defer sess.CloseWithError(NoError, "session ended")
 
 	u.Handler.ServeMOQ(sess)
 }
@@ -343,6 +347,9 @@ func (f HandleFunc) ServeMOQ(sess *Session) {
 func (s *Server) handleNativeQUIC(conn StreamConn) error {
 	if s.Handler != nil {
 		sess := newSession(conn, s.TrackMux, s.connManager, s.Config, s.FetchHandler, nil, s.Logger)
+		// Clean up the session when the Handler returns (idempotent if the
+		// Handler already closed it), so the conn is removed from the manager.
+		defer sess.CloseWithError(NoError, "session ended")
 		s.Handler.ServeMOQ(sess)
 	}
 	return fmt.Errorf("no native QUIC handler configured")
@@ -457,11 +464,13 @@ func (s *Server) Close() error {
 	connectionManager := s.connManager
 	s.connManager = nil
 
-	// Terminate all active sessions
+	// Terminate all active connections so their sessions unblock and run their
+	// cleanup (ServeHTTP/handleNativeQUIC defer CloseWithError -> removeConn),
+	// draining the connManager. Previously this goroutine body was empty, so
+	// active connections were never closed and <-Done() hung forever (#181).
 	for conn := range connectionManager.connections {
-		// Close sessions concurrently; log potential errors.
 		go func(conn StreamConn) {
-
+			_ = conn.CloseWithError(transport.ConnErrorCode(NoError), "server shutdown")
 		}(conn)
 	}
 

--- a/moqt/server.go
+++ b/moqt/server.go
@@ -468,7 +468,7 @@ func (s *Server) Close() error {
 	// cleanup (ServeHTTP/handleNativeQUIC defer CloseWithError -> removeConn),
 	// draining the connManager. Previously this goroutine body was empty, so
 	// active connections were never closed and <-Done() hung forever (#181).
-	for conn := range connectionManager.connections {
+	for _, conn := range connectionManager.conns() {
 		go func(conn StreamConn) {
 			_ = conn.CloseWithError(transport.ConnErrorCode(NoError), "server shutdown")
 		}(conn)
@@ -524,7 +524,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	connManager := s.connManager
 	s.connManager = nil
 
-	for conn := range connManager.connections {
+	for _, conn := range connManager.conns() {
 		// Send goaway to sessions concurrently; log potential errors.
 		go func(conn StreamConn) {
 			err := s.goAway(ctx, conn)

--- a/moqt/server_test.go
+++ b/moqt/server_test.go
@@ -408,6 +408,64 @@ func TestServer_Close_ClosesListenersAndWTServer(t *testing.T) {
 	assert.True(t, closed)
 }
 
+// TestServer_Close_ReturnsWithActiveSession is a regression test for #181:
+// Server.Close() previously hung on <-connManager.Done() because the
+// "terminate sessions" loop had an empty goroutine body (active connections
+// were never closed) and peer-/force-closed sessions were never removed from
+// the manager. With the fix, Close() closes active connections (so their
+// sessions unblock and clean up) and returns promptly.
+func TestServer_Close_ReturnsWithActiveSession(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := pc.LocalAddr().String()
+	_ = pc.Close()
+
+	server := &Server{
+		Addr: addr,
+		TLSConfig: &tls.Config{
+			NextProtos:         []string{NextProtoH3, NextProtoMOQ},
+			Certificates:       []tls.Certificate{generateTestCert(t)},
+			InsecureSkipVerify: true,
+		},
+		Handler: HandleFunc(func(sess *Session) { <-sess.Context().Done() }),
+	}
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, ErrServerClosed) {
+			t.Logf("server: %v", err)
+		}
+	}()
+
+	// Dial and keep the client session open so the server has an ACTIVE session.
+	client := &Dialer{TLSConfig: &tls.Config{InsecureSkipVerify: true}}
+	var active *Session
+	require.Eventually(t, func() bool {
+		s, derr := client.Dial(context.Background(), "https://"+addr+"/moqt", nil)
+		if derr != nil {
+			return false
+		}
+		active = s
+		return true
+	}, 5*time.Second, 50*time.Millisecond, "listener should accept a dial")
+	defer func() {
+		if active != nil {
+			_ = active.CloseWithError(NoError, "test done")
+		}
+	}()
+
+	// Server.Close() must return promptly even with the active session.
+	done := make(chan struct{})
+	go func() {
+		_ = server.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Server.Close() hung with an active connection (regression #181)")
+	}
+}
+
 func TestServer_Shutdown_NoSessions(t *testing.T) {
 	s := &Server{}
 	s.init()

--- a/moqt/session.go
+++ b/moqt/session.go
@@ -187,6 +187,16 @@ func (s *Session) CloseWithError(code SessionErrorCode, msg string) error {
 	}
 	s.isTerminating.Store(true)
 
+	// Always remove the conn from the manager exactly once, even if the
+	// underlying conn.CloseWithError fails (e.g. the peer already closed it).
+	// Without this, a peer-closed session leaks in the connManager and
+	// Server.Close()/Shutdown() hang on <-connManager.Done().
+	if s.connManager != nil {
+		connManager := s.connManager
+		s.connManager = nil
+		defer connManager.removeConn(s.conn)
+	}
+
 	err := s.conn.CloseWithError(transport.ConnErrorCode(code), msg)
 	if err != nil {
 		if appErr, ok := errors.AsType[*transport.ApplicationError](err); ok {
@@ -203,13 +213,6 @@ func (s *Session) CloseWithError(code SessionErrorCode, msg string) error {
 
 	close(s.probeResponseCh)
 	close(s.probeTargetsCh)
-
-	if s.connManager != nil {
-		connManager := s.connManager
-		s.connManager = nil
-
-		connManager.removeConn(s.conn)
-	}
 
 	return nil
 }


### PR DESCRIPTION
## Problem (#181)

`Server.Close()` / `Shutdown()` blocked forever on `<-connManager.Done()` due to three compounding bugs:

1. **Empty shutdown loop** — `Server.Close()`'s "terminate sessions" loop spawned goroutines with **empty bodies**, so active connections were never closed.
2. **Cleanup only on explicit close** — `removeConn` lived only in `Session.CloseWithError`, and neither `WebTransportHandler.ServeHTTP` nor `handleNativeQUIC` called it after the Handler returned. So a **peer-closed** session (Handler returns on ctx-done) leaked in the connManager.
3. **Early return skipped cleanup** — `CloseWithError` returned before `removeConn` if `conn.CloseWithError` errored (e.g. peer already closed).

Surfaced by the real-QUIC tests added in #179/#184 (which had to bound `Close()` with a timeout to avoid hanging).

## Fix

- `Server.Close()` now closes each active connection (so its session unblocks and cleans up).
- `ServeHTTP` / `handleNativeQUIC` `defer sess.CloseWithError` after the Handler returns (idempotent).
- `Session.CloseWithError` removes the conn via `defer`, so cleanup happens even when the underlying conn close fails.

## Validation

- New `TestServer_Close_ReturnsWithActiveSession` keeps a client session **open** and asserts `Server.Close()` returns within 5s (previously hung forever). Passes in ~0.01s with the fix.
- Full `go test ./moqt/` green; `go vet` / gofmt clean.

## Notes
- Real behavior/shutdown fix; CHANGELOG `### Fixed` entry added.
- The bounded `Close()` guards in #179/#184's tests are now harmless (no longer hit) — left as defense-in-depth.