### PR TITLE
ci(bench): restore microbenchmark signal; split slow integration suite

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -68,9 +68,10 @@ jobs:
           # and the trackReaders map at session.go ~732).
           go test -race -count=1 -timeout=10m ./moqt/...
 
-  # Capture a benchmark baseline on main / tags / manual dispatch, and compare
-  # PRs against the latest baseline using benchstat. Bounded -benchtime keeps
-  # CI affordable while -count=10 gives benchstat enough samples for variance.
+  # Microbenchmark baseline + regression comparison. Captures a baseline on
+  # main / tags / manual dispatch and compares PRs against it with benchstat.
+  # Microbenchmarks only (fast, stable signal); the slow broadcast/QUIC
+  # integration suite runs in the benchmark-integration job below.
   benchmark:
     runs-on: ubuntu-latest
     steps:
@@ -122,14 +123,22 @@ jobs:
           fi
           test -f baseline/bench-baseline.txt && echo "have_baseline=true" >> "$GITHUB_OUTPUT" || true
 
-      - name: Run benchmarks
+      - name: Run benchmarks (micro)
+        # Microbenchmarks only: -skip excludes the slow broadcast/QUIC
+        # integration benchmarks (BenchmarkBroadcastServer_* and
+        # BenchmarkStreamIo_RealQUIC, run separately in benchmark-integration)
+        # so this job stays fast and relevant for wire-layer / encode-decode PRs.
         # -run=^$ skips all tests so only benchmarks execute.
         # -benchmem reports allocs/op and B/op.
+        # -benchtime=1s lets Go pick a high iteration count per sample, so ns/op
+        #   has a stable mean. (At -benchtime=1x a single-iteration sample had
+        #   ~150% CV on microbenchmarks — unusable for benchstat. 1s vs 1x is
+        #   identical for the excluded 10s/op integration benchmarks, so raising
+        #   it costs nothing there.)
         # -count=10 gives benchstat enough samples to estimate variance.
-        # -benchtime is bounded so the job stays affordable.
         # -timeout guards against a runaway benchmark.
         run: |
-          go test -run='^$' -bench=. -benchmem -benchtime=1x -count=10 -timeout=20m ./moqt/... | tee bench-new.txt
+          go test -run='^$' -bench=. -skip='BroadcastServer|StreamIo_RealQUIC' -benchmem -benchtime=1s -count=10 -timeout=15m ./moqt/... | tee bench-new.txt
 
       - name: Compare against baseline (PRs only)
         if: github.event_name == 'pull_request' && steps.baseline.outputs.have_baseline == 'true'
@@ -162,3 +171,31 @@ jobs:
           name: bench-pr-${{ github.event.pull_request.number }}
           path: bench-new.txt
           retention-days: 14
+
+  # Slow broadcast/QUIC integration benchmarks. Each op is a multi-second
+  # aggregate (frames/sec, MB/s) that is stable across samples, so -benchtime=1x
+  # is appropriate here (unlike the microbenchmarks above). Runs only on push
+  # (main/tags) and manual dispatch — NOT on PRs — because it costs ~10-19
+  # runner-minutes and is irrelevant to wire-layer micro-PRs. Uploaded for trend
+  # archival only; no benchstat gate.
+  benchmark-integration:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.26.0"
+
+      - name: Run integration benchmarks
+        run: |
+          go test -run='^$' -bench='BroadcastServer|StreamIo_RealQUIC' -benchmem -benchtime=1x -count=5 -timeout=25m ./moqt/... | tee bench-integration.txt
+
+      - name: Upload integration bench output
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-integration
+          path: bench-integration.txt
+          retention-days: 90

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -199,21 +199,33 @@ func (t Test) Coverage() error {
 
 type Bench mg.Namespace
 
-// Short runs the moqt benchmarks once with allocations reporting. Use this for
-// a quick local sanity check while iterating.
+// Short runs the moqt microbenchmarks once with allocations reporting. Use this
+// for a quick local sanity check while iterating. Skips the slow broadcast/QUIC
+// integration benchmarks (see Bench.Integration) so it actually finishes fast.
 func (Bench) Short() error {
-	fmt.Println("Running benchmarks (short: -count=1 -benchtime=1x -benchmem)...")
-	return sh.RunV("go", "test", "-run=^$", "-bench=.", "-benchmem",
+	fmt.Println("Running benchmarks (short: micro only, -count=1 -benchtime=1x -benchmem)...")
+	return sh.RunV("go", "test", "-run=^$", "-bench=.", "-skip=BroadcastServer|StreamIo_RealQUIC", "-benchmem",
 		"-benchtime=1x", "-count=1", "-timeout=10m", "./moqt/...")
 }
 
-// Full runs the moqt benchmarks with enough samples for benchstat. Mirrors what
-// CI captures: -count=10 -benchmem, bounded -benchtime. Output is written to
-// bench-new.txt so it can be compared with Bench.Compare.
+// Full runs the moqt microbenchmarks with enough samples for benchstat. Mirrors
+// CI's benchmark (micro) job: -count=10 -benchmem -benchtime=1s, with the slow
+// broadcast/QUIC integration benchmarks skipped (see Bench.Integration). Prints
+// to stdout; capture it for a baseline, e.g. `mage bench:full > bench-baseline.txt`.
 func (Bench) Full() error {
-	fmt.Println("Running benchmarks (full: -count=10 -benchtime=1x -benchmem)...")
-	return sh.RunV("go", "test", "-run=^$", "-bench=.",
-		"-benchmem", "-benchtime=1x", "-count=10", "-timeout=20m", "./moqt/...")
+	fmt.Println("Running benchmarks (full: micro only, -count=10 -benchtime=1s -benchmem)...")
+	return sh.RunV("go", "test", "-run=^$", "-bench=.", "-skip=BroadcastServer|StreamIo_RealQUIC",
+		"-benchmem", "-benchtime=1s", "-count=10", "-timeout=15m", "./moqt/...")
+}
+
+// Integration runs the slow broadcast/QUIC integration benchmarks. Each op is a
+// multi-second aggregate (frames/sec, MB/s), so -benchtime=1x is appropriate
+// here (unlike the microbenchmarks). Mirrors CI's benchmark-integration job.
+// Expect roughly 10-19 minutes.
+func (Bench) Integration() error {
+	fmt.Println("Running benchmarks (integration: broadcast/QUIC, -count=5 -benchtime=1x -benchmem)...")
+	return sh.RunV("go", "test", "-run=^$", "-bench=BroadcastServer|StreamIo_RealQUIC",
+		"-benchmem", "-benchtime=1x", "-count=5", "-timeout=25m", "./moqt/...")
 }
 
 // Compare runs the benchmarks, writes the result to bench-new.txt, and compares
@@ -250,8 +262,8 @@ func (Bench) Compare(baselinePath string) error {
 		return fmt.Errorf("create %s: %w", newPath, err)
 	}
 	defer out.Close()
-	cmd := exec.Command("go", "test", "-run=^$", "-bench=.",
-		"-benchmem", "-benchtime=1x", "-count=10", "-timeout=20m", "./moqt/...")
+	cmd := exec.Command("go", "test", "-run=^$", "-bench=.", "-skip=BroadcastServer|StreamIo_RealQUIC",
+		"-benchmem", "-benchtime=1s", "-count=10", "-timeout=15m", "./moqt/...")
 	cmd.Stdout = out
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -387,9 +399,10 @@ func Help() {
 	fmt.Println("  mage test:coverage - Run tests with coverage")
 	fmt.Println("")
 	fmt.Println("Benchmarks:")
-	fmt.Println("  mage bench:short                       - Quick benchmark sanity check (-count=1)")
-	fmt.Println("  mage bench:full                        - Full benchmark run for baselines (-count=10)")
-	fmt.Println("  mage bench:compare [baseline.txt]      - Run benchmarks and compare vs a baseline with benchstat")
+	fmt.Println("  mage bench:short                       - Quick microbenchmark sanity check (-count=1)")
+	fmt.Println("  mage bench:full                        - Full microbenchmark run for baselines (-count=10); mirrors CI's micro job")
+	fmt.Println("  mage bench:integration                 - Slow broadcast/QUIC integration benchmarks; mirrors CI's integration job")
+	fmt.Println("  mage bench:compare [baseline.txt]      - Run microbenchmarks and compare vs a baseline with benchstat")
 	fmt.Println("")
 	fmt.Println("Interop:")
 	fmt.Println("  mage interop:ts                       - Dockerized interop using TypeScript client (preferred)")


### PR DESCRIPTION
## Why

The `benchmark` CI job **and** the mage `bench:full` / `bench:compare` targets all ran `-benchtime=1x` — i.e. **one iteration per sample**. For microbenchmarks that meant ~150% CV: `BenchmarkBroadcastPath_String` ranged **120–2224 ns/op** across 10 samples (measured from #184's own green CI run). At that noise floor, the nanosecond-scale savings claimed by the open wire-layer PRs (varint, message encode/decode, `ReadMessageLength`, `WriteString`) are **invisible to benchstat** — real wins and no-ops both report `~`.

Separately, the slow broadcast/QUIC integration benchmarks (`BenchmarkBroadcastServer_*`, `BenchmarkStreamIo_RealQUIC`) ate **~19 of ~23 min** of the benchmark job and are irrelevant to those micro-PRs.

## What

- **`benchmark` job → micro only**: `-skip='BroadcastServer|StreamIo_RealQUIC'` + `-benchtime=1s`. Micro CV drops to **~1.5%** (verified locally: `BroadcastPath_String` → 0.2146–0.2225 ns/op; `ReadMessageLength` → 16.84–17.64 ns/op). `1s` vs `1x` is identical for the excluded 10 s/op integration benchmarks, so no cost increase there.
- **New `benchmark-integration` job**: runs only the broadcast/QUIC suite at `-benchtime=1x -count=5`, gated to `push` / `workflow_dispatch` (**not PRs**), uploads `bench-integration` for trend archival. Each op is a stable multi-second aggregate (frames/sec, MB/s), so `1x` stays appropriate here.
- **`magefiles`**: `Bench.Short/Full/Compare` mirror the micro split; new `Bench.Integration`. `go vet -tags=mage` passes.

## Verification

- `-skip` confirmed to exclude **exactly** the slow benchmarks and keep every micro (incl. `BroadcastPath_String` and all `internal/message` wire benchmarks).
- The exact CI micro command runs clean: exit 0, **0** integration benchmarks leaked, no FAIL/panic.
- `go.yml` parses as valid UTF-8 YAML; jobs = `build, race, benchmark, benchmark-integration`.

## Caveat

The first PR merged after this compares against the pre-existing `1x` baseline (noisy). Self-heals on the next push to `main`, which captures a clean `1s` micro baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
