### PR TITLE
docs(server): document Handler ordering for default WebTransport path (#180)

### DIFF
--- a/moqt/server.go
+++ b/moqt/server.go
@@ -73,8 +73,14 @@ type Server struct {
 	// If nil, the server should use a global default mux or initialize a new one.
 	TrackMux *TrackMux
 
-	// Handler serves accepted native QUIC sessions (i.e. connections negotiated with NextProtoMOQ).
-	// If nil, native QUIC connections are not handled.
+	// Handler serves accepted sessions for both native QUIC (NextProtoMOQ) and
+	// the default WebTransport path. If nil, sessions are not handled (native
+	// QUIC connections are rejected; WebTransport requests fall back).
+	//
+	// The default WebTransport handler captures Handler when the Server is
+	// initialized (init runs once, on the first Serve* call), so Handler must
+	// be set before the server starts serving to take effect for WebTransport.
+	// The native-QUIC path reads Handler live at connection time.
 	Handler Handler
 
 	// FetchHandler serves incoming FETCH requests on native QUIC sessions.
@@ -122,6 +128,10 @@ func (s *Server) init() {
 // Logger. If Handler is nil, the returned handler falls back for every request
 // (no session is created), matching the native-QUIC "no handler configured"
 // behavior.
+//
+// The Server's fields are snapshotted here at init time (init runs once, on the
+// first Serve* call), unlike the native-QUIC path which reads Handler live.
+// Set Handler (and the other fields) before the server starts serving.
 func (s *Server) defaultWebTransportHandler() http.Handler {
 	return &WebTransportHandler{
 		Config:       s.Config,


### PR DESCRIPTION
Closes #180 (doc-level).

The default WebTransport handler snapshots \`Server.Handler\` when \`init()\` runs (once, on the first \`Serve*\` call), whereas the native-QUIC path (\`handleNativeQUIC\`) reads \`Handler\` live at connection time. The common pattern (set \`Handler\` at construction, then \`ListenAndServe\`) works for both; this just documents the ordering requirement so the inconsistency isn't a silent footgun.

A live-read fix is possible but would add a per-request allocation (building a \`WebTransportHandler\` per request) or a redesign of the standalone \`WebTransportHandler\` struct — not worth it for an edge case. Documenting is proportionate.

Doc-only; no behavior change. Carries \`no-changelog\`.