### PR TITLE
test(message): report true Encode allocations (io.Discard, not bytes.Buffer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **moqt/internal/message:** The `*_Encode` benchmarks now write to `io.Discard` instead of a `bytes.Buffer`. The Buffer's internal growth on `Write` was counted by `-benchmem`, inflating the reported Encode cost to ~3 allocs/op when Encode's own allocation is only 1 scratch buffer (~8–96 B by message size). No production behavior change; this corrects the measurement. (A production memprofile of the broadcast path confirms `message.Encode` is not an allocation hot spot — `(*Frame).decode`, QUIC stream setup, and `slog` dominate.)
 - **moqt/internal/message:** `ReadMessageLength` now fast-paths `io.ByteReader` (bytes.Reader, bufio.Reader, QUIC streams), eliminating a per-call heap allocation (1 → 0) and ~65% faster varint-length decoding. Behavior is unchanged; non-ByteReader callers use the previous allocating path.
 - **Dependencies:** Updated `quic-go` to v0.60.0.
 ### Removed

--- a/moqt/internal/message/wire_benchmark_test.go
+++ b/moqt/internal/message/wire_benchmark_test.go
@@ -20,6 +20,13 @@ func encodeMessage(m interface{ Encode(io.Writer) error }) []byte {
 	return buf.Bytes()
 }
 
+// The *_Encode benchmarks below write to io.Discard rather than a *bytes.Buffer.
+// A bytes.Buffer grows its internal slice on Write, and that growth is counted by
+// -benchmem — previously inflating the reported Encode cost to ~3 allocs/op when
+// Encode's own allocation is only 1 scratch buffer. io.Discard isolates Encode's
+// true allocation. (The encodeMessage helper above still uses bytes.Buffer because
+// it needs the encoded bytes back for the *_Decode benchmarks.)
+
 // --- GroupMessage ---
 
 func BenchmarkGroupMessage_Encode(b *testing.B) {
@@ -32,8 +39,7 @@ func BenchmarkGroupMessage_Encode(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		var buf bytes.Buffer
-		if err := msg.Encode(&buf); err != nil {
+		if err := msg.Encode(io.Discard); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -84,8 +90,7 @@ func BenchmarkSubscribeMessage_Encode(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		var buf bytes.Buffer
-		if err := msg.Encode(&buf); err != nil {
+		if err := msg.Encode(io.Discard); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -142,8 +147,7 @@ func BenchmarkAnnounceMessage_Encode(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		var buf bytes.Buffer
-		if err := msg.Encode(&buf); err != nil {
+		if err := msg.Encode(io.Discard); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -194,8 +198,7 @@ func BenchmarkAnnounceInterestMessage_Encode(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		var buf bytes.Buffer
-		if err := msg.Encode(&buf); err != nil {
+		if err := msg.Encode(io.Discard); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -242,8 +245,7 @@ func BenchmarkFetchMessage_Encode(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		var buf bytes.Buffer
-		if err := msg.Encode(&buf); err != nil {
+		if err := msg.Encode(io.Discard); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -293,8 +295,7 @@ func BenchmarkSubscribeOkMessage_Encode(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		var buf bytes.Buffer
-		if err := msg.Encode(&buf); err != nil {
+		if err := msg.Encode(io.Discard); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -345,8 +346,7 @@ func BenchmarkSubscribeUpdateMessage_Encode(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		var buf bytes.Buffer
-		if err := msg.Encode(&buf); err != nil {
+		if err := msg.Encode(io.Discard); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -395,8 +395,7 @@ func BenchmarkSubscribeDropMessage_Encode(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		var buf bytes.Buffer
-		if err := msg.Encode(&buf); err != nil {
+		if err := msg.Encode(io.Discard); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -441,8 +440,7 @@ func BenchmarkGoawayMessage_Encode(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		var buf bytes.Buffer
-		if err := msg.Encode(&buf); err != nil {
+		if err := msg.Encode(io.Discard); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -486,8 +484,7 @@ func BenchmarkProbeMessage_Encode(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		var buf bytes.Buffer
-		if err := msg.Encode(&buf); err != nil {
+		if err := msg.Encode(io.Discard); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -531,10 +528,10 @@ var varintMagnitudes = []struct {
 	val  uint64
 }{
 	{"0", 0},
-	{"127", 127},        // maxVarInt1 (1-byte)
-	{"16383", 16383},    // maxVarInt2 (2-byte)
-	{"1<<21", 1 << 21},  // inside 4-byte bucket
-	{"1<<28", 1 << 28},  // inside 4-byte bucket
+	{"127", 127},             // maxVarInt1 (1-byte)
+	{"16383", 16383},         // maxVarInt2 (2-byte)
+	{"1<<21", 1 << 21},       // inside 4-byte bucket
+	{"1<<28", 1 << 28},       // inside 4-byte bucket
 	{"maxUint62", maxUint62}, // maxVarInt8 (8-byte, max valid)
 }
 


### PR DESCRIPTION
## What

The `*_Encode` benchmarks in `moqt/internal/message` now write to `io.Discard` instead of a `*bytes.Buffer`. **No production code changes** — the `pool.go` and Encode-method changes from the first draft of this PR have been removed.

## Why

The benchmarks encoded into a `bytes.Buffer`, and the Buffer's internal growth on `Write` is counted by `-benchmem`. That growth accounted for ~2 of the reported "3 allocs/op", masking Encode's true cost. Encode's real allocation is **1 scratch buffer per call (~8–96 B by message size)** — not 3. `io.Discard` isolates it. (`encodeMessage`, used by the `*_Decode` benchmarks, still uses `bytes.Buffer` because it needs the bytes back.)

This corrects the measurement that misled #157 (and the first draft of this PR) into "eliminating allocations" that were mostly the test harness.

## Why no pool (earlier draft dropped)

An earlier draft pooled the encode buffer for "0 allocs/op". Profiling the **real** path (`BenchmarkBroadcastServer_HighLoad/clients-10`, real QUIC) showed the pool is invisible in production:

- benchstat main-vs-pool: B/op 18.80→18.83 Mi (p=0.095), allocs/op 260.6k→257.8k (p=0.095), throughput 3010 frames/op both — **no significant change**.
- memprofile: `message.*Encode` / `getBuf` / `putBuf` → **"no matches found"** — below the sampling threshold. Real alloc hot spots: `(*Frame).decode` (~17%), QUIC stream/flow-control setup, `slog`.

`message.Encode` is control-plane (a few Subscribe/Announce per session), so pooling it can't move the data-plane needle. If alloc reduction is ever a real production goal, the target is `Frame.decode`, not `message.Encode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)