### PR TITLE
ci(bench): post benchstat comparison as a PR comment

### DIFF
--- a/.github/workflows/benchmark-label.yml
+++ b/.github/workflows/benchmark-label.yml
@@ -25,6 +25,7 @@ on:
 permissions:
   contents: read
   actions: read
+  pull-requests: write # post the benchstat comparison as a PR comment
 
 jobs:
   benchmark:
@@ -78,13 +79,36 @@ jobs:
         run: |
           go test -run='^$' -bench=. -skip='BroadcastServer|StreamIo_RealQUIC' -benchmem -benchtime=1s -count=10 -timeout=15m ./moqt/... | tee bench-new.txt
 
-      - name: Compare against baseline
+      - name: Compare against baseline and build comment
         if: steps.baseline.outputs.have_baseline == 'true'
-        run: |
-          echo "::group::benchstat comparison (baseline -> PR)"
-          benchstat baseline/bench-baseline.txt bench-new.txt
-          echo "::endgroup::"
         continue-on-error: true
+        run: |
+          {
+            echo '## 🏎️ Benchmark comparison (main → PR)'
+            echo ''
+            echo '<sub>Triggered by the `performance-check` label. Microbenchmarks only (`-benchtime=1s -count=10`); the slow broadcast/QUIC integration suite is excluded via `-skip`. `↓`/`↑` = significant decrease/increase; `~` = no significant change (p ≥ 0.05).</sub>'
+            echo ''
+            echo '```text'
+            benchstat baseline/bench-baseline.txt bench-new.txt
+            echo '```'
+            echo ''
+            echo '**How to read:** `allocs/op` and `B/op` are deterministic — any delta there is real. `sec/op` deltas flagged `↓`/`↑` are statistically significant (p < 0.05); the `±%` column is run-to-run variance, not the magnitude of the change. Full raw output is in the workflow log and the uploaded `bench-perfcheck-pr-*` artifact.'
+          } > benchstat-comment.md
+          echo '::group::benchstat comparison (main -> PR)'
+          cat benchstat-comment.md
+          echo '::endgroup::'
+
+      - name: Post comparison as PR comment
+        if: steps.baseline.outputs.have_baseline == 'true' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -s benchstat-comment.md ]; then
+            gh pr comment "$PR" --body-file benchstat-comment.md
+          else
+            echo "Empty comment body; skipping."
+          fi
 
       - name: Upload PR bench output
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What
Posts the benchstat comparison as an inline PR comment in the `performance-check` label workflow (#189), so reviewers don't have to open the workflow run or download the artifact.

## Why
#189 proved the important path works — label triggers the workflow, benchmarks run, benchstat is generated, artifact is uploaded — but the result was only in the workflow log + artifact. The original workflow design was "add the `performance-check` label → get results in a comment." This closes that gap.

## Changes (`benchmark-label.yml` only)
1. **`permissions: pull-requests: write`** — required to post a comment (previously only `contents: read` + `actions: read`).
2. **Capture the benchstat output** into `benchstat-comment.md`, wrapped with a short header and interpretation caveats (also still echoed to the workflow log under a group).
3. **New "Post comparison as PR comment" step** — `gh pr comment --body-file`, gated on a baseline existing *and* the event being a `pull_request` (skips on manual dispatch or when there's no main baseline yet).

The comment carries interpretation guidance so it isn't misread:
- `allocs/op` and `B/op` are **deterministic** — any delta there is real.
- `sec/op` deltas flagged `↓`/`↑` by benchstat are statistically significant (p < 0.05); the `±%` column is run-to-run **variance**, not the magnitude of the change.

## Notes
- Posts a new comment per run (no dedup yet — a future enhancement could find-and-edit an existing comment).
- Builds on #186's trustworthy `-benchtime=1s` measurement; **no change to what is measured**, only to how the result is surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
