### PR TITLE
test(moqt): make ReceiveSubscribeStream tests deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **moqt:** `Server` now wires a `WebTransportHandler` (built from the Server's `Handler` / `TrackMux` / `Config`) as the default WebTransport handler. Previously `Server.init()` passed a nil HTTP handler, so every WebTransport request fell through to `http.DefaultServeMux` (no MOQ route) and 404'd — the Server's default WebTransport path was non-functional, and `BenchmarkBroadcastServer_HighLoad` silently reported 0 frames/op.
 - **moqt:** `Server.Close()` no longer hangs when connections are active. Previously the "terminate sessions" loop had an empty body (active connections were never closed) and sessions were removed from the connection manager only on an explicit, successful `CloseWithError` — so peer-/force-closed sessions leaked and `Server.Close()`/`Shutdown()` blocked forever on `<-connManager.Done()`. `Server.Close()` now closes active connections, the serving paths (`WebTransportHandler.ServeHTTP`, `handleNativeQUIC`) clean up the session when the Handler returns, and `Session.CloseWithError` always removes the connection from the manager.
+- **moqt:** `ReceiveSubscribeStream` tests now wait on a `doneCh` signal instead of arbitrary `time.Sleep`, eliminating flakiness and speeding up the suite.
 
 ## [v0.15.0] - 2026-04-26
 

--- a/moqt/receive_subscribe_stream.go
+++ b/moqt/receive_subscribe_stream.go
@@ -13,10 +13,12 @@ func newReceiveSubscribeStream(id SubscribeID, stream transport.Stream, config *
 		config:      config,
 		stream:      stream,
 		updatedCh:   make(chan struct{}, 1),
+		doneCh:      make(chan struct{}),
 	}
 
 	// Listen for updates in a separate goroutine
 	go func() {
+		defer close(substr.doneCh)
 		var updateMsg message.SubscribeUpdateMessage
 		var err error
 
@@ -57,6 +59,7 @@ type receiveSubscribeStream struct {
 
 	config          *SubscribeConfig
 	updatedCh       chan struct{}
+	doneCh          chan struct{}
 	responseStarted bool
 }
 

--- a/moqt/receive_subscribe_stream_test.go
+++ b/moqt/receive_subscribe_stream_test.go
@@ -51,7 +51,7 @@ func TestNewReceiveSubscribeStream(t *testing.T) {
 			assert.NotNil(t, rss, "newReceiveSubscribeStream should not return nil")
 			assert.Equal(t, tt.subscribeID, rss.SubscribeID(), "SubscribeID should match")
 			assert.NotNil(t, rss.Updated(), "Updated channel should not be nil") // Wait for goroutine to process EOF and close
-			time.Sleep(10 * time.Millisecond)
+			<-rss.doneCh
 		})
 	}
 }
@@ -90,7 +90,7 @@ func TestReceiveSubscribeStream_SubscribeID(t *testing.T) {
 			result := rss.SubscribeID()
 			assert.Equal(t, tt.subscribeID, result, "SubscribeID should match expected value")
 
-			time.Sleep(10 * time.Millisecond)
+			<-rss.doneCh
 		})
 	}
 }
@@ -128,7 +128,7 @@ func TestReceiveSubscribeStream_TrackConfig(t *testing.T) {
 				assert.Equal(t, tt.config.Priority, resultConfig.Priority, "TrackPriority should match")
 			}
 
-			time.Sleep(10 * time.Millisecond)
+			<-rss.doneCh
 		})
 	}
 }
@@ -146,12 +146,10 @@ func TestReceiveSubscribeStream_Updated(t *testing.T) {
 	updatedCh := rss.Updated()
 	assert.NotNil(t, updatedCh, "Updated channel should not be nil")
 
-	// EOF stops the background goroutine; it does not close Updated().
-	time.Sleep(10 * time.Millisecond)
-	assert.NotNil(t, updatedCh)
+	<-rss.doneCh
 
-	// Give some time for the goroutine to complete
-	time.Sleep(10 * time.Millisecond)
+	// EOF stops the background goroutine; it does not close Updated().
+	assert.NotNil(t, updatedCh)
 }
 
 func TestReceiveSubscribeStream_ListenUpdates_WithSubscribeUpdateMessage(t *testing.T) {
@@ -190,8 +188,7 @@ func TestReceiveSubscribeStream_ListenUpdates_WithSubscribeUpdateMessage(t *test
 		assert.Equal(t, TrackPriority(5), updatedConfig.Priority, "TrackPriority should be updated")
 	}
 
-	// Give some time for the goroutine to complete
-	time.Sleep(10 * time.Millisecond)
+	<-rss.doneCh
 }
 
 func TestReceiveSubscribeStream_CloseWithError(t *testing.T) {
@@ -321,9 +318,7 @@ func TestReceiveSubscribeStream_ConcurrentAccess(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 	}
 
-	// Give some time for the goroutine to complete
-	time.Sleep(10 * time.Millisecond)
-
+	<-rss.doneCh
 }
 
 func TestReceiveSubscribeStream_Close_DoesNotCancelReadOnGracefulClose(t *testing.T) {
@@ -351,10 +346,11 @@ func TestReceiveSubscribeStream_UpdateChannelBehavior(t *testing.T) {
 
 		rss := newReceiveSubscribeStream(subscribeID, mockStream, config)
 
-		// Wait for the goroutine to handle EOF and close the channel
-		time.Sleep(50 * time.Millisecond)
+		// Wait for the goroutine to handle EOF
+		<-rss.doneCh
 
-		// Verify channel is closed by trying to receive
+		// Verify channel is NOT explicitly closed by EOF, but the test ensures stability.
+		// Tests here verify that it doesn't crash or behave improperly when the loop ends.
 		select {
 		case _, ok := <-rss.Updated():
 			if ok {
@@ -362,13 +358,9 @@ func TestReceiveSubscribeStream_UpdateChannelBehavior(t *testing.T) {
 			} else {
 				t.Log("Channel is properly closed")
 			}
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(10 * time.Millisecond):
 			t.Log("Channel should be closed and ready to receive")
 		}
-
-		// Give some time for the goroutine to complete
-		time.Sleep(10 * time.Millisecond)
-
 	})
 
 	t.Run("multiple updates sent to channel", func(t *testing.T) {
@@ -418,7 +410,6 @@ func TestReceiveSubscribeStream_UpdateChannelBehavior(t *testing.T) {
 		// We received at least the minimum expected updates
 		assert.GreaterOrEqual(t, updateCount, expectedUpdates, "Should receive at least expected number of updates")
 
-		// Give some time for the goroutine to complete
-		time.Sleep(10 * time.Millisecond)
+		<-rss.doneCh
 	})
 }


### PR DESCRIPTION
## What
Makes the `ReceiveSubscribeStream` tests deterministic by replacing arbitrary `time.Sleep` waits with a `doneCh` signal that is closed when the background update goroutine exits. Same change as #155 — opened fresh because #155's CHANGELOG hunk was written against an old base and would corrupt `main`'s CHANGELOG on merge (duplicate `[Unreleased]` section, title stranded mid-file).

## Why
`time.Sleep(10ms)` waits are flaky and slow — they guess at how long the goroutine takes. A `doneCh` (closed once via `defer` when the goroutine returns) lets each test block until the goroutine has *actually* finished: no flakiness, and faster (no fixed delays).

## Changes
- `receive_subscribe_stream.go`: add `doneCh chan struct{}`, initialized per stream, closed exactly once via `defer close(...)` at the top of the update goroutine. No change to the data path or runtime behavior.
- `receive_subscribe_stream_test.go`: replace the `time.Sleep` waits with `<-rss.doneCh`.
- `CHANGELOG.md`: entry under `[Unreleased] / Fixed`.

## Verified
- `go test -run TestReceiveSubscribeStream ./moqt/` passes.
- `go vet ./moqt/` clean; `gofmt` clean.
- `-race` not run locally (no gcc on Windows) — CI runs it on Linux.

Supersedes #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
