### PR TITLE
test(moqt): replace time.Sleep with testing/synctest in ReceiveSubscribeStream tests

### DIFF
--- a/moqt/receive_subscribe_stream_test.go
+++ b/moqt/receive_subscribe_stream_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/qumo-dev/gomoqt/moqt/internal/message"
@@ -13,6 +14,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// The tests below wrap goroutine-starting setup in synctest.Test. The background
+// goroutine started by newReceiveSubscribeStream reads until Decode errors
+// (EOF for a zero-value FakeQUICStream), then exits. synctest.Test guarantees
+// that goroutine has exited before the test body returns — so the assertions
+// observe the final state deterministically, with no time.Sleep. (mux_test.go
+// and session_test.go use the same pattern.)
 
 func TestNewReceiveSubscribeStream(t *testing.T) {
 	tests := map[string]struct {
@@ -44,14 +52,15 @@ func TestNewReceiveSubscribeStream(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			mockStream := &FakeQUICStream{}
+			synctest.Test(t, func(t *testing.T) {
+				mockStream := &FakeQUICStream{}
 
-			rss := newReceiveSubscribeStream(tt.subscribeID, mockStream, tt.config)
+				rss := newReceiveSubscribeStream(tt.subscribeID, mockStream, tt.config)
 
-			assert.NotNil(t, rss, "newReceiveSubscribeStream should not return nil")
-			assert.Equal(t, tt.subscribeID, rss.SubscribeID(), "SubscribeID should match")
-			assert.NotNil(t, rss.Updated(), "Updated channel should not be nil") // Wait for goroutine to process EOF and close
-			time.Sleep(10 * time.Millisecond)
+				assert.NotNil(t, rss, "newReceiveSubscribeStream should not return nil")
+				assert.Equal(t, tt.subscribeID, rss.SubscribeID(), "SubscribeID should match")
+				assert.NotNil(t, rss.Updated(), "Updated channel should not be nil")
+			})
 		})
 	}
 }
@@ -79,18 +88,18 @@ func TestReceiveSubscribeStream_SubscribeID(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			mockStream := &FakeQUICStream{}
+			synctest.Test(t, func(t *testing.T) {
+				mockStream := &FakeQUICStream{}
 
-			config := &SubscribeConfig{
-				Priority: TrackPriority(1),
-			}
+				config := &SubscribeConfig{
+					Priority: TrackPriority(1),
+				}
 
-			rss := newReceiveSubscribeStream(tt.subscribeID, mockStream, config)
+				rss := newReceiveSubscribeStream(tt.subscribeID, mockStream, config)
 
-			result := rss.SubscribeID()
-			assert.Equal(t, tt.subscribeID, result, "SubscribeID should match expected value")
-
-			time.Sleep(10 * time.Millisecond)
+				result := rss.SubscribeID()
+				assert.Equal(t, tt.subscribeID, result, "SubscribeID should match expected value")
+			})
 		})
 	}
 }
@@ -116,82 +125,79 @@ func TestReceiveSubscribeStream_TrackConfig(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			subscribeID := SubscribeID(123)
-			mockStream := &FakeQUICStream{}
+			synctest.Test(t, func(t *testing.T) {
+				subscribeID := SubscribeID(123)
+				mockStream := &FakeQUICStream{}
 
-			rss := newReceiveSubscribeStream(subscribeID, mockStream, tt.config)
+				rss := newReceiveSubscribeStream(subscribeID, mockStream, tt.config)
 
-			resultConfig := rss.TrackConfig()
+				resultConfig := rss.TrackConfig()
 
-			assert.NotNil(t, resultConfig, "TrackConfig should not be nil")
-			if tt.config != nil {
-				assert.Equal(t, tt.config.Priority, resultConfig.Priority, "TrackPriority should match")
-			}
-
-			time.Sleep(10 * time.Millisecond)
+				assert.NotNil(t, resultConfig, "TrackConfig should not be nil")
+				if tt.config != nil {
+					assert.Equal(t, tt.config.Priority, resultConfig.Priority, "TrackPriority should match")
+				}
+			})
 		})
 	}
 }
 
 func TestReceiveSubscribeStream_Updated(t *testing.T) {
-	subscribeID := SubscribeID(123)
-	mockStream := &FakeQUICStream{}
+	synctest.Test(t, func(t *testing.T) {
+		subscribeID := SubscribeID(123)
+		mockStream := &FakeQUICStream{}
 
-	config := &SubscribeConfig{
-		Priority: TrackPriority(1),
-	}
+		config := &SubscribeConfig{
+			Priority: TrackPriority(1),
+		}
 
-	rss := newReceiveSubscribeStream(subscribeID, mockStream, config)
+		rss := newReceiveSubscribeStream(subscribeID, mockStream, config)
 
-	updatedCh := rss.Updated()
-	assert.NotNil(t, updatedCh, "Updated channel should not be nil")
+		updatedCh := rss.Updated()
+		assert.NotNil(t, updatedCh, "Updated channel should not be nil")
 
-	// EOF stops the background goroutine; it does not close Updated().
-	time.Sleep(10 * time.Millisecond)
-	assert.NotNil(t, updatedCh)
-
-	// Give some time for the goroutine to complete
-	time.Sleep(10 * time.Millisecond)
+		// EOF stops the background goroutine; it does not close Updated().
+		assert.NotNil(t, updatedCh)
+	})
 }
 
 func TestReceiveSubscribeStream_ListenUpdates_WithSubscribeUpdateMessage(t *testing.T) {
-	subscribeID := SubscribeID(123)
+	synctest.Test(t, func(t *testing.T) {
+		subscribeID := SubscribeID(123)
 
-	// Create a valid SubscribeUpdateMessage
-	updateMsg := message.SubscribeUpdateMessage{
-		SubscriberPriority: 5,
-	}
+		// Create a valid SubscribeUpdateMessage
+		updateMsg := message.SubscribeUpdateMessage{
+			SubscriberPriority: 5,
+		}
 
-	// Encode the message
-	buf := &bytes.Buffer{}
-	err := updateMsg.Encode(buf)
-	require.NoError(t, err)
+		// Encode the message
+		buf := &bytes.Buffer{}
+		err := updateMsg.Encode(buf)
+		require.NoError(t, err)
 
-	mockStream := &FakeQUICStream{
-		ReadFunc: buf.Read,
-	}
+		mockStream := &FakeQUICStream{
+			ReadFunc: buf.Read,
+		}
 
-	config := &SubscribeConfig{
-		Priority: TrackPriority(1),
-	}
+		config := &SubscribeConfig{
+			Priority: TrackPriority(1),
+		}
 
-	rss := newReceiveSubscribeStream(subscribeID, mockStream, config)
+		rss := newReceiveSubscribeStream(subscribeID, mockStream, config)
 
-	// Wait for the update to be processed
-	select {
-	case <-rss.Updated():
-		// Should receive update notification
-	case <-time.After(100 * time.Millisecond):
-		t.Error("Expected to receive update notification")
-	}
-	// Check that config was updated
-	updatedConfig := rss.TrackConfig()
-	if err == nil {
-		assert.Equal(t, TrackPriority(5), updatedConfig.Priority, "TrackPriority should be updated")
-	}
-
-	// Give some time for the goroutine to complete
-	time.Sleep(10 * time.Millisecond)
+		// Wait for the update to be processed
+		select {
+		case <-rss.Updated():
+			// Should receive update notification
+		case <-time.After(100 * time.Millisecond):
+			t.Error("Expected to receive update notification")
+		}
+		// Check that config was updated
+		updatedConfig := rss.TrackConfig()
+		if err == nil {
+			assert.Equal(t, TrackPriority(5), updatedConfig.Priority, "TrackPriority should be updated")
+		}
+	})
 }
 
 func TestReceiveSubscribeStream_CloseWithError(t *testing.T) {
@@ -213,6 +219,9 @@ func TestReceiveSubscribeStream_CloseWithError(t *testing.T) {
 		},
 	}
 
+	// Not wrapped in synctest: the mock ReadFunc blocks forever (select{}) to
+	// keep the background reader goroutine alive while closeWithError runs —
+	// synctest cannot service a select{}, so this stays on real time.
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			subscribeID := SubscribeID(123)
@@ -270,60 +279,58 @@ func TestReceiveSubscribeStream_CloseWithError_MultipleClose(t *testing.T) {
 }
 
 func TestReceiveSubscribeStream_ConcurrentAccess(t *testing.T) {
-	subscribeID := SubscribeID(123)
-	mockStream := &FakeQUICStream{}
+	synctest.Test(t, func(t *testing.T) {
+		subscribeID := SubscribeID(123)
+		mockStream := &FakeQUICStream{}
 
-	config := &SubscribeConfig{
-		Priority: TrackPriority(1),
-	}
+		config := &SubscribeConfig{
+			Priority: TrackPriority(1),
+		}
 
-	rss := newReceiveSubscribeStream(subscribeID, mockStream, config)
+		rss := newReceiveSubscribeStream(subscribeID, mockStream, config)
 
-	// Test concurrent access to SubscribeID (should be safe as it's read-only)
-	var wg sync.WaitGroup
-	numGoroutines := 10
+		// Test concurrent access to SubscribeID (should be safe as it's read-only)
+		var wg sync.WaitGroup
+		numGoroutines := 10
 
-	wg.Add(numGoroutines)
-	for range numGoroutines {
+		wg.Add(numGoroutines)
+		for range numGoroutines {
+			go func() {
+				defer wg.Done()
+				id := rss.SubscribeID()
+				assert.Equal(t, subscribeID, id)
+			}()
+		}
+
+		// Test concurrent access to TrackConfig
+		wg.Add(numGoroutines)
+		for range numGoroutines {
+			go func() {
+				defer wg.Done()
+				config := rss.TrackConfig()
+				assert.NotNil(t, config)
+			}()
+		}
+
+		// Wait for all goroutines to complete
+		done := make(chan struct{})
 		go func() {
-			defer wg.Done()
-			id := rss.SubscribeID()
-			assert.Equal(t, subscribeID, id)
+			wg.Wait()
+			close(done)
 		}()
-	}
 
-	// Test concurrent access to TrackConfig
-	wg.Add(numGoroutines)
-	for range numGoroutines {
-		go func() {
-			defer wg.Done()
-			config := rss.TrackConfig()
-			assert.NotNil(t, config)
-		}()
-	}
-
-	// Wait for all goroutines to complete
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		// All concurrent accesses completed successfully
-	case <-time.After(1 * time.Second):
-		t.Error("Concurrent access test timed out")
-	}
-	// Clean up - wait for update channel to close
-	select {
-	case <-rss.Updated():
-	case <-time.After(100 * time.Millisecond):
-	}
-
-	// Give some time for the goroutine to complete
-	time.Sleep(10 * time.Millisecond)
-
+		select {
+		case <-done:
+			// All concurrent accesses completed successfully
+		case <-time.After(1 * time.Second):
+			t.Error("Concurrent access test timed out")
+		}
+		// Clean up - wait for update channel to close
+		select {
+		case <-rss.Updated():
+		case <-time.After(100 * time.Millisecond):
+		}
+	})
 }
 
 func TestReceiveSubscribeStream_Close_DoesNotCancelReadOnGracefulClose(t *testing.T) {
@@ -345,80 +352,75 @@ func TestReceiveSubscribeStream_Close_DoesNotCancelReadOnGracefulClose(t *testin
 
 func TestReceiveSubscribeStream_UpdateChannelBehavior(t *testing.T) {
 	t.Run("channel closes on EOF", func(t *testing.T) {
-		subscribeID := SubscribeID(123)
-		mockStream := &FakeQUICStream{}
-		config := &SubscribeConfig{Priority: TrackPriority(1)}
+		synctest.Test(t, func(t *testing.T) {
+			subscribeID := SubscribeID(123)
+			mockStream := &FakeQUICStream{}
+			config := &SubscribeConfig{Priority: TrackPriority(1)}
 
-		rss := newReceiveSubscribeStream(subscribeID, mockStream, config)
+			rss := newReceiveSubscribeStream(subscribeID, mockStream, config)
 
-		// Wait for the goroutine to handle EOF and close the channel
-		time.Sleep(50 * time.Millisecond)
-
-		// Verify channel is closed by trying to receive
-		select {
-		case _, ok := <-rss.Updated():
-			if ok {
+			// The background goroutine processes EOF and exits; Updated() is
+			// not closed by EOF, so this receive falls through to the timeout.
+			select {
+			case _, ok := <-rss.Updated():
+				if ok {
+					t.Log("Channel should be closed and ready to receive")
+				} else {
+					t.Log("Channel is properly closed")
+				}
+			case <-time.After(100 * time.Millisecond):
 				t.Log("Channel should be closed and ready to receive")
-			} else {
-				t.Log("Channel is properly closed")
 			}
-		case <-time.After(100 * time.Millisecond):
-			t.Log("Channel should be closed and ready to receive")
-		}
-
-		// Give some time for the goroutine to complete
-		time.Sleep(10 * time.Millisecond)
-
+		})
 	})
 
 	t.Run("multiple updates sent to channel", func(t *testing.T) {
-		subscribeID := SubscribeID(123)
+		synctest.Test(t, func(t *testing.T) {
+			subscribeID := SubscribeID(123)
 
-		// Create multiple update messages
-		updates := []message.SubscribeUpdateMessage{
-			{
-				SubscriberPriority: 1,
-			},
-			{
-				SubscriberPriority: 2,
-			},
-		}
-
-		buf := &bytes.Buffer{}
-		for _, update := range updates {
-			err := update.Encode(buf)
-			require.NoError(t, err)
-		}
-
-		mockStream := &FakeQUICStream{
-			ReadFunc: buf.Read,
-		}
-
-		config := &SubscribeConfig{Priority: TrackPriority(0)}
-		rss := newReceiveSubscribeStream(subscribeID, mockStream, config) // Should receive multiple update notifications
-		updateCount := 0
-		expectedUpdates := 1 // We expect at least 1 update, but may get more
-
-		timeout := time.After(200 * time.Millisecond)
-		for updateCount < expectedUpdates {
-			select {
-			case _, ok := <-rss.Updated():
-				if !ok {
-					// Channel closed
-					t.Logf("Channel closed after %d updates", updateCount)
-					break
-				}
-				updateCount++
-				t.Logf("Received update %d", updateCount)
-			case <-timeout:
-				t.Errorf("Timeout waiting for updates, received %d out of at least %d expected", updateCount, expectedUpdates)
-				return
+			// Create multiple update messages
+			updates := []message.SubscribeUpdateMessage{
+				{
+					SubscriberPriority: 1,
+				},
+				{
+					SubscriberPriority: 2,
+				},
 			}
-		}
-		// We received at least the minimum expected updates
-		assert.GreaterOrEqual(t, updateCount, expectedUpdates, "Should receive at least expected number of updates")
 
-		// Give some time for the goroutine to complete
-		time.Sleep(10 * time.Millisecond)
+			buf := &bytes.Buffer{}
+			for _, update := range updates {
+				err := update.Encode(buf)
+				require.NoError(t, err)
+			}
+
+			mockStream := &FakeQUICStream{
+				ReadFunc: buf.Read,
+			}
+
+			config := &SubscribeConfig{Priority: TrackPriority(0)}
+			rss := newReceiveSubscribeStream(subscribeID, mockStream, config) // Should receive multiple update notifications
+			updateCount := 0
+			expectedUpdates := 1 // We expect at least 1 update, but may get more
+
+			timeout := time.After(200 * time.Millisecond)
+			for updateCount < expectedUpdates {
+				select {
+				case _, ok := <-rss.Updated():
+					if !ok {
+						// Channel closed
+						t.Logf("Channel closed after %d updates", updateCount)
+						break
+					}
+					updateCount++
+					t.Logf("Received update %d", updateCount)
+				case <-timeout:
+					t.Errorf("Timeout waiting for updates, received %d out of at least %d expected", updateCount, expectedUpdates)
+					return
+				}
+			}
+			// We received at least the minimum expected updates
+			assert.GreaterOrEqual(t, updateCount, expectedUpdates, "Should receive at least expected number of updates")
+		})
 	})
 }


### PR DESCRIPTION
## What
Replaces the `time.Sleep` waits in `ReceiveSubscribeStream` tests with `testing/synctest.Test`, which deterministically waits for the background goroutine to exit before the test body returns. **Test-only — no production change.**

## Why
The arbitrary 10–50ms `time.Sleep` calls were flaky on slow CI and needlessly slowed the suite. `synctest.Test` removes them and matches the existing convention in `mux_test.go` and `session_test.go`. `TestReceiveSubscribeStream_CloseWithError` intentionally stays on real time — its mock `ReadFunc` blocks forever (`select{}`), which synctest cannot service.

## Verified
- `go test -run TestReceiveSubscribeStream ./moqt/` passes (0.117s).
- Based on current `main`; touches only `receive_subscribe_stream_test.go`.

Supersedes the `doneCh` approach (#194, closed) — this needs no production change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
