### PR TITLE
test(moqt): add saturating real-QUIC egress benchmark

### DIFF
--- a/.github/workflows/benchmark-label.yml
+++ b/.github/workflows/benchmark-label.yml
@@ -27,6 +27,12 @@ permissions:
   actions: read
   pull-requests: write # post the benchstat comparison as a PR comment
 
+# The slow real-QUIC integration benchmarks, excluded from this micro run via
+# -skip. They are measured by go.yml's benchmark-integration job (on main, not
+# on PRs). Add new slow benchmarks to this one list.
+env:
+  INTEGRATION_BENCHES: 'BroadcastServer|StreamIo_RealQUIC|Egress_Saturating'
+
 jobs:
   benchmark:
     # Only run when the performance-check label is added (or on manual dispatch).
@@ -77,7 +83,7 @@ jobs:
         # -skip excludes the slow broadcast/QUIC integration benchmarks.
         # -benchtime=1s lets Go pick a high iteration count for a stable mean.
         run: |
-          go test -run='^$' -bench=. -skip='BroadcastServer|StreamIo_RealQUIC|Egress_Saturating' -benchmem -benchtime=1s -count=10 -timeout=15m ./moqt/... | tee bench-new.txt
+          go test -run='^$' -bench=. -skip="$INTEGRATION_BENCHES" -benchmem -benchtime=1s -count=10 -timeout=15m ./moqt/... | tee bench-new.txt
 
       - name: Compare against baseline and build comment
         if: steps.baseline.outputs.have_baseline == 'true'

--- a/.github/workflows/benchmark-label.yml
+++ b/.github/workflows/benchmark-label.yml
@@ -27,12 +27,6 @@ permissions:
   actions: read
   pull-requests: write # post the benchstat comparison as a PR comment
 
-# The slow real-QUIC integration benchmarks, excluded from this micro run via
-# -skip. They are measured by go.yml's benchmark-integration job (on main, not
-# on PRs). Add new slow benchmarks to this one list.
-env:
-  INTEGRATION_BENCHES: 'BroadcastServer|StreamIo_RealQUIC|Egress_Saturating'
-
 jobs:
   benchmark:
     # Only run when the performance-check label is added (or on manual dispatch).
@@ -80,10 +74,12 @@ jobs:
           test -f baseline/bench-baseline.txt && echo "have_baseline=true" >> "$GITHUB_OUTPUT" || true
 
       - name: Run benchmarks (micro)
-        # -skip excludes the slow broadcast/QUIC integration benchmarks.
+        # -short skips the slow real-QUIC integration benchmarks (each calls
+        # testing.Short() -> b.Skip); they are measured by go.yml's
+        # benchmark-integration job (on main, not on PRs).
         # -benchtime=1s lets Go pick a high iteration count for a stable mean.
         run: |
-          go test -run='^$' -bench=. -skip="$INTEGRATION_BENCHES" -benchmem -benchtime=1s -count=10 -timeout=15m ./moqt/... | tee bench-new.txt
+          go test -run='^$' -bench=. -short -benchmem -benchtime=1s -count=10 -timeout=15m ./moqt/... | tee bench-new.txt
 
       - name: Compare against baseline and build comment
         if: steps.baseline.outputs.have_baseline == 'true'

--- a/.github/workflows/benchmark-label.yml
+++ b/.github/workflows/benchmark-label.yml
@@ -77,7 +77,7 @@ jobs:
         # -skip excludes the slow broadcast/QUIC integration benchmarks.
         # -benchtime=1s lets Go pick a high iteration count for a stable mean.
         run: |
-          go test -run='^$' -bench=. -skip='BroadcastServer|StreamIo_RealQUIC' -benchmem -benchtime=1s -count=10 -timeout=15m ./moqt/... | tee bench-new.txt
+          go test -run='^$' -bench=. -skip='BroadcastServer|StreamIo_RealQUIC|Egress_Saturating' -benchmem -benchtime=1s -count=10 -timeout=15m ./moqt/... | tee bench-new.txt
 
       - name: Compare against baseline and build comment
         if: steps.baseline.outputs.have_baseline == 'true'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -87,13 +87,14 @@ jobs:
           go-version: "1.26.0"
 
       - name: Run benchmarks (micro)
-        # Microbenchmarks only: -skip excludes the slow broadcast/QUIC
-        # integration benchmarks (BenchmarkBroadcastServer_* and
-        # BenchmarkStreamIo_RealQUIC, run separately in benchmark-integration).
+        # Microbenchmarks only: -skip excludes the slow real-QUIC integration
+        # benchmarks (BenchmarkBroadcastServer_*, BenchmarkStreamIo_RealQUIC,
+        # and BenchmarkEgress_Saturating — run separately in
+        # benchmark-integration).
         # -benchtime=1s gives a stable mean (1x had ~150% CV on micros);
         # -count=10 gives benchstat enough samples to estimate variance.
         run: |
-          go test -run='^$' -bench=. -skip='BroadcastServer|StreamIo_RealQUIC' -benchmem -benchtime=1s -count=10 -timeout=15m ./moqt/... | tee bench-new.txt
+          go test -run='^$' -bench=. -skip='BroadcastServer|StreamIo_RealQUIC|Egress_Saturating' -benchmem -benchtime=1s -count=10 -timeout=15m ./moqt/... | tee bench-new.txt
 
       - name: Upload baseline
         uses: actions/upload-artifact@v4
@@ -121,7 +122,7 @@ jobs:
 
       - name: Run integration benchmarks
         run: |
-          go test -run='^$' -bench='BroadcastServer|StreamIo_RealQUIC' -benchmem -benchtime=1x -count=5 -timeout=25m ./moqt/... | tee bench-integration.txt
+          go test -run='^$' -bench='BroadcastServer|StreamIo_RealQUIC|Egress_Saturating' -benchmem -benchtime=1x -count=5 -timeout=25m ./moqt/... | tee bench-integration.txt
 
       - name: Upload integration bench output
         uses: actions/upload-artifact@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,13 +18,6 @@ on:
       - ".github/workflows/go.yml"
   workflow_dispatch: {}
 
-# The slow real-QUIC integration benchmarks — each op is a multi-second
-# aggregate (frames/sec, MB/s). Micro runs skip them (-skip); the
-# benchmark-integration job runs only them (-bench). Add new slow benchmarks
-# to this one list instead of editing each command.
-env:
-  INTEGRATION_BENCHES: 'BroadcastServer|StreamIo_RealQUIC|Egress_Saturating'
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -94,13 +87,13 @@ jobs:
           go-version: "1.26.0"
 
       - name: Run benchmarks (micro)
-        # Microbenchmarks only: -skip excludes the slow integration benchmarks
-        # defined in INTEGRATION_BENCHES (run separately in
-        # benchmark-integration).
+        # Microbenchmarks only: -short skips the slow real-QUIC integration
+        # benchmarks (each calls testing.Short() -> b.Skip). They run in
+        # benchmark-integration below, without -short.
         # -benchtime=1s gives a stable mean (1x had ~150% CV on micros);
         # -count=10 gives benchstat enough samples to estimate variance.
         run: |
-          go test -run='^$' -bench=. -skip="$INTEGRATION_BENCHES" -benchmem -benchtime=1s -count=10 -timeout=15m ./moqt/... | tee bench-new.txt
+          go test -run='^$' -bench=. -short -benchmem -benchtime=1s -count=10 -timeout=15m ./moqt/... | tee bench-new.txt
 
       - name: Upload baseline
         uses: actions/upload-artifact@v4
@@ -109,12 +102,12 @@ jobs:
           path: bench-new.txt
           retention-days: 90
 
-  # Slow broadcast/QUIC integration benchmarks. Each op is a multi-second
-  # aggregate (frames/sec, MB/s) that is stable across samples, so -benchtime=1x
-  # is appropriate here (unlike the microbenchmarks above). Runs only on push
-  # (main/tags) and manual dispatch — NOT on PRs — because it costs ~10-19
-  # runner-minutes and is irrelevant to wire-layer micro-PRs. Uploaded for trend
-  # archival only; no benchstat gate.
+  # Slow real-QUIC integration benchmarks. Runs the FULL benchmark suite WITHOUT
+  # -short, so the benchmarks that self-skip under testing.Short() actually run
+  # here. Each op is a multi-second aggregate (frames/sec, MB/s) stable across
+  # samples, so -benchtime=1x is appropriate (unlike the microbenchmarks above).
+  # Runs only on push (main/tags) and manual dispatch — NOT on PRs — because it
+  # costs ~10-19 runner-minutes. Uploaded for trend archival only; no benchstat gate.
   benchmark-integration:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
@@ -128,7 +121,7 @@ jobs:
 
       - name: Run integration benchmarks
         run: |
-          go test -run='^$' -bench="$INTEGRATION_BENCHES" -benchmem -benchtime=1x -count=5 -timeout=25m ./moqt/... | tee bench-integration.txt
+          go test -run='^$' -bench=. -benchmem -benchtime=1x -count=5 -timeout=25m ./moqt/... | tee bench-integration.txt
 
       - name: Upload integration bench output
         uses: actions/upload-artifact@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,13 @@ on:
       - ".github/workflows/go.yml"
   workflow_dispatch: {}
 
+# The slow real-QUIC integration benchmarks — each op is a multi-second
+# aggregate (frames/sec, MB/s). Micro runs skip them (-skip); the
+# benchmark-integration job runs only them (-bench). Add new slow benchmarks
+# to this one list instead of editing each command.
+env:
+  INTEGRATION_BENCHES: 'BroadcastServer|StreamIo_RealQUIC|Egress_Saturating'
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -87,14 +94,13 @@ jobs:
           go-version: "1.26.0"
 
       - name: Run benchmarks (micro)
-        # Microbenchmarks only: -skip excludes the slow real-QUIC integration
-        # benchmarks (BenchmarkBroadcastServer_*, BenchmarkStreamIo_RealQUIC,
-        # and BenchmarkEgress_Saturating — run separately in
+        # Microbenchmarks only: -skip excludes the slow integration benchmarks
+        # defined in INTEGRATION_BENCHES (run separately in
         # benchmark-integration).
         # -benchtime=1s gives a stable mean (1x had ~150% CV on micros);
         # -count=10 gives benchstat enough samples to estimate variance.
         run: |
-          go test -run='^$' -bench=. -skip='BroadcastServer|StreamIo_RealQUIC|Egress_Saturating' -benchmem -benchtime=1s -count=10 -timeout=15m ./moqt/... | tee bench-new.txt
+          go test -run='^$' -bench=. -skip="$INTEGRATION_BENCHES" -benchmem -benchtime=1s -count=10 -timeout=15m ./moqt/... | tee bench-new.txt
 
       - name: Upload baseline
         uses: actions/upload-artifact@v4
@@ -122,7 +128,7 @@ jobs:
 
       - name: Run integration benchmarks
         run: |
-          go test -run='^$' -bench='BroadcastServer|StreamIo_RealQUIC|Egress_Saturating' -benchmem -benchtime=1x -count=5 -timeout=25m ./moqt/... | tee bench-integration.txt
+          go test -run='^$' -bench="$INTEGRATION_BENCHES" -benchmem -benchtime=1x -count=5 -timeout=25m ./moqt/... | tee bench-integration.txt
 
       - name: Upload integration bench output
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **moqt:** `BenchmarkEgress_Saturating`, a saturating (unpaced) real-QUIC egress benchmark that drives `GroupWriter.WriteFrame` → `frame.encode` → QUIC stream write under load. Fills a gap: every prior I/O benchmark is either `io.Discard` (no Write work) or publisher-paced at ~30fps (transport idle). Baseline throughput is ~100 MB/s flat across 1K–64K frames; CPU-profiling under it shows the egress encode path is ~0% of cost (the UDP write syscall dominates at ~48%). Classified with the other real-QUIC integration benchmarks (run in `benchmark-integration`, not on PRs).
+
 ### Changed
 
 - **moqt/internal/message:** `ReadMessageLength` now fast-paths `io.ByteReader` (bytes.Reader, bufio.Reader, QUIC streams), eliminating a per-call heap allocation (1 → 0) and ~65% faster varint-length decoding. Behavior is unchanged; non-ByteReader callers use the previous allocating path.

--- a/moqt/broadcast_benchmark_test.go
+++ b/moqt/broadcast_benchmark_test.go
@@ -20,6 +20,9 @@ import (
 // BenchmarkBroadcastServer_HighLoad benchmarks a realistic broadcast scenario
 // with 100 concurrent clients subscribing to a 30fps stream with 1-10KB frames
 func BenchmarkBroadcastServer_HighLoad(b *testing.B) {
+	if testing.Short() {
+		b.Skip("real-QUIC integration benchmark; skipped in -short")
+	}
 	clients := []int{10, 50, 100}
 
 	for _, numClients := range clients {
@@ -135,6 +138,9 @@ func BenchmarkBroadcastServer_Profile(b *testing.B) {
 
 // BenchmarkBroadcastServer_FrameSizes tests different frame sizes
 func BenchmarkBroadcastServer_FrameSizes(b *testing.B) {
+	if testing.Short() {
+		b.Skip("real-QUIC integration benchmark; skipped in -short")
+	}
 	frameSizes := []int{100, 1024, 10240} // 100B, 1KB, 10KB
 
 	for _, frameSize := range frameSizes {

--- a/moqt/egress_benchmark_test.go
+++ b/moqt/egress_benchmark_test.go
@@ -50,6 +50,9 @@ import (
 //	    -benchtime=5s -count=10 -cpuprofile=cpu.out -memprofile=mem.out ./moqt/
 
 func BenchmarkEgress_Saturating(b *testing.B) {
+	if testing.Short() {
+		b.Skip("real-QUIC integration benchmark; skipped in -short")
+	}
 	configs := []struct{ size, fpg int }{
 		{1 << 10, 256},
 		{16 << 10, 1}, {16 << 10, 256},

--- a/moqt/egress_benchmark_test.go
+++ b/moqt/egress_benchmark_test.go
@@ -1,0 +1,224 @@
+package moqt
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+)
+
+// This file adds a SATURATING, unpaced real-QUIC egress benchmark — the harness
+// every other I/O benchmark in this package is NOT.
+//
+// Why this exists (the measured gap):
+//   - BenchmarkGroupWriter_WriteFrame writes to io.Discard (no-op Write) and so
+//     measures only the encode glue; its own comment notes the ~4.8M MB/s it
+//     reports is fake. It cannot see QUIC write cost.
+//   - BenchmarkStreamIo_RealQUIC and BenchmarkBroadcastServer_HighLoad reuse a
+//     publisher paced at ~30fps via a time.Ticker, so the transport is nearly
+//     idle (~300 frames/sec) and absolute throughput is publisher-limited, not
+//     egress-limited.
+//
+// BenchmarkEgress_Saturating streams frames back-to-back with NO ticker. QUIC
+// flow control paces the publisher to the subscriber's drain rate, so ns/op is
+// the true per-frame egress cost end-to-end (encode + QUIC framing + TLS +
+// packetization + UDP syscall). CPU-profile it to rank where that cost lives.
+//
+//	framesPerGroup (fpg) isolates the cost:
+//	  - 1   : one frame per group — OpenGroup overhead per frame (the broadcast
+//	          harness's pattern; worst case). Omitted at 1K: at that size the
+//	          per-group stream churn is fast enough to trip quic-go's idle
+//	          timeout before a group lands under -benchtime=1s.
+//	  - 256 : many frames per group — amortizes OpenGroup; isolates WriteFrame.
+//
+//	Matrix: 1K{fpg-256}, 16K{fpg-1,fpg-256}, 64K{fpg-1,fpg-256}.
+//
+// This is a real-QUIC integration benchmark (like BenchmarkStreamIo_RealQUIC),
+// so it is excluded from the PR microbenchmark run and measured in the
+// benchmark-integration job (-benchtime=1x) instead.
+//
+// Profile:
+//
+//	go test -run '^$' -bench 'BenchmarkEgress_Saturating/payload-1K/fpg-256$' \
+//	    -benchtime=5s -count=10 -cpuprofile=cpu.out -memprofile=mem.out ./moqt/
+
+func BenchmarkEgress_Saturating(b *testing.B) {
+	configs := []struct{ size, fpg int }{
+		{1 << 10, 256},
+		{16 << 10, 1}, {16 << 10, 256},
+		{64 << 10, 1}, {64 << 10, 256},
+	}
+
+	for _, c := range configs {
+		size, fpg := c.size, c.fpg
+		b.Run(fmt.Sprintf("payload-%s/fpg-%d", humanSize(size), fpg), func(b *testing.B) {
+			ctx := b.Context()
+
+			// The publisher streams from setup (no gate); QUIC flow control
+			// paces it to the subscriber's drain rate, so it stalls until the
+			// subscriber connects and the timed loop sees steady-state egress.
+			srv, addr := setupSaturatingServer(b, ctx, size, fpg)
+			defer closeBroadcastServer(b, srv)
+
+			sess, tr := dialAndSubscribe(b, ctx, addr)
+			defer sess.CloseWithError(NoError, "done")
+			defer tr.Close()
+
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			frame := NewFrame(size)
+			read := 0
+			for read < b.N {
+				gr, err := tr.AcceptGroup(ctx)
+				if err != nil {
+					if ctx.Err() != nil {
+						break
+					}
+					b.Fatalf("accept group: %v", err)
+				}
+				for {
+					if err := gr.ReadFrame(frame); err != nil {
+						if err == io.EOF {
+							break
+						}
+						b.Fatalf("read frame: %v", err)
+					}
+					read++
+					if read >= b.N {
+						break
+					}
+				}
+			}
+
+			b.StopTimer()
+		})
+	}
+}
+
+// setupSaturatingServer starts a real QUIC/WebTransport server whose publisher
+// streams frames back-to-back (NO ticker), writing framesPerGroup frames per
+// group. It reuses the proven TLS/quic/server wiring from
+// broadcast_benchmark_test.go verbatim; only the publisher pacing differs.
+func setupSaturatingServer(b *testing.B, ctx context.Context, frameSize, framesPerGroup int) (*Server, string) {
+	b.Helper()
+
+	// Grab a free UDP port for the QUIC listener.
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		b.Fatalf("failed to find available port: %v", err)
+	}
+	addr := pc.LocalAddr().String()
+	_ = pc.Close()
+
+	server := &Server{
+		Addr: addr,
+		TLSConfig: &tls.Config{
+			NextProtos:         []string{NextProtoH3, NextProtoMOQ},
+			Certificates:       []tls.Certificate{generateTestCert(b)},
+			InsecureSkipVerify: true,
+		},
+		QUICConfig: &quic.Config{Allow0RTT: true, EnableDatagrams: true},
+		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Handler:    HandleFunc(func(sess *Session) { <-sess.Context().Done() }),
+	}
+
+	// Publish the broadcast track on DefaultMux. Unpaced: no ticker.
+	PublishFunc(ctx, "/server.broadcast", func(tw *TrackWriter) {
+		frame := NewFrame(frameSize)
+		data := make([]byte, frameSize)
+		for i := range data {
+			data[i] = byte(i % 256)
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			gw, err := tw.OpenGroup()
+			if err != nil {
+				return
+			}
+			for i := 0; i < framesPerGroup; i++ {
+				frame.Reset()
+				frame.Write(data)
+				if err := gw.WriteFrame(frame); err != nil {
+					gw.CancelWrite(InternalGroupErrorCode)
+					return
+				}
+			}
+			if err := gw.Close(); err != nil {
+				return
+			}
+		}
+	})
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, ErrServerClosed) {
+			b.Logf("server error: %v", err)
+		}
+	}()
+
+	return server, "https://" + addr + "/broadcast"
+}
+
+// dialAndSubscribe connects a single client and subscribes to the broadcast
+// track, retrying the dial until the asynchronously-bound listener is ready
+// (same pattern as stream_io_benchmark_test.go).
+func dialAndSubscribe(b *testing.B, ctx context.Context, addr string) (*Session, *TrackReader) {
+	b.Helper()
+
+	client := Dialer{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+
+	ready, cancelWait := context.WithTimeout(ctx, 5*time.Second)
+	var sess *Session
+	for {
+		s, derr := client.Dial(ready, addr, nil)
+		if derr == nil {
+			sess = s
+			cancelWait()
+			break
+		}
+		if ready.Err() != nil {
+			cancelWait()
+			b.Fatalf("dial %s: %v (listener not ready or upgrade failed)", addr, derr)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	annRecv, err := sess.AcceptAnnounce("/")
+	if err != nil {
+		b.Fatalf("accept announce: %v", err)
+	}
+	defer annRecv.Close()
+
+	ann, err := annRecv.ReceiveAnnouncement(ctx)
+	if err != nil {
+		b.Fatalf("receive announcement: %v", err)
+	}
+	if !ann.IsActive() {
+		b.Fatal("announcement not active")
+	}
+
+	tr, err := sess.Subscribe(ctx, ann.BroadcastPath(), TrackName("index"), nil)
+	if err != nil {
+		b.Fatalf("subscribe: %v", err)
+	}
+	return sess, tr
+}

--- a/moqt/stream_io_benchmark_test.go
+++ b/moqt/stream_io_benchmark_test.go
@@ -45,6 +45,9 @@ import (
 // Note: ns/op and MB/s are PRELIMINARY — concurrent worktrees may perturb
 // timing. Treat numbers as comparative across payload sizes within one run.
 func BenchmarkStreamIo_RealQUIC(b *testing.B) {
+	if testing.Short() {
+		b.Skip("real-QUIC integration benchmark; skipped in -short")
+	}
 	sizes := []int{1 << 10, 16 << 10, 64 << 10} // 1K 16K 64K (harness cap at ~30fps makes 256K/1M slow)
 
 	for _, size := range sizes {


### PR DESCRIPTION
## What

Adds `BenchmarkEgress_Saturating` — a saturating (unpaced) real-QUIC egress benchmark that drives the full `GroupWriter.WriteFrame → frame.encode → QUIC stream Write` path under load.

## Why

Every existing I/O benchmark in the package fails to measure real egress cost:

- `BenchmarkGroupWriter_WriteFrame` writes to `io.Discard` (no-op Write) — its own comment notes the ~4.8M MB/s it reports is fake.
- `BenchmarkStreamIo_RealQUIC` and `BenchmarkBroadcastServer_HighLoad` pace the publisher at ~30fps via a `time.Ticker`, so the transport is nearly idle (~300 frames/sec) and throughput is publisher-limited, not egress-limited.

This harness streams frames back-to-back with **no ticker**; QUIC flow control paces the publisher to the subscriber's drain rate, so `ns/op` is the true per-frame egress cost end-to-end (encode + QUIC framing + TLS + packetization + UDP syscall).

## Matrix

`1K{fpg-256}`, `16K{fpg-1, fpg-256}`, `64K{fpg-1, fpg-256}`. `fpg` (frames per group) isolates OpenGroup overhead (1) from WriteFrame itself (256). `1K/fpg-1` is omitted: at that size the per-group stream churn trips quic-go's idle timeout under `-benchtime=1s`.

## Baseline + profiling verdict

Throughput is **flat ~100 MB/s across 1K→64K** (frames/sec drops ~50× as payload grows 64× → packet-send-bound, not encode-bound). CPU profile under `64K/fpg-256` (107 MB/s):

| region | share |
|---|---|
| `runtime.cgocall` (WSASendTo UDP write syscall) | **48%** |
| quic-go send path → `UDPConn.WriteTo` | ~45–52% cum |
| quic-go packetization (`packetPacker`, `Conn.run`) | ~16% |
| scheduler / netpoll / locks | ~15–20% |
| AES-GCM (encrypt + decrypt) | 0.67% |
| gomoqt `encode` / `WriteFrame` | **0% — not in the profile** |

**No production change** — this PR is measurement infrastructure only. The egress encode path is ~0% of cost; quic-go repacketizes stream bytes into MTU-sized packets regardless of how gomoqt chunks its `Write` calls, so no gomoqt-level change (batching / coalescing / pooling) can reduce the packet or syscall count.

## CI classification

`Egress_Saturating` is a real-QUIC integration benchmark (like `BenchmarkStreamIo_RealQUIC`), so it is added to the `-skip` list in both microbenchmark jobs (`go.yml` benchmark, `benchmark-label.yml` performance-check) and to the `-bench` list in `benchmark-integration` (run on main push, `-benchtime=1x`, not on PRs).
