### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix OOM DoS via unbounded varint allocation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2024-06-20 - Unbounded memory allocation in payload Decode
+
+**Vulnerability:** The application was vulnerable to Out-Of-Memory (OOM) Denial of Service (DoS) attacks. Unbounded allocation occurred because varint sizes were read and directly passed to `make([]byte, size)` during payload decoding without checking limits.
+
+**Learning:** When parsing variable length inputs, trusting the encoded length directly can cause memory exhaustion. Testing correctly identifies the maximum parseable integer value in benchmarks, but failed to exercise OOM behavior when the test input omitted the actual bytes.
+
+**Prevention:** Apply a hard upper bound limit before allocating buffers for payloads based on network varints. Limit memory allocation size to prevent DoS.

--- a/moqt/counting_send_stream_test.go
+++ b/moqt/counting_send_stream_test.go
@@ -112,9 +112,9 @@ func (c *CountingSendStream) Inner() transport.SendStream { return c.inner }
 
 // WriteCounters is an immutable snapshot of the counting stream's state.
 type WriteCounters struct {
-	WriteCalls  int64   // total number of Write calls observed
-	BytesWritten int64  // total bytes successfully written
-	Buckets     []int64 // write-size histogram (index = floor(log2(size)), size 0 -> 0)
+	WriteCalls   int64   // total number of Write calls observed
+	BytesWritten int64   // total bytes successfully written
+	Buckets      []int64 // write-size histogram (index = floor(log2(size)), size 0 -> 0)
 }
 
 // Snapshot returns a consistent point-in-time view of the counters.

--- a/moqt/frame.go
+++ b/moqt/frame.go
@@ -93,6 +93,10 @@ func (f *Frame) decode(src io.Reader) error {
 	}
 
 	// Ensure the payload slice has enough capacity
+	if num > message.MaxMessageSize {
+		return message.ErrMessageTooLarge
+	}
+
 	if cap(f.body) < int(num) {
 		f.body = make([]byte, num)
 	} else {

--- a/moqt/internal/message/announce.go
+++ b/moqt/internal/message/announce.go
@@ -58,6 +58,9 @@ func (am *AnnounceMessage) Decode(src io.Reader) error {
 		return err
 	}
 
+	if size > MaxMessageSize {
+		return ErrMessageTooLarge
+	}
 	b := make([]byte, size)
 
 	_, err = io.ReadFull(src, b)

--- a/moqt/internal/message/announce_interest.go
+++ b/moqt/internal/message/announce_interest.go
@@ -39,6 +39,9 @@ func (aim *AnnounceInterestMessage) Decode(src io.Reader) error {
 		return err
 	}
 
+	if num > MaxMessageSize {
+		return ErrMessageTooLarge
+	}
 	b := make([]byte, num)
 
 	_, err = io.ReadFull(src, b)

--- a/moqt/internal/message/fetch.go
+++ b/moqt/internal/message/fetch.go
@@ -38,6 +38,9 @@ func (f *FetchMessage) Decode(src io.Reader) error {
 		return err
 	}
 
+	if size > MaxMessageSize {
+		return ErrMessageTooLarge
+	}
 	b := make([]byte, size)
 
 	_, err = io.ReadFull(src, b)

--- a/moqt/internal/message/goaway.go
+++ b/moqt/internal/message/goaway.go
@@ -36,6 +36,9 @@ func (gm *GoawayMessage) Decode(src io.Reader) error {
 		return err
 	}
 
+	if num > MaxMessageSize {
+		return ErrMessageTooLarge
+	}
 	b := make([]byte, num)
 
 	_, err = io.ReadFull(src, b)

--- a/moqt/internal/message/group.go
+++ b/moqt/internal/message/group.go
@@ -38,6 +38,9 @@ func (g *GroupMessage) Decode(src io.Reader) error {
 		return err
 	}
 
+	if size > MaxMessageSize {
+		return ErrMessageTooLarge
+	}
 	b := make([]byte, size)
 
 	_, err = io.ReadFull(src, b)

--- a/moqt/internal/message/message.go
+++ b/moqt/internal/message/message.go
@@ -1,8 +1,12 @@
 package message
 
 import (
+	"errors"
 	"fmt"
 )
+
+const MaxMessageSize = 50 * 1024 * 1024 // 50MB
+var ErrMessageTooLarge = errors.New("message too large")
 
 func VarintLen(i uint64) int {
 	if i <= maxVarInt1 {

--- a/moqt/internal/message/probe.go
+++ b/moqt/internal/message/probe.go
@@ -38,6 +38,9 @@ func (pm *ProbeMessage) Decode(src io.Reader) error {
 		return err
 	}
 
+	if size > MaxMessageSize {
+		return ErrMessageTooLarge
+	}
 	b := make([]byte, size)
 
 	_, err = io.ReadFull(src, b)

--- a/moqt/internal/message/subscribe.go
+++ b/moqt/internal/message/subscribe.go
@@ -72,6 +72,9 @@ func (s *SubscribeMessage) Decode(src io.Reader) error {
 		return err
 	}
 
+	if size > MaxMessageSize {
+		return ErrMessageTooLarge
+	}
 	b := make([]byte, size)
 
 	_, err = io.ReadFull(src, b)

--- a/moqt/internal/message/subscribe_drop.go
+++ b/moqt/internal/message/subscribe_drop.go
@@ -56,6 +56,9 @@ func (sdm *SubscribeDropMessage) Decode(src io.Reader) error {
 		return err
 	}
 
+	if size > MaxMessageSize {
+		return ErrMessageTooLarge
+	}
 	b := make([]byte, size)
 
 	_, err = io.ReadFull(src, b)

--- a/moqt/internal/message/subscribe_ok.go
+++ b/moqt/internal/message/subscribe_ok.go
@@ -53,6 +53,9 @@ func (som *SubscribeOkMessage) Decode(src io.Reader) error {
 		return err
 	}
 
+	if num > MaxMessageSize {
+		return ErrMessageTooLarge
+	}
 	b := make([]byte, num)
 	_, err = io.ReadFull(src, b)
 	if err != nil {

--- a/moqt/internal/message/subscribe_update.go
+++ b/moqt/internal/message/subscribe_update.go
@@ -48,6 +48,9 @@ func (sum *SubscribeUpdateMessage) Decode(src io.Reader) error {
 		return err
 	}
 
+	if size > MaxMessageSize {
+		return ErrMessageTooLarge
+	}
 	b := make([]byte, size)
 
 	_, err = io.ReadFull(src, b)

--- a/moqt/internal/message/wire_benchmark_test.go
+++ b/moqt/internal/message/wire_benchmark_test.go
@@ -531,10 +531,10 @@ var varintMagnitudes = []struct {
 	val  uint64
 }{
 	{"0", 0},
-	{"127", 127},        // maxVarInt1 (1-byte)
-	{"16383", 16383},    // maxVarInt2 (2-byte)
-	{"1<<21", 1 << 21},  // inside 4-byte bucket
-	{"1<<28", 1 << 28},  // inside 4-byte bucket
+	{"127", 127},             // maxVarInt1 (1-byte)
+	{"16383", 16383},         // maxVarInt2 (2-byte)
+	{"1<<21", 1 << 21},       // inside 4-byte bucket
+	{"1<<28", 1 << 28},       // inside 4-byte bucket
 	{"maxUint62", maxUint62}, // maxVarInt8 (8-byte, max valid)
 }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application was vulnerable to Out-Of-Memory (OOM) Denial of Service (DoS) attacks. Unbounded memory allocation occurred because variable-length integers (varints) from the network were read and directly passed to `make([]byte, size)` during payload decoding across multiple message types and frames, without any size validation. A maliciously crafted message with a massive length prefix but no actual payload bytes would cause the server to allocate gigabytes of memory and crash instantly.
🎯 Impact: Unauthenticated attackers could remotely crash the application by sending a single tiny, malformed packet, causing memory exhaustion and service downtime.
🔧 Fix: Added a hard upper bound `MaxMessageSize` constant (50MB) and an `ErrMessageTooLarge` error definition. Injected checks against this limit immediately before every `make([]byte, size)` and `make([]byte, num)` allocation in the 10 payload `Decode` methods and `moqt.Frame.decode`. 
✅ Verification: Ran `go test ./...` and `go vet ./...` to ensure no legitimate functionality is broken. Added a journal entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16118377371151660500](https://jules.google.com/task/16118377371151660500) started by @okdaichi*