### PR TITLE
⚡ Bolt: Optimize WriteString for zero-allocation string appending

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-21 - String encoding allocations
+**Learning:** In Go, passing a `string` to a function that accepts `[]byte` by doing `[]byte(s)` forces a heap allocation, even if the bytes are immediately appended. However, using `append([]byte, s...)` is handled natively by the compiler and performs a zero-allocation direct copy from the string to the slice.
+**Action:** When appending strings to a byte slice in hot paths like network encoding (`WriteString` or `WriteStringArray`), always use `append(dest, s...)` directly instead of converting to bytes or passing to byte-writing functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **moqt:** Optimized string serialization in `message_writer.go` by adopting zero-allocation string appends (`append([]byte, string...)`), reducing GC pressure in message encoding hot paths.
 - **moqt/internal/message:** `ReadMessageLength` now fast-paths `io.ByteReader` (bytes.Reader, bufio.Reader, QUIC streams), eliminating a per-call heap allocation (1 → 0) and ~65% faster varint-length decoding. Behavior is unchanged; non-ByteReader callers use the previous allocating path.
 - **Dependencies:** Updated `quic-go` to v0.60.0.
 ### Removed

--- a/moqt/internal/message/message_writer.go
+++ b/moqt/internal/message/message_writer.go
@@ -47,15 +47,21 @@ func WriteBytes(dest []byte, b []byte) ([]byte, int) {
 	return dest, n + len(b)
 }
 
+// WriteString appends a string to the byte slice directly, avoiding string-to-bytes conversion allocations.
 func WriteString(dest []byte, s string) ([]byte, int) {
-	return WriteBytes(dest, []byte(s))
+	dest, n := WriteVarint(dest, uint64(len(s)))
+	dest = append(dest, s...)
+	return dest, n + len(s)
 }
 
+// WriteStringArray appends an array of strings, inlining the string append for zero-allocation performance.
 func WriteStringArray(dest []byte, arr []string) ([]byte, int) {
 	dest, n := WriteVarint(dest, uint64(len(arr)))
 	var m int
 	for _, str := range arr {
-		dest, m = WriteString(dest, str)
+		dest, m = WriteVarint(dest, uint64(len(str)))
+		dest = append(dest, str...)
+		m += len(str)
 		n += m
 	}
 	return dest, n


### PR DESCRIPTION
💡 **What:** Changed `WriteString` and `WriteStringArray` in `message_writer.go` to directly use `append(dest, string...)` instead of casting strings to byte slices first or passing them to `WriteBytes`.
🎯 **Why:** In Go, passing a `string` to a `[]byte` argument like `[]byte(s)` triggers a heap allocation. However, `append([]byte, string...)` is specially optimized by the compiler to directly copy the memory without allocating a new byte slice. This prevents unnecessary memory allocation when serializing variables.
📊 **Impact:** Reduces memory allocations in message serialization hot paths (0 allocs per op instead of 1 alloc per string).
🔬 **Measurement:** `go test -bench . -benchmem ./moqt/internal/message` shows a measurable speed up on `WriteString` with 0 allocations. All unit tests pass cleanly.

---
*PR created automatically by Jules for task [5536855669123589882](https://jules.google.com/task/5536855669123589882) started by @okdaichi*