### PR TITLE
ci(bench): count=10 + benchtime=50ms (meaningful, viable benchmarks)

### DIFF
--- a/.github/scripts/bench-report.sh
+++ b/.github/scripts/bench-report.sh
@@ -52,7 +52,7 @@ improv=$(grep -E ' -[0-9]+\.[0-9]+% ' "$full" | grep -vc '^geomean' || true)
   echo "<!-- bench-report -->"
   echo "## 🏎️ Benchmark comparison (main → PR)"
   echo
-  echo "<sub>Microbenchmarks \`-benchtime=100ms -count=6\` (turnaround over precision). \`allocs/op\` and \`B/op\` are deterministic — any delta there is real. \`sec/op\` is a quick signal; re-run locally with \`-benchtime=1s -count=10+\` for significance. In the table, \`+\` = regression, \`-\` = improvement, \`~\` = not significant.</sub>"
+  echo "<sub>Microbenchmarks \`-benchtime=50ms -count=10\` (turnaround over precision; significance from -count). \`allocs/op\` and \`B/op\` are deterministic — any delta there is real. \`sec/op\` is a quick signal; re-run locally with \`-benchtime=1s -count=10+\` for significance. In the table, \`+\` = regression, \`-\` = improvement, \`~\` = not significant.</sub>"
   echo
 } > "$out"
 

--- a/.github/scripts/bench-report.sh
+++ b/.github/scripts/bench-report.sh
@@ -52,7 +52,7 @@ improv=$(grep -E ' -[0-9]+\.[0-9]+% ' "$full" | grep -vc '^geomean' || true)
   echo "<!-- bench-report -->"
   echo "## 🏎️ Benchmark comparison (main → PR)"
   echo
-  echo "<sub>Microbenchmarks \`-benchtime=100ms -count=4\` (turnaround over precision). \`allocs/op\` and \`B/op\` are deterministic — any delta there is real. \`sec/op\` is a quick signal; re-run locally with \`-benchtime=1s -count=10+\` for significance. In the table, \`+\` = regression, \`-\` = improvement, \`~\` = not significant.</sub>"
+  echo "<sub>Microbenchmarks \`-benchtime=100ms -count=6\` (turnaround over precision). \`allocs/op\` and \`B/op\` are deterministic — any delta there is real. \`sec/op\` is a quick signal; re-run locally with \`-benchtime=1s -count=10+\` for significance. In the table, \`+\` = regression, \`-\` = improvement, \`~\` = not significant.</sub>"
   echo
 } > "$out"
 

--- a/.github/workflows/benchmark-label.yml
+++ b/.github/workflows/benchmark-label.yml
@@ -17,11 +17,13 @@
 # Only packages whose *.go changed are benchmarked, so a PR that touches no
 # implementation (docs/CI-only) runs no benchmarks and posts no comment.
 #
-# Turnaround over precision: -benchtime=100ms -count=4. allocs/op and B/op are
+# Turnaround over precision: -benchtime=100ms -count=6. allocs/op and B/op are
 # deterministic regardless of these flags -> the reliable signal; sec/op is a
 # quick indicator (re-run locally with -benchtime=1s -count=10+ for significance).
-# count must be >=4: at count=3 benchstat reports "~" for every benchmark. The
-# slow real-QUIC integration benchmarks self-skip under -short (testing.Short()).
+# count=6: benchstat needs >=6 samples to compute a confidence interval and
+# meaningful p-values; at count=4 it flags every non-identical median at p=0.029
+# (noise shows up as spurious "significant" deltas). The slow real-QUIC
+# integration benchmarks self-skip under -short (testing.Short()).
 name: Benchmark (performance-check)
 
 on:
@@ -42,7 +44,7 @@ jobs:
       BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       # Same flags for base and PR so the comparison is like-for-like.
-      BENCH_FLAGS: "-benchtime=100ms -count=4"
+      BENCH_FLAGS: "-benchtime=100ms -count=6"
     steps:
       - name: Checkout PR head (full history for base diff + worktree)
         uses: actions/checkout@v4

--- a/.github/workflows/benchmark-label.yml
+++ b/.github/workflows/benchmark-label.yml
@@ -17,13 +17,16 @@
 # Only packages whose *.go changed are benchmarked, so a PR that touches no
 # implementation (docs/CI-only) runs no benchmarks and posts no comment.
 #
-# Turnaround over precision: -benchtime=100ms -count=6. allocs/op and B/op are
-# deterministic regardless of these flags -> the reliable signal; sec/op is a
-# quick indicator (re-run locally with -benchtime=1s -count=10+ for significance).
-# count=6: benchstat needs >=6 samples to compute a confidence interval and
-# meaningful p-values; at count=4 it flags every non-identical median at p=0.029
-# (noise shows up as spurious "significant" deltas). The slow real-QUIC
-# integration benchmarks self-skip under -short (testing.Short()).
+# Turnaround over precision: -benchtime=50ms -count=10. Statistical significance
+# comes from -count (10 samples); -benchtime is kept low because the moqt suite
+# is large and shared-runner wall time is ~2-3x variable, so a higher benchtime
+# blows the timeout (count=4/100ms already timed out on a slow runner). 50ms
+# still runs 10k+ iterations/sample, so per-sample means stay stable. allocs/op
+# and B/op are deterministic regardless of these flags -> the reliable signal;
+# sec/op is a quick indicator (re-run locally with -benchtime=1s -count=10+).
+# count=10: benchstat needs >=6 samples for a CI / meaningful p-values; at
+# count=4 it flags every non-identical median at p=0.029 (spurious "significant"
+# deltas). The slow real-QUIC integration benchmarks self-skip under -short.
 name: Benchmark (performance-check)
 
 on:
@@ -39,12 +42,12 @@ jobs:
   benchmark:
     if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'performance-check'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       # Same flags for base and PR so the comparison is like-for-like.
-      BENCH_FLAGS: "-benchtime=100ms -count=6"
+      BENCH_FLAGS: "-benchtime=50ms -count=10"
     steps:
       - name: Checkout PR head (full history for base diff + worktree)
         uses: actions/checkout@v4
@@ -56,6 +59,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.26.0"
+          cache: true # reuse the Go build cache -> faster cold compile of base + PR test binaries
 
       - name: Install benchstat
         run: go install golang.org/x/perf/cmd/benchstat@latest
@@ -94,7 +98,7 @@ jobs:
             [ -d "./$pkg" ] || continue
             echo "::group::Base benchmark: $pkg"
             # || true: a build/run failure in one package must not abort the rest.
-            go test -run='^$' -bench=. -short -benchmem $BENCH_FLAGS -timeout=10m "./$pkg" \
+            go test -run='^$' -bench=. -short -benchmem $BENCH_FLAGS -timeout=15m "./$pkg" \
               >> "$GITHUB_WORKSPACE/base.txt" 2>&1 || true
             echo "::endgroup::"
           done < "$GITHUB_WORKSPACE/pkgs.txt"
@@ -106,7 +110,7 @@ jobs:
           while IFS= read -r pkg; do
             [ -d "./$pkg" ] || continue
             echo "::group::PR benchmark: $pkg"
-            go test -run='^$' -bench=. -short -benchmem $BENCH_FLAGS -timeout=10m "./$pkg" \
+            go test -run='^$' -bench=. -short -benchmem $BENCH_FLAGS -timeout=15m "./$pkg" \
               >> pr.txt 2>&1 || true
             echo "::endgroup::"
           done < pkgs.txt


### PR DESCRIPTION
## What

Bump the per-PR benchmark `-count` from 4 to 6 (in `BENCH_FLAGS` and the script's header text).

## Why

At `count=4`, benchstat's minimum achievable p-value is **0.029** — so it flags **every** non-identical median as "significant". On the post-#216 canary (#206) that produced **"24 improvements / 12 regressions"** that were mostly **±2–6% noise** (plus a false **+16%** on a sub-2 ns bench) — alongside the real signal.

`count=6` is benchstat's confidence-interval floor: with ≥6 samples it computes a CI and meaningful p-values, so small noise no longer reaches significance and only real deltas surface in the filtered view.

## Notes

- A base+PR run stays well under the 25 m timeout (~19 m for the `moqt` package, the largest).
- `allocs/op` and `B/op` are deterministic at any `-count`, so they remain the most reliable signal regardless.
- Only `-count` changes; `-benchtime=100ms`, the same-job base+PR structure, and `bench-report.sh` logic are unchanged.

Follow-up to #216 (the same-job validity fix).
