### PR TITLE
fix(moqt): nil-map race in AnnouncementWriter.SendAnnouncement (flaky race job)

### DIFF
--- a/moqt/announcement_writer.go
+++ b/moqt/announcement_writer.go
@@ -237,6 +237,14 @@ func (aw *AnnouncementWriter) SendAnnouncement(announcement *Announcement) error
 	aw.mu.Lock()
 	defer aw.mu.Unlock()
 
+	// The writer may have been Closed (or CloseWithError'd) while the lock was
+	// released above to call the previous announcement's end handler -- Close
+	// nils aw.actives. Re-check before encoding: assigning into a nil map panics,
+	// and we must not encode onto a closing stream.
+	if aw.actives == nil {
+		return nil
+	}
+
 	// Encode and send ACTIVE announcement
 	err := message.AnnounceMessage{
 		AnnounceStatus:      message.ACTIVE,


### PR DESCRIPTION
## Problem
`go test -race` intermittently panics in `AnnouncementWriter.SendAnnouncement`:
```
panic: assignment to entry in nil map
  announcement_writer.go:256   aw.actives[suffix] = ...
  mux.go:339                   serveAnnouncements
  mux_test.go:1784             TestMux_ServeAnnouncements_ConcurrentAnnounce_NoDeadlock
```
This makes go.yml's `race` job **flaky on main** (failed 06-17 ×2, 06-19) and on PRs that touch anything in `moqt`.

## Cause
`SendAnnouncement` reads `aw.actives` under its **first** lock, then **releases the lock** to call the previous announcement's `end()`, then reacquires and does `aw.actives[suffix] = ...`. `Close()` / `CloseWithError()` nil out `aw.actives` — so if a close lands in that unlocked window, the assignment hits a nil map and panics. Classic TOCTOU.

## Fix
After reacquiring the lock, re-check `aw.actives == nil` and return early: a closing writer shouldn't encode onto its stream or assign into the (nilled) map.

- Pre-existing bug — **not** introduced by any open perf PR (#200–#206 don't touch `announcement_writer.go`).
- The `performance-check` benchmark workflow is unaffected (it runs `-bench`, not this test), but this clears the red `race` check on the perf PRs.

## Verification
`go build ./moqt/` passes. The existing `TestMux_ServeAnnouncements_ConcurrentAnnounce_NoDeadlock` exercises the racy path; the guard turns the intermittent panic into a clean early-return.
