### PR TITLE
🧪 [testing improvement] Improve TestTrackRef_Clone coverage and deep copy verification

### DIFF
--- a/.jules/testing.md
+++ b/.jules/testing.md
@@ -1,0 +1,4 @@
+## 2024-06-22 - Testing Go Deep Copy Logic
+**Context:** Improved testing for a Go map containing `json.RawMessage` (which is an alias for `[]byte`).
+**Learning:** Testing deep copies of nested slices (like `map[string][]byte`) requires mutating an element inside the slice rather than simply re-assigning the map key. If only the map key is re-assigned, it only proves the maps are distinct, but does not prove the underlying slice data is distinct.
+**Solution:** `clone.ExtraFields["x"][1] = '9'` to test the slice memory boundaries instead of `clone.ExtraFields["x"] = ...`

--- a/msf/catalog_test.go
+++ b/msf/catalog_test.go
@@ -998,16 +998,26 @@ func TestTrackRef_Clone(t *testing.T) {
 	ref := TrackRef{
 		Namespace:   "live",
 		Name:        "video",
-		ExtraFields: map[string]json.RawMessage{"x": json.RawMessage(`1`)},
+		ExtraFields: map[string]json.RawMessage{
+			"x":      json.RawMessage(`[1, 2, 3]`),
+			"nilval": nil,
+		},
 	}
 
 	clone := ref.Clone()
 	assert.Equal(t, ref.Namespace, clone.Namespace)
 	assert.Equal(t, ref.Name, clone.Name)
 	assert.Contains(t, clone.ExtraFields, "x")
+	assert.Contains(t, clone.ExtraFields, "nilval")
+	assert.Nil(t, clone.ExtraFields["nilval"])
 
-	clone.ExtraFields["x"] = json.RawMessage(`2`)
-	assert.Equal(t, json.RawMessage(`1`), ref.ExtraFields["x"])
+	// Test byte slice deep copy: mutating clone's underlying slice should not affect original
+	clone.ExtraFields["x"][1] = '9'
+	assert.Equal(t, byte('1'), ref.ExtraFields["x"][1], "original byte slice should not be mutated")
+
+	// Test map shallow copy: re-assigning map entry should not affect original
+	clone.ExtraFields["y"] = json.RawMessage(`[4, 5, 6]`)
+	assert.NotContains(t, ref.ExtraFields, "y")
 }
 
 func TestTrackRef_effectiveNamespace(t *testing.T) {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `TrackRef.Clone()` was tested for map isolation but did not verify the deep-copy isolation of the underlying byte slices (`json.RawMessage`) or handle `nil` branches within the map.

📊 **Coverage:** `TestTrackRef_Clone` now explicitly tests:
- `nil` values within `ExtraFields` mapping.
- Map distinctness by adding new keys instead of overwriting existing ones.
- Byte slice deep-copy boundaries by mutating underlying byte array elements (`clone.ExtraFields["x"][1] = '9'`) and ensuring the original struct is unharmed.

✨ **Result:** Improved robustness by asserting that true deep copies of `TrackRef` occur and increased `cloneRawMessage` test coverage.

---
*PR created automatically by Jules for task [4601435540187784364](https://jules.google.com/task/4601435540187784364) started by @okdaichi*