### PR TITLE
test(bench): fix pervasive bytes.Repeat(b.N+1) decode benches; add field-coder + routing benches

### DIFF
--- a/moqt/group_benchmark_test.go
+++ b/moqt/group_benchmark_test.go
@@ -16,6 +16,29 @@ func newBenchmarkSendStream(writer io.Writer) *FakeQUICSendStream {
 	return &FakeQUICSendStream{WriteFunc: writer.Write}
 }
 
+// loopReader is an io.Reader that yields src's bytes forever, wrapping around
+// with no allocation and no EOF. It replaces the bytes.Repeat(src, b.N+1)
+// pattern in benchmarks whose hot loop cannot tolerate the per-drain cost of a
+// reader running dry: instead of a b.N-proportional input buffer (which OOMs
+// CI on slow runners and inflates sec/op via GC scan of a huge live heap), the
+// input is a single copy of src, repeated on demand. src must be non-empty.
+type loopReader struct {
+	src []byte
+	off int
+}
+
+func (r *loopReader) Read(p []byte) (int, error) {
+	if len(p) == 0 || len(r.src) == 0 {
+		return 0, nil
+	}
+	n := copy(p, r.src[r.off:])
+	for n < len(p) {
+		n += copy(p[n:], r.src)
+	}
+	r.off = (r.off + n) % len(r.src)
+	return n, nil
+}
+
 // BenchmarkGroupReader_ReadFrame benchmarks reading frames from a group
 func BenchmarkGroupReader_ReadFrame(b *testing.B) {
 	frameSizes := []int{64, 1024, 16384, 65536} // Different frame sizes
@@ -36,9 +59,12 @@ func BenchmarkGroupReader_ReadFrame(b *testing.B) {
 			_ = testFrame.encode(&buf)
 			encodedData := buf.Bytes()
 
-			// Create a repeating reader for the benchmark
-			repeatingData := bytes.Repeat(encodedData, b.N+1)
-			reader := bytes.NewReader(repeatingData)
+			// loopReader yields the encoded frame forever with no allocation
+			// and no EOF, so the hot loop needs neither a b.N-proportional
+			// input buffer (bytes.Repeat(encodedData, b.N+1), which OOMs CI)
+			// nor the stream/groupReader rebuild + mid-loop b.ResetTimer() the
+			// EOF path used (which polluted allocs/op with rebuild allocations).
+			reader := &loopReader{src: encodedData}
 
 			// Wrap the reader to implement ReceiveStream
 			recvStream := newBenchmarkReceiveStream(reader)
@@ -53,15 +79,7 @@ func BenchmarkGroupReader_ReadFrame(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				frame.Reset()
-				err := groupReader.ReadFrame(frame)
-				if err == io.EOF {
-					b.ResetTimer()
-					reader = bytes.NewReader(repeatingData)
-					recvStream = newBenchmarkReceiveStream(reader)
-					groupReader = newGroupReader(GroupSequence(1), recvStream, nil)
-					continue
-				}
-				if err != nil {
+				if err := groupReader.ReadFrame(frame); err != nil {
 					b.Fatalf("ReadFrame failed: %v", err)
 				}
 			}
@@ -118,8 +136,6 @@ func BenchmarkGroupReader_ConcurrentRead(b *testing.B) {
 			_ = testFrame.encode(&buf)
 			encodedData := buf.Bytes()
 
-			repeatingData := bytes.Repeat(encodedData, b.N*conc+1)
-
 			b.ReportAllocs()
 			b.ResetTimer()
 
@@ -130,15 +146,17 @@ func BenchmarkGroupReader_ConcurrentRead(b *testing.B) {
 				go func() {
 					defer wg.Done()
 
-					reader := bytes.NewReader(repeatingData)
+					// Each goroutine gets its own loopReader (one frame,
+					// repeated forever, no allocation, no EOF), replacing the
+					// b.N*conc+1 shared buffer that scaled with b.N and OOM'd CI.
+					reader := &loopReader{src: encodedData}
 					recvStream := newBenchmarkReceiveStream(reader)
 					groupReader := newGroupReader(GroupSequence(1), recvStream, nil)
 					frame := NewFrame(frameSize)
 
 					for i := 0; i < b.N/conc; i++ {
 						frame.Reset()
-						err := groupReader.ReadFrame(frame)
-						if err != nil {
+						if err := groupReader.ReadFrame(frame); err != nil {
 							return
 						}
 					}
@@ -240,12 +258,15 @@ func BenchmarkGroupReader_MemoryAllocation(b *testing.B) {
 	var buf bytes.Buffer
 	_ = testFrame.encode(&buf)
 	encodedData := buf.Bytes()
-	repeatingData := bytes.Repeat(encodedData, b.N+1)
+	// Each iteration reads exactly one frame from a fresh stream, so a single
+	// loopReader (one frame, no EOF) suffices — replacing
+	// bytes.Repeat(encodedData, b.N+1), which allocated a b.N-proportional
+	// buffer whose tail was never read.
 
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		reader := bytes.NewReader(repeatingData)
+		reader := &loopReader{src: encodedData}
 		recvStream := newBenchmarkReceiveStream(reader)
 		groupReader := newGroupReader(GroupSequence(1), recvStream, nil)
 

--- a/moqt/internal/message/primitives_benchmark_test.go
+++ b/moqt/internal/message/primitives_benchmark_test.go
@@ -1,0 +1,269 @@
+package message
+
+import (
+	"bytes"
+	"testing"
+)
+
+// This file benchmarks the per-field wire coders (message_reader.go /
+// message_writer.go) in isolation. They are the hottest pure-compute path in
+// the library — every field on every message flows through them — yet they had
+// no direct benchmarks, which is why optimization PRs such as #198 (ReadString
+// via unsafe.String) and #214 (WriteString) could not be measured directly and
+// the benchmark workflow posted "No significant changes". The composite
+// *Message_Decode benches blur these costs together; these isolate them so a
+// future change to one coder can be attributed precisely.
+//
+// Measurement notes (the suite's recurring traps, guarded against here):
+//   - Inputs are pre-encoded ONCE outside the timer into a fixed-size tile, so
+//     the input buffer never scales with b.N (the #213 bytes.Repeat(b, b.N+1)
+//     trap that OOMs CI). Read coders advance an offset into the tile rather
+//     than allocating per iteration.
+//   - Write coders reuse one destination buffer (reset to [:0] each iteration),
+//     so append() never grows it (the #192 growable-buffer trap).
+//   - Every return value is sunk into a package-level var so the compiler
+//     cannot dead-code-eliminate the measured call.
+
+var (
+	sinkUint64 uint64
+	sinkStr    string
+	sinkSlice  []byte
+	sinkArr    []string
+	sinkInt    int
+)
+
+// tile replicates b into a ~64 KiB buffer. The size is a CONSTANT (does not
+// scale with b.N), so unlike bytes.Repeat(b, b.N+1) it cannot OOM or inflate GC
+// pressure as the benchmark iterates more.
+func tile(b []byte) []byte {
+	const budget = 1 << 16 // 64 KiB
+	return bytes.Repeat(b, budget/len(b)+1)
+}
+
+// --- Read side ---
+
+// BenchmarkReadVarint measures varint decoding at each of the four legal widths.
+// The input for each width is pre-encoded once and tiled; the loop only slices
+// and advances an offset (no allocation), sinking the decoded value + length so
+// the decode cannot be eliminated.
+func BenchmarkReadVarint(b *testing.B) {
+	widths := []struct {
+		name string
+		val  uint64
+	}{
+		{"1byte", maxVarInt1},     // top-2-bits 0b00
+		{"2byte", maxVarInt2},     // top-2-bits 0b01
+		{"4byte", maxVarInt4},     // top-2-bits 0b10
+		{"8byte", maxVarInt8},     // top-2-bits 0b11
+	}
+	for _, w := range widths {
+		b.Run(w.name, func(b *testing.B) {
+			enc := make([]byte, 0, 8)
+			enc, _ = WriteVarint(enc, w.val)
+			repeating := tile(enc)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(enc)))
+			b.ResetTimer()
+
+			off := 0
+			for b.Loop() {
+				if off+len(enc) > len(repeating) {
+					off = 0
+				}
+				v, n, err := ReadVarint(repeating[off:])
+				if err != nil {
+					b.Fatal(err)
+				}
+				sinkUint64 = v
+				sinkInt = n
+				off += n
+			}
+		})
+	}
+}
+
+// BenchmarkReadBytes measures length-prefixed byte-slice decoding. ReadBytes
+// returns an aliased sub-slice of the input (b[:num]), so the expected cost is
+// 0 allocs/op; the returned slice is sunk so the slice + prefix decode stay live.
+func BenchmarkReadBytes(b *testing.B) {
+	payload := []byte("hello-world-payload") // 19 bytes -> 1-byte varint prefix
+	enc := make([]byte, 0, len(payload)+1)
+	enc, _ = WriteBytes(enc, payload)
+	repeating := tile(enc)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(enc)))
+	b.ResetTimer()
+
+	off := 0
+	for b.Loop() {
+		if off+len(enc) > len(repeating) {
+			off = 0
+		}
+		bs, n, err := ReadBytes(repeating[off:])
+		if err != nil {
+			b.Fatal(err)
+		}
+		sinkSlice = bs
+		sinkInt = n
+		off += n
+	}
+}
+
+// BenchmarkReadString measures ReadString. ReadString does string(str) on the
+// aliased sub-slice, which COPIES the bytes into a new backing array, so the
+// expected cost is 1 alloc/op. This is the allocation #198 (unsafe.String)
+// tried to remove; sinking the string into sinkStr also defeats any
+// escape-to-stack optimization that could hide the copy.
+func BenchmarkReadString(b *testing.B) {
+	payload := []byte("hello-world-payload")
+	enc := make([]byte, 0, len(payload)+1)
+	enc, _ = WriteBytes(enc, payload)
+	repeating := tile(enc)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(enc)))
+	b.ResetTimer()
+
+	off := 0
+	for b.Loop() {
+		if off+len(enc) > len(repeating) {
+			off = 0
+		}
+		s, n, err := ReadString(repeating[off:])
+		if err != nil {
+			b.Fatal(err)
+		}
+		sinkStr = s
+		sinkInt = n
+		off += n
+	}
+}
+
+// BenchmarkReadStringArray measures count-prefixed string-array decoding.
+// ReadStringArray allocates the backing slice (make([]string, 0, count)) plus
+// one copied string per element, so the expected cost is >=2 allocs/op for a
+// non-degenerate array. A 3-element array is used so the result is
+// representative rather than the degenerate 0/1-element case.
+func BenchmarkReadStringArray(b *testing.B) {
+	arr := []string{"alpha", "beta", "gamma"}
+	enc := make([]byte, 0, 32)
+	enc, _ = WriteStringArray(enc, arr)
+	repeating := tile(enc)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(enc)))
+	b.ResetTimer()
+
+	off := 0
+	for b.Loop() {
+		if off+len(enc) > len(repeating) {
+			off = 0
+		}
+		a, n, err := ReadStringArray(repeating[off:])
+		if err != nil {
+			b.Fatal(err)
+		}
+		sinkArr = a
+		sinkInt = n
+		off += n
+	}
+}
+
+// --- Write side ---
+//
+// All write coders reuse a single destination buffer, reset to [:0] each
+// iteration so append() never grows it. b.SetBytes uses a one-time probe
+// outside the timer for the exact encoded length (not derived from the value's
+// bit pattern, which is error-prone). []byte(s) inside WriteString is a free
+// no-op conversion per escape analysis, so these report 0 allocs/op — the
+// asymmetry with ReadString's 1 alloc/op is the signal these benches preserve.
+
+func BenchmarkWriteVarint(b *testing.B) {
+	widths := []struct {
+		name string
+		val  uint64
+	}{
+		{"1byte", maxVarInt1},
+		{"2byte", maxVarInt2},
+		{"4byte", maxVarInt4},
+		{"8byte", maxVarInt8},
+	}
+	for _, w := range widths {
+		b.Run(w.name, func(b *testing.B) {
+			probe := make([]byte, 0, 8)
+			_, encLen := WriteVarint(probe, w.val)
+
+			dest := make([]byte, 0, 8) // cap covers the widest single varint
+
+			b.ReportAllocs()
+			b.SetBytes(int64(encLen))
+			b.ResetTimer()
+
+			for b.Loop() {
+				dest = dest[:0]
+				out, n := WriteVarint(dest, w.val)
+				sinkInt = n
+				sinkSlice = out
+			}
+		})
+	}
+}
+
+func BenchmarkWriteBytes(b *testing.B) {
+	payload := []byte("hello-world-payload")
+	probe := make([]byte, 0, len(payload)+1)
+	_, encLen := WriteBytes(probe, payload)
+
+	dest := make([]byte, 0, len(payload)+8)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(encLen))
+	b.ResetTimer()
+
+	for b.Loop() {
+		dest = dest[:0]
+		out, n := WriteBytes(dest, payload)
+		sinkInt = n
+		sinkSlice = out
+	}
+}
+
+func BenchmarkWriteString(b *testing.B) {
+	s := "hello-world-payload"
+	probe := make([]byte, 0, len(s)+1)
+	_, encLen := WriteString(probe, s)
+
+	dest := make([]byte, 0, len(s)+8)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(encLen))
+	b.ResetTimer()
+
+	for b.Loop() {
+		dest = dest[:0]
+		out, n := WriteString(dest, s)
+		sinkInt = n
+		sinkSlice = out
+	}
+}
+
+func BenchmarkWriteStringArray(b *testing.B) {
+	arr := []string{"alpha", "beta", "gamma"}
+	probe := make([]byte, 0, 64)
+	_, encLen := WriteStringArray(probe, arr)
+
+	dest := make([]byte, 0, 64) // 1-byte count + 3*(1-byte len + <=5-byte str) = 22 bytes <= 64
+
+	b.ReportAllocs()
+	b.SetBytes(int64(encLen))
+	b.ResetTimer()
+
+	for b.Loop() {
+		dest = dest[:0]
+		out, n := WriteStringArray(dest, arr)
+		sinkInt = n
+		sinkSlice = out
+	}
+}

--- a/moqt/internal/message/wire_benchmark_test.go
+++ b/moqt/internal/message/wire_benchmark_test.go
@@ -20,6 +20,18 @@ func encodeMessage(m interface{ Encode(io.Writer) error }) []byte {
 	return buf.Bytes()
 }
 
+// tile replicates b to fill a ~64 KiB buffer so a decode reader rarely drains
+// during a run. The size is a CONSTANT: unlike bytes.Repeat(b, b.N+1) it does
+// not scale with the iteration count, so it cannot OOM a slow runner or inflate
+// GC pressure as b.N grows (the trap #213 fixed in BenchmarkFrame_Decode). On a
+// rare drain the decode benches rewind with reader.Reset(repeating), which is
+// zero-allocation, so drains never pollute allocs/op and add only negligible
+// overhead relative to a full decode.
+func tile(b []byte) []byte {
+	const budget = 1 << 16 // 64 KiB
+	return bytes.Repeat(b, budget/len(b)+1)
+}
+
 // The *_Encode benchmarks below write to io.Discard rather than a *bytes.Buffer.
 // A bytes.Buffer grows its internal slice on Write, and that growth is counted by
 // -benchmem — previously inflating the reported Encode cost to ~3 allocs/op when
@@ -51,7 +63,7 @@ func BenchmarkGroupMessage_Decode(b *testing.B) {
 		GroupSequence: 1 << 28,
 	}
 	encoded := encodeMessage(msg)
-	repeating := bytes.Repeat(encoded, b.N+1)
+	repeating := tile(encoded)
 	reader := bytes.NewReader(repeating)
 
 	var decoded message.GroupMessage
@@ -108,7 +120,7 @@ func BenchmarkSubscribeMessage_Decode(b *testing.B) {
 		EndGroup:             1 << 28,
 	}
 	encoded := encodeMessage(msg)
-	repeating := bytes.Repeat(encoded, b.N+1)
+	repeating := tile(encoded)
 	reader := bytes.NewReader(repeating)
 
 	var decoded message.SubscribeMessage
@@ -165,7 +177,7 @@ func BenchmarkAnnounceMessage_Decode(b *testing.B) {
 		},
 	}
 	encoded := encodeMessage(msg)
-	repeating := bytes.Repeat(encoded, b.N+1)
+	repeating := tile(encoded)
 	reader := bytes.NewReader(repeating)
 
 	var decoded message.AnnounceMessage
@@ -210,7 +222,7 @@ func BenchmarkAnnounceInterestMessage_Decode(b *testing.B) {
 		ExcludeHop:          1 << 28,
 	}
 	encoded := encodeMessage(msg)
-	repeating := bytes.Repeat(encoded, b.N+1)
+	repeating := tile(encoded)
 	reader := bytes.NewReader(repeating)
 
 	var decoded message.AnnounceInterestMessage
@@ -259,7 +271,7 @@ func BenchmarkFetchMessage_Decode(b *testing.B) {
 		GroupSequence: 1 << 28,
 	}
 	encoded := encodeMessage(msg)
-	repeating := bytes.Repeat(encoded, b.N+1)
+	repeating := tile(encoded)
 	reader := bytes.NewReader(repeating)
 
 	var decoded message.FetchMessage
@@ -310,7 +322,7 @@ func BenchmarkSubscribeOkMessage_Decode(b *testing.B) {
 		EndGroup:            1 << 28,
 	}
 	encoded := encodeMessage(msg)
-	repeating := bytes.Repeat(encoded, b.N+1)
+	repeating := tile(encoded)
 	reader := bytes.NewReader(repeating)
 
 	var decoded message.SubscribeOkMessage
@@ -361,7 +373,7 @@ func BenchmarkSubscribeUpdateMessage_Decode(b *testing.B) {
 		EndGroup:             1 << 28,
 	}
 	encoded := encodeMessage(msg)
-	repeating := bytes.Repeat(encoded, b.N+1)
+	repeating := tile(encoded)
 	reader := bytes.NewReader(repeating)
 
 	var decoded message.SubscribeUpdateMessage
@@ -408,7 +420,7 @@ func BenchmarkSubscribeDropMessage_Decode(b *testing.B) {
 		ErrorCode:  1 << 10,
 	}
 	encoded := encodeMessage(msg)
-	repeating := bytes.Repeat(encoded, b.N+1)
+	repeating := tile(encoded)
 	reader := bytes.NewReader(repeating)
 
 	var decoded message.SubscribeDropMessage
@@ -451,7 +463,7 @@ func BenchmarkGoawayMessage_Decode(b *testing.B) {
 		NewSessionURI: "https://relay.example.com/eu-west/moqt-session?token=abc123",
 	}
 	encoded := encodeMessage(msg)
-	repeating := bytes.Repeat(encoded, b.N+1)
+	repeating := tile(encoded)
 	reader := bytes.NewReader(repeating)
 
 	var decoded message.GoawayMessage
@@ -496,7 +508,7 @@ func BenchmarkProbeMessage_Decode(b *testing.B) {
 		RTT:     1 << 10,
 	}
 	encoded := encodeMessage(msg)
-	repeating := bytes.Repeat(encoded, b.N+1)
+	repeating := tile(encoded)
 	reader := bytes.NewReader(repeating)
 
 	var decoded message.ProbeMessage
@@ -581,9 +593,9 @@ func BenchmarkReadMessageLength(b *testing.B) {
 				n = 8
 			}
 			encoded := make([]byte, 0, n)
-			_, _ = message.WriteMessageLength(encoded, tc.val)
+			encoded, _ = message.WriteMessageLength(encoded, tc.val)
 			// Tile the encoded varint so the reader never drains mid-bench.
-			repeating := bytes.Repeat(encoded, b.N+1)
+			repeating := tile(encoded)
 			reader := bytes.NewReader(repeating)
 
 			b.ReportAllocs()
@@ -615,8 +627,8 @@ func BenchmarkReadMessageLength(b *testing.B) {
 // No validation logic is added here — measurement only.
 func BenchmarkReadMessageLength_MaxUint62_NoBody(b *testing.B) {
 	encoded := make([]byte, 0, 8)
-	_, _ = message.WriteMessageLength(encoded, maxUint62)
-	repeating := bytes.Repeat(encoded, b.N+1)
+	encoded, _ = message.WriteMessageLength(encoded, maxUint62)
+	repeating := tile(encoded)
 	reader := bytes.NewReader(repeating)
 
 	b.ReportAllocs()

--- a/moqt/mux_benchmark_test.go
+++ b/moqt/mux_benchmark_test.go
@@ -395,6 +395,13 @@ func BenchmarkTrackMux_AllocationPatterns(b *testing.B) {
 	})
 }
 
+// Sinks for the StringOperations routing-parser sub-benches, so the compiler
+// cannot eliminate the real prefixSegments/pathSegments calls.
+var (
+	sinkSegs []prefixSegment
+	sinkLast string
+)
+
 // BenchmarkTrackMux_StringOperations benchmarks string operations impact
 func BenchmarkTrackMux_StringOperations(b *testing.B) {
 	b.Run("path-validation", func(b *testing.B) {
@@ -442,6 +449,46 @@ func BenchmarkTrackMux_StringOperations(b *testing.B) {
 		for i := 0; b.Loop(); i++ {
 			path := paths[i%len(paths)]
 			strings.Split(string(path), "/")
+		}
+	})
+
+	// The two sub-benches below call the REAL routing parsers from mux.go
+	// (the optimized strings.IndexByte path and the production strings.Split
+	// path), not a stand-in. These are the functions #220 targeted; measuring
+	// them directly gives a baseline for future changes to the routing hot path.
+	b.Run("prefixSegments", func(b *testing.B) {
+		// prefixSegments strips [1:len-1], so inputs must be prefix-shaped
+		// (leading + trailing slash).
+		prefixes := []string{
+			"/level1/level2/",
+			"/room/user123/",
+			"/game/match456/audio/",
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; b.Loop(); i++ {
+			prefix := prefixes[i%len(prefixes)]
+			sinkSegs = prefixSegments(prefix)
+		}
+	})
+
+	b.Run("pathSegments", func(b *testing.B) {
+		paths := []BroadcastPath{
+			BroadcastPath("/level1/level2/track"),
+			BroadcastPath("/room/user123/video"),
+			BroadcastPath("/game/match456/audio"),
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; b.Loop(); i++ {
+			path := paths[i%len(paths)]
+			segs, last := pathSegments(path)
+			sinkSegs = segs
+			sinkLast = last
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Investigation of benchmark coverage turned up that the suite was **not** actually trustworthy after #213: that PR fixed the `bytes.Repeat(x, b.N+1)` anti-pattern (b.N-proportional input buffer → CI OOM/timeout + inflated `sec/op` from GC scanning a huge live heap) in **one** benchmark (`BenchmarkFrame_Decode`), but the identical bug persisted in **15 more**. This PR fixes all 15, fixes a second latent bug found along the way, and adds the missing isolated benchmarks for the hottest paths that optimization PRs keep targeting but couldn't be measured.

Test-only — no production code changed.

## Finding 1 — the `bytes.Repeat(x, b.N+1)` anti-pattern was pervasive

`grep` finds it in 15 benchmarks:
- `wire_benchmark_test.go` (12): the ten `*Message_Decode` benches + `BenchmarkReadMessageLength` + `BenchmarkReadMessageLength_MaxUint62_NoBody`.
- `group_benchmark_test.go` (3): `ReadFrame`, `ConcurrentRead`, `MemoryAllocation`.

**Fix:**
- **wire (12 sites):** a fixed-budget `tile()` helper (64 KiB, b.N-independent). The decode benches' `reader.Reset(repeating)` EOF path is zero-alloc, so rare drains don't pollute `allocs/op`.
- **group (3 sites):** couldn't use `tile()` — their EOF path *rebuilt* the stream+groupReader (allocations that pollute `allocs/op`) and called `b.ResetTimer()` mid-loop. Added `loopReader`, an `io.Reader` that yields one encoded frame forever with no allocation and no EOF. (`MemoryAllocation` read only one frame per fresh reader, so its `bytes.Repeat` was pure waste.)

## Finding 2 — two benches silently measured nothing

While fixing the above, `BenchmarkReadMessageLength` and `..._MaxUint62_NoBody` panicked with divide-by-zero (my `tile()` divides by `len(src)`). Root cause: they **discarded** `WriteMessageLength`'s return value, so the source slice stayed length 0 — and `bytes.Repeat([], b.N+1)` returned empty, so both silently measured **EOF-spin, not real varint decode**. Capturing the return fixes it; they now report real numbers (0 allocs/op on the `io.ByteReader` fast path, `ns/op` scaling sensibly with varint width: 5ns for 1-byte → 19ns for 8-byte).

## Finding 3 — the hottest coders had no isolated benchmarks

New file `moqt/internal/message/primitives_benchmark_test.go`: isolated benches for `ReadVarint`/`ReadBytes`/`ReadString`/`ReadStringArray` and `WriteVarint`/`WriteBytes`/`WriteString`/`WriteStringArray`. These are the per-field wire coders (every field on every message) and the exact targets of **#198** (`ReadString`→`unsafe.String`) and **#214** (`WriteString`), yet had no direct benchmark — so both PRs couldn't be measured and the workflow posted "No significant changes". Deterministic signals now visible: `ReadString` = **1 alloc/op** (the string copy #198 targeted), all writes / `ReadBytes` / `ReadVarint` = **0 allocs/op**.

`BenchmarkTrackMux_StringOperations` gained `prefixSegments`/`pathSegments` sub-benches calling the **real** routing parsers (`mux.go`); the existing `"path-splitting"` sub-bench measured a `strings.Split` stand-in, not the functions **#220** targeted.

## Verification

Local smoke runs (tiny benchtime — confirms compile + deterministic allocs, not a perf run):
- `go vet ./moqt/...` clean; package unit tests pass.
- All 15 fixed benches run with no panic/OOM at high iteration counts (e.g. `MaxUint62` at 100k iters: 19ns, 0 allocs).
- New primitive benches match predicted `allocs/op` exactly.
- Group benches read real frames via `loopReader` at all sizes (64B–64KiB) with no framing errors.

The `performance-check` label triggers CI benchstat (main → PR). Because these are correctness/reliability fixes to the benches themselves (not behavior changes), most deltas will be in `sec/op` reliability and the new benches appearing — `allocs/op` for existing benches is unchanged (the buggy allocation was pre-timer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
