### PR TITLE
🧪 [testing] Add test for TrackRef.ID

### DIFF
--- a/msf/catalog_test.go
+++ b/msf/catalog_test.go
@@ -1020,6 +1020,36 @@ func TestTrackRef_Clone(t *testing.T) {
 	assert.NotContains(t, ref.ExtraFields, "y")
 }
 
+func TestTrackRef_ID(t *testing.T) {
+	tests := map[string]struct {
+		ref              TrackRef
+		defaultNamespace string
+		expected         TrackID
+	}{
+		"explicit namespace": {
+			ref:              TrackRef{Namespace: "live", Name: "video"},
+			defaultNamespace: "other",
+			expected:         TrackID{Namespace: "live", Name: "video"},
+		},
+		"inherits default": {
+			ref:              TrackRef{Name: "audio"},
+			defaultNamespace: "live/demo",
+			expected:         TrackID{Namespace: "live/demo", Name: "audio"},
+		},
+		"sentinel when both empty": {
+			ref:              TrackRef{Name: "data"},
+			defaultNamespace: "",
+			expected:         TrackID{Namespace: inheritedNamespaceSentinel, Name: "data"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.ref.ID(tt.defaultNamespace))
+		})
+	}
+}
+
 func TestTrackRef_effectiveNamespace(t *testing.T) {
 	tests := map[string]struct {
 		ref              TrackRef


### PR DESCRIPTION
🎯 **What:** The testing gap for `TrackRef.ID` was addressed by adding a table-driven test to `msf/catalog_test.go`.
📊 **Coverage:** Scenarios covered include:
- Explicit namespace on `TrackRef`
- Inherited namespace from default
- Empty `TrackRef` and default namespace, which should result in `inheritedNamespaceSentinel`
✨ **Result:** Enhanced test coverage around identity retrieval.

---
*PR created automatically by Jules for task [403486676508148427](https://jules.google.com/task/403486676508148427) started by @okdaichi*