### PR TITLE
🧪 [test improvement] Add test for TrackRef.Validate

### DIFF
--- a/msf/catalog_test.go
+++ b/msf/catalog_test.go
@@ -996,8 +996,8 @@ func TestTrackRef_MarshalJSON_RoundTrip(t *testing.T) {
 
 func TestTrackRef_Clone(t *testing.T) {
 	ref := TrackRef{
-		Namespace:   "live",
-		Name:        "video",
+		Namespace: "live",
+		Name:      "video",
 		ExtraFields: map[string]json.RawMessage{
 			"x":      json.RawMessage(`[1, 2, 3]`),
 			"nilval": nil,
@@ -1424,4 +1424,61 @@ func TestBroadcast_SetCatalog_KeepsActiveRemovesStale(t *testing.T) {
 	catalog := b.Catalog()
 	assert.Len(t, catalog.Tracks, 1)
 	assert.Equal(t, "video", catalog.Tracks[0].Name)
+}
+
+func TestTrackRef_Validate(t *testing.T) {
+	tests := map[string]struct {
+		ref      TrackRef
+		path     string
+		expected []string
+	}{
+		"valid": {
+			ref: TrackRef{
+				Namespace: "foo",
+				Name:      "bar",
+			},
+			path:     "test",
+			expected: nil,
+		},
+		"empty name": {
+			ref: TrackRef{
+				Namespace: "foo",
+				Name:      "",
+			},
+			path:     "test",
+			expected: []string{"test: name is required"},
+		},
+		"extra fields": {
+			ref: TrackRef{
+				Namespace: "foo",
+				Name:      "bar",
+				ExtraFields: map[string]json.RawMessage{
+					"unknown": json.RawMessage(`"value"`),
+				},
+			},
+			path:     "test",
+			expected: []string{"test: remove track entries may contain only name and optional namespace"},
+		},
+		"empty name and extra fields": {
+			ref: TrackRef{
+				Namespace: "foo",
+				Name:      "",
+				ExtraFields: map[string]json.RawMessage{
+					"unknown": json.RawMessage(`"value"`),
+				},
+			},
+			path: "test",
+			expected: []string{
+				"test: name is required",
+				"test: remove track entries may contain only name and optional namespace",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			problems := tc.ref.Validate(tc.path)
+			assert.Equal(t, tc.expected, problems)
+		})
+	}
 }


### PR DESCRIPTION
🎯 **What:** This PR introduces tests for the `TrackRef.Validate` method in the `msf` package, which was previously untested.

📊 **Coverage:** The new table-driven test covers the following scenarios:
*   A valid `TrackRef` (both Name and Namespace present, no ExtraFields).
*   An empty `Name` field (returns "name is required").
*   Presence of `ExtraFields` (returns "remove track entries may contain only name and optional namespace").
*   Both empty `Name` and presence of `ExtraFields` (returns both errors).

✨ **Result:** Test coverage and confidence in `TrackRef.Validate` validation logic are improved, ensuring invalid catalog deltas are correctly identified.

---
*PR created automatically by Jules for task [3899207636977091854](https://jules.google.com/task/3899207636977091854) started by @okdaichi*