### PR TITLE
🧪 [Testing] Improve TrackClone.Validate test coverage

### DIFF
--- a/msf/catalog_test.go
+++ b/msf/catalog_test.go
@@ -1091,24 +1091,35 @@ func TestTrackClone_Clone(t *testing.T) {
 
 func TestTrackClone_Validate(t *testing.T) {
 	tests := map[string]struct {
-		clone        TrackClone
-		errorMessage string
+		clone          TrackClone
+		expectedErrors []string
 	}{
+		"valid": {
+			clone:          TrackClone{Track: Track{Name: "video-720"}, ParentName: "video-1080"},
+			expectedErrors: nil,
+		},
 		"missing name": {
-			clone:        TrackClone{Track: Track{}, ParentName: "parent"},
-			errorMessage: "name is required",
+			clone:          TrackClone{Track: Track{}, ParentName: "parent"},
+			expectedErrors: []string{"test: name is required"},
 		},
 		"missing parentName": {
-			clone:        TrackClone{Track: Track{Name: "video"}},
-			errorMessage: "parentName is required for clone tracks",
+			clone:          TrackClone{Track: Track{Name: "video"}},
+			expectedErrors: []string{"test: parentName is required for clone tracks"},
+		},
+		"missing both": {
+			clone:          TrackClone{Track: Track{}},
+			expectedErrors: []string{"test: name is required", "test: parentName is required for clone tracks"},
 		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			problems := tt.clone.Validate("test")
-			require.NotEmpty(t, problems)
-			assert.Contains(t, problems[0], tt.errorMessage)
+			if len(tt.expectedErrors) == 0 {
+				require.Empty(t, problems)
+			} else {
+				require.Equal(t, tt.expectedErrors, problems)
+			}
 		})
 	}
 }


### PR DESCRIPTION
🎯 **What:** The unit tests for `TrackClone.Validate()` only checked if a single problem was returned for isolated missing fields. It was missing testing for the fully valid "happy path" and multiple simultaneously missing fields.
📊 **Coverage:** Added test cases for a valid `TrackClone` (empty error slice) and a scenario where both `Name` and `ParentName` are missing, which asserts that the expected two error messages are present in the returned slice.
✨ **Result:** Improved test coverage and reliability for the `Validate` method by ensuring it accumulates errors correctly.

---
*PR created automatically by Jules for task [475514072752988970](https://jules.google.com/task/475514072752988970) started by @okdaichi*