### PR TITLE
🧪 [testing improvement] Add missing test for TrackWriter.CloseWithError()

### DIFF
--- a/moqt/internal/message/primitives_benchmark_test.go
+++ b/moqt/internal/message/primitives_benchmark_test.go
@@ -51,10 +51,10 @@ func BenchmarkReadVarint(b *testing.B) {
 		name string
 		val  uint64
 	}{
-		{"1byte", maxVarInt1},     // top-2-bits 0b00
-		{"2byte", maxVarInt2},     // top-2-bits 0b01
-		{"4byte", maxVarInt4},     // top-2-bits 0b10
-		{"8byte", maxVarInt8},     // top-2-bits 0b11
+		{"1byte", maxVarInt1}, // top-2-bits 0b00
+		{"2byte", maxVarInt2}, // top-2-bits 0b01
+		{"4byte", maxVarInt4}, // top-2-bits 0b10
+		{"8byte", maxVarInt8}, // top-2-bits 0b11
 	}
 	for _, w := range widths {
 		b.Run(w.name, func(b *testing.B) {

--- a/moqt/session_test.go
+++ b/moqt/session_test.go
@@ -44,12 +44,12 @@ func (noStatsConn) AcceptStream(context.Context) (transport.Stream, error) { ret
 func (noStatsConn) AcceptUniStream(context.Context) (transport.ReceiveStream, error) {
 	return nil, io.EOF
 }
-func (noStatsConn) CloseWithError(transport.ConnErrorCode, string) error { return nil }
-func (noStatsConn) Context() context.Context                             { return context.Background() }
-func (noStatsConn) LocalAddr() net.Addr                                  { return &net.TCPAddr{} }
-func (noStatsConn) OpenStream() (transport.Stream, error)                { return nil, io.EOF }
+func (noStatsConn) CloseWithError(transport.ConnErrorCode, string) error     { return nil }
+func (noStatsConn) Context() context.Context                                 { return context.Background() }
+func (noStatsConn) LocalAddr() net.Addr                                      { return &net.TCPAddr{} }
+func (noStatsConn) OpenStream() (transport.Stream, error)                    { return nil, io.EOF }
 func (noStatsConn) OpenStreamSync(context.Context) (transport.Stream, error) { return nil, io.EOF }
-func (noStatsConn) OpenUniStream() (transport.SendStream, error)         { return nil, io.EOF }
+func (noStatsConn) OpenUniStream() (transport.SendStream, error)             { return nil, io.EOF }
 func (noStatsConn) OpenUniStreamSync(context.Context) (transport.SendStream, error) {
 	return nil, io.EOF
 }

--- a/moqt/track_writer_test.go
+++ b/moqt/track_writer_test.go
@@ -648,3 +648,58 @@ func TestTrackWriter_DropGroups_ContextCanceled(t *testing.T) {
 	})
 	assert.Error(t, err)
 }
+
+func TestTrackWriter_CloseWithError(t *testing.T) {
+	mockStreams := make([]*FakeQUICSendStream, 0)
+	openUniStreamFunc := func(_ context.Context) (transport.SendStream, error) {
+		mockSendStream := &FakeQUICSendStream{}
+		mockStreams = append(mockStreams, mockSendStream)
+		return mockSendStream, nil
+	}
+
+	mockStream := &FakeQUICStream{}
+	substr := newReceiveSubscribeStream(SubscribeID(1), mockStream, &SubscribeConfig{})
+	var onCloseTrackCalled bool
+	sender := newTrackWriter("/broadcastpath", "trackname", substr, openUniStreamFunc, func() {
+		onCloseTrackCalled = true
+	})
+
+	// Open a group to ensure activeGroups is populated
+	_, err := sender.OpenGroup(context.Background())
+	assert.NoError(t, err)
+	assert.Len(t, mockStreams, 1)
+
+	// Open a second group
+	_, err = sender.OpenGroup(context.Background())
+	assert.NoError(t, err)
+	assert.Len(t, mockStreams, 2)
+
+	// Now call CloseWithError
+	errorCode := SubscribeErrorCode(123)
+	sender.CloseWithError(errorCode)
+
+	// Verify groupManager is nil and activeGroups are cancelled
+	assert.Nil(t, sender.groupManager)
+
+	// Both groups should have CancelWrite called with PublishAbortedErrorCode
+	for _, stream := range mockStreams {
+		assert.NotNil(t, stream.cancelWriteErr)
+		streamErr, ok := stream.cancelWriteErr.(*transport.StreamError)
+		assert.True(t, ok)
+		assert.Equal(t, transport.StreamErrorCode(PublishAbortedErrorCode), streamErr.ErrorCode)
+	}
+
+	// Verify onCloseTrack was called
+	assert.True(t, onCloseTrackCalled)
+
+	// Verify subscribe stream was closed with error
+	assert.NotNil(t, mockStream.cancelReadErr)
+	streamErr, ok := mockStream.cancelReadErr.(*transport.StreamError)
+	assert.True(t, ok)
+	assert.Equal(t, transport.StreamErrorCode(errorCode), streamErr.ErrorCode)
+
+	assert.NotNil(t, mockStream.cancelWriteErr)
+	streamErr2, ok2 := mockStream.cancelWriteErr.(*transport.StreamError)
+	assert.True(t, ok2)
+	assert.Equal(t, transport.StreamErrorCode(errorCode), streamErr2.ErrorCode)
+}

--- a/msf/catalog_test.go
+++ b/msf/catalog_test.go
@@ -996,8 +996,8 @@ func TestTrackRef_MarshalJSON_RoundTrip(t *testing.T) {
 
 func TestTrackRef_Clone(t *testing.T) {
 	ref := TrackRef{
-		Namespace:   "live",
-		Name:        "video",
+		Namespace: "live",
+		Name:      "video",
 		ExtraFields: map[string]json.RawMessage{
 			"x":      json.RawMessage(`[1, 2, 3]`),
 			"nilval": nil,


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for `TrackWriter.CloseWithError()` in `moqt/track_writer_test.go`.
📊 **Coverage:** The new `TestTrackWriter_CloseWithError` test verifies the full cancellation pipeline:
- Active groups are individually aborted with `PublishAbortedErrorCode`.
- The `groupManager` is effectively decoupled (`nil`).
- The user-provided `onCloseTrackFunc` callback is executed.
- The underlying `receiveSubscribeStream` is closed properly propagating the incoming `SubscribeErrorCode`.
✨ **Result:** Enhanced test coverage around the critical error teardown path of `TrackWriter`, providing better safety guarantees when track state transitions to aborted.

---
*PR created automatically by Jules for task [15249366895177718196](https://jules.google.com/task/15249366895177718196) started by @okdaichi*