### PR TITLE
🧪 Add test for CatalogDelta.MarshalJSON()

### DIFF
--- a/msf/catalog_test.go
+++ b/msf/catalog_test.go
@@ -977,6 +977,13 @@ func TestCatalogDelta_MarshalJSON_RoundTrip(t *testing.T) {
 	assert.Equal(t, "video-1080", decoded.CloneTracks[0].ParentName)
 }
 
+func TestCatalogDelta_MarshalJSON_EmptyDelta(t *testing.T) {
+	delta := CatalogDelta{}
+	data, err := json.Marshal(delta)
+	require.NoError(t, err)
+	assert.Equal(t, `{"deltaUpdate":true}`, string(data))
+}
+
 func TestTrackRef_MarshalJSON_RoundTrip(t *testing.T) {
 	ref := TrackRef{
 		Namespace: "live/demo",
@@ -996,8 +1003,8 @@ func TestTrackRef_MarshalJSON_RoundTrip(t *testing.T) {
 
 func TestTrackRef_Clone(t *testing.T) {
 	ref := TrackRef{
-		Namespace:   "live",
-		Name:        "video",
+		Namespace: "live",
+		Name:      "video",
 		ExtraFields: map[string]json.RawMessage{
 			"x":      json.RawMessage(`[1, 2, 3]`),
 			"nilval": nil,


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test for `CatalogDelta.MarshalJSON()` has been covered. A new test validates that an empty `CatalogDelta` correctly marshals into JSON with only `{"deltaUpdate":true}` as per the implementation.
📊 **Coverage:** Tests an empty `CatalogDelta` struct, covering the rationale of marshaling a struct and comparing against an expected JSON string, and ensuring the `deltaUpdate=true` property is inherently injected when marshaled.
✨ **Result:** The improvement in test coverage increases the robustness around the MSF catalog delta marshalling implementations.

---
*PR created automatically by Jules for task [4442042408961876929](https://jules.google.com/task/4442042408961876929) started by @okdaichi*