### PR TITLE
🧪 Add test for TrackRef.MarshalJSON with ExtraFields

### DIFF
--- a/msf/catalog_test.go
+++ b/msf/catalog_test.go
@@ -1159,6 +1159,24 @@ func TestCatalogDelta_UnmarshalJSON_ExtraFields(t *testing.T) {
 	assert.Contains(t, delta.ExtraFields, "com.example.ext")
 }
 
+
+func TestTrackRef_MarshalJSON_ExtraFields(t *testing.T) {
+	ref := TrackRef{
+		Name: "video",
+		ExtraFields: map[string]json.RawMessage{
+			"customField": json.RawMessage(`"customValue"`),
+		},
+	}
+
+	data, err := json.Marshal(ref)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, "video", decoded["name"])
+	assert.Equal(t, "customValue", decoded["customField"])
+}
+
 func TestTrackRef_MarshalJSON_NameOnly(t *testing.T) {
 	ref := TrackRef{Name: "video"}
 


### PR DESCRIPTION
🎯 **What:** Added a missing test for `TrackRef.MarshalJSON()` in `msf/catalog_test.go` to cover the `ExtraFields` handling, addressing an uncovered execution path.

📊 **Coverage:** The new test specifically verifies that when a `TrackRef` struct has `ExtraFields` populated, those fields are correctly shallow-copied and included in the final marshaled JSON output alongside standard fields like `Name`. This covers lines 256-257 in `msf/catalog_delta.go` which were previously untested.

✨ **Result:** Test coverage for `msf/catalog_delta.go` improved and the correct marshaling behavior of `ExtraFields` is now explicitly guaranteed, preventing future regressions.

---
*PR created automatically by Jules for task [6868545907846773276](https://jules.google.com/task/6868545907846773276) started by @okdaichi*