### PR TITLE
🧪 Add test coverage for CatalogDelta.Clone deltaOpOrder

### DIFF
--- a/msf/catalog_test.go
+++ b/msf/catalog_test.go
@@ -906,6 +906,7 @@ func TestTrackDuration_VODRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(data), `"trackDuration":120000`)
 }
+
 func TestCatalogDelta_Clone(t *testing.T) {
 	generatedAt := int64(5000)
 	delta := CatalogDelta{
@@ -916,6 +917,7 @@ func TestCatalogDelta_Clone(t *testing.T) {
 		RemoveTracks:     []TrackRef{{Name: "old", Namespace: "ns"}},
 		CloneTracks:      []TrackClone{{Track: Track{Name: "video-720"}, ParentName: "video-1080"}},
 		ExtraFields:      map[string]json.RawMessage{"ext": json.RawMessage(`1`)},
+		deltaOpOrder:     []deltaOperationKind{deltaOperationAdd, deltaOperationRemove, deltaOperationClone},
 	}
 
 	clone := delta.Clone()
@@ -930,11 +932,16 @@ func TestCatalogDelta_Clone(t *testing.T) {
 	require.Len(t, clone.CloneTracks, 1)
 	assert.Equal(t, "video-720", clone.CloneTracks[0].Name)
 	assert.Contains(t, clone.ExtraFields, "ext")
+	assert.Equal(t, []deltaOperationKind{deltaOperationAdd, deltaOperationRemove, deltaOperationClone}, clone.deltaOpOrder)
 
 	// Mutating clone should not affect original.
 	clone.AddTracks[0].Name = "mutated"
 	assert.Equal(t, "video", delta.AddTracks[0].Name)
+
+	clone.deltaOpOrder[0] = deltaOperationRemove
+	assert.Equal(t, []deltaOperationKind{deltaOperationAdd, deltaOperationRemove, deltaOperationClone}, delta.deltaOpOrder)
 }
+
 
 func TestCatalogDelta_MarshalJSON_RoundTrip(t *testing.T) {
 	generatedAt := int64(42)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing validation that the `deltaOpOrder` slice inside `CatalogDelta` is securely cloned without retaining memory pointers to the original's slice.

📊 **Coverage:** The `TestCatalogDelta_Clone` unit test has been updated to initialize a `deltaOpOrder` slice with operation kinds. A new assertion specifically verifies that modifying the first element of `clone.deltaOpOrder` does *not* mutate the `deltaOpOrder` slice in the original `delta`.

✨ **Result:** Test coverage for the `Clone()` method has been improved by properly verifying that nested slice state (specifically `deltaOpOrder` implemented as `[]deltaOperationKind`) acts as a secure, isolated deep copy without referencing the underlying array of its source.

---
*PR created automatically by Jules for task [3668284612240156342](https://jules.google.com/task/3668284612240156342) started by @okdaichi*