### PR TITLE
🧪 [testing] Add test for TrackClone.UnmarshalJSON success cases

### DIFF
--- a/msf/catalog_test.go
+++ b/msf/catalog_test.go
@@ -996,8 +996,8 @@ func TestTrackRef_MarshalJSON_RoundTrip(t *testing.T) {
 
 func TestTrackRef_Clone(t *testing.T) {
 	ref := TrackRef{
-		Namespace:   "live",
-		Name:        "video",
+		Namespace: "live",
+		Name:      "video",
 		ExtraFields: map[string]json.RawMessage{
 			"x":      json.RawMessage(`[1, 2, 3]`),
 			"nilval": nil,
@@ -1342,6 +1342,47 @@ func TestTrackRef_UnmarshalJSON_FieldErrors(t *testing.T) {
 			var ref TrackRef
 			err := json.Unmarshal([]byte(tt.input), &ref)
 			require.Error(t, err)
+		})
+	}
+}
+
+func TestTrackClone_UnmarshalJSON_Success(t *testing.T) {
+	w := int64(1280)
+	tests := map[string]struct {
+		input    string
+		expected TrackClone
+	}{
+		"basic clone": {
+			input: `{"name":"video-720","parentName":"video-1080"}`,
+			expected: TrackClone{
+				Track:      Track{Name: "video-720"},
+				ParentName: "video-1080",
+			},
+		},
+		"with extra fields": {
+			input: `{"name":"video-720","parentName":"video-1080","width":1280}`,
+			expected: TrackClone{
+				Track: Track{
+					Name:  "video-720",
+					Width: &w,
+				},
+				ParentName: "video-1080",
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var clone TrackClone
+			err := json.Unmarshal([]byte(tt.input), &clone)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected.Name, clone.Name)
+			assert.Equal(t, tt.expected.ParentName, clone.ParentName)
+			if tt.expected.Width != nil {
+				require.NotNil(t, clone.Width)
+				assert.Equal(t, *tt.expected.Width, *clone.Width)
+			}
 		})
 	}
 }


### PR DESCRIPTION
🎯 **What**: Added `TestTrackClone_UnmarshalJSON_Success` to cover the successful unmarshaling paths for `TrackClone`.
📊 **Coverage**: Added coverage for basic clone JSON data and clone data with inherited track properties, verifying it unmarshals successfully.
✨ **Result**: Improved code coverage by explicitly testing that JSON input byte slices correctly decode `parentName` and inner `Track` fields using a table-driven test.

---
*PR created automatically by Jules for task [11691103967834956976](https://jules.google.com/task/11691103967834956976) started by @okdaichi*