### PR TITLE
🧪 Add missing deep copy test for TrackClone

### DIFF
--- a/msf/catalog_test.go
+++ b/msf/catalog_test.go
@@ -996,8 +996,8 @@ func TestTrackRef_MarshalJSON_RoundTrip(t *testing.T) {
 
 func TestTrackRef_Clone(t *testing.T) {
 	ref := TrackRef{
-		Namespace:   "live",
-		Name:        "video",
+		Namespace: "live",
+		Name:      "video",
 		ExtraFields: map[string]json.RawMessage{
 			"x":      json.RawMessage(`[1, 2, 3]`),
 			"nilval": nil,
@@ -1076,7 +1076,13 @@ func TestTrackClone_MarshalJSON_RoundTrip(t *testing.T) {
 
 func TestTrackClone_Clone(t *testing.T) {
 	original := TrackClone{
-		Track:      Track{Name: "video-720", Codec: "av01"},
+		Track: Track{
+			Name:  "video-720",
+			Codec: "av01",
+			ExtraFields: map[string]json.RawMessage{
+				"x": json.RawMessage(`[1, 2, 3]`),
+			},
+		},
 		ParentName: "video-1080",
 	}
 
@@ -1084,6 +1090,11 @@ func TestTrackClone_Clone(t *testing.T) {
 	assert.Equal(t, "video-720", clone.Name)
 	assert.Equal(t, "video-1080", clone.ParentName)
 	assert.Equal(t, "av01", clone.Codec)
+	assert.Contains(t, clone.ExtraFields, "x")
+
+	// Test byte slice deep copy
+	clone.ExtraFields["x"][1] = '9'
+	assert.Equal(t, byte('1'), original.ExtraFields["x"][1], "original byte slice should not be mutated")
 
 	clone.Name = "mutated"
 	assert.Equal(t, "video-720", original.Name)


### PR DESCRIPTION
🎯 **What:** 
Added a test to explicitly verify the deep-copy behavior of `TrackClone.Clone()`, specifically targeting the `ExtraFields` map containing `json.RawMessage` byte slices. The previous test only covered shallow string field properties.

📊 **Coverage:** 
- The test now asserts that `ExtraFields` exist on the cloned object.
- It mutates the underlying byte slice of the clone's `ExtraFields` and verifies that the original slice remains untouched, proving a deep copy occurred.

✨ **Result:** 
Improved test robustness for catalog delta serialization mechanisms, ensuring that complex fields do not suffer from reference leaks during copy operations.

---
*PR created automatically by Jules for task [8959454155043986295](https://jules.google.com/task/8959454155043986295) started by @okdaichi*