### PR TITLE
🧪 [testing] Add tests for TrackClone.MarshalJSON()

### DIFF
--- a/msf/catalog_test.go
+++ b/msf/catalog_test.go
@@ -1074,6 +1074,28 @@ func TestTrackClone_MarshalJSON_RoundTrip(t *testing.T) {
 	assert.Equal(t, int64(1280), *decoded.Width)
 }
 
+
+func TestTrackClone_MarshalJSON(t *testing.T) {
+	t.Run("with parent name", func(t *testing.T) {
+		clone := TrackClone{
+			Track:      Track{Name: "video-720"},
+			ParentName: "video-1080",
+		}
+		data, err := clone.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"video-720","parentName":"video-1080"}`, string(data))
+	})
+
+	t.Run("without parent name", func(t *testing.T) {
+		clone := TrackClone{
+			Track: Track{Name: "video-720"},
+		}
+		data, err := clone.MarshalJSON()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"name":"video-720"}`, string(data))
+	})
+}
+
 func TestTrackClone_Clone(t *testing.T) {
 	original := TrackClone{
 		Track:      Track{Name: "video-720", Codec: "av01"},


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing explicit tests for the TrackClone.MarshalJSON() function in msf/catalog_delta.go.
📊 **Coverage:** TrackClone.MarshalJSON() is now tested for marshaling with and without a parentName.
✨ **Result:** Increased test coverage and validation of json marshaling for TrackClone entries.

---
*PR created automatically by Jules for task [6515995810931188636](https://jules.google.com/task/6515995810931188636) started by @okdaichi*