### PR TITLE
feat(moq-web): add AbortSignal cancellation to openGroup and stream creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **moq-web:** `TrackWriter.openGroup`/`openGroupAt` and `StreamConn.openStream`/`openUniStream` now accept an optional `AbortSignal` to cancel or time out stream creation, mirroring Go's `OpenGroup(ctx)` → `openUniStreamFunc(ctx)`. The signal is composed internally with `Promise.race` (golikejs `watchSignal`) against the track context; an aborted open never leaves an orphaned stream. Also fixes a leak where a failed group-header write left the allocated stream half-open (Go always `CancelWrite`s).
 - **moqt:** `BenchmarkEgress_Saturating`, a saturating real-QUIC egress benchmark that drives `GroupWriter.WriteFrame` end-to-end (encode → QUIC stream → UDP). Run in the `benchmark-integration` job, not on PRs.
 
 ### Changed

--- a/moq-web/src/internal/webtransport/connection.ts
+++ b/moq-web/src/internal/webtransport/connection.ts
@@ -5,8 +5,12 @@ import { StreamConnError, StreamConnErrorInfo } from "./error.ts";
 import { background, ContextCancelledError, watchSignal } from "@okdaichi/golikejs/context";
 
 export interface StreamConn {
-	openStream(signal?: AbortSignal): Promise<[Stream, undefined] | [undefined, Error]>;
-	openUniStream(signal?: AbortSignal): Promise<[SendStream, undefined] | [undefined, Error]>;
+	openStream(
+		options?: { signal?: AbortSignal },
+	): Promise<[Stream, undefined] | [undefined, Error]>;
+	openUniStream(
+		options?: { signal?: AbortSignal },
+	): Promise<[SendStream, undefined] | [undefined, Error]>;
 	acceptStream(): Promise<[Stream, undefined] | [undefined, Error]>;
 	acceptUniStream(): Promise<[ReceiveStream, undefined] | [undefined, Error]>;
 	close(closeInfo?: WebTransportCloseInfo): void;
@@ -46,8 +50,9 @@ export class WebTransportSession implements StreamConn {
 	}
 
 	async openStream(
-		signal?: AbortSignal,
+		options?: { signal?: AbortSignal },
 	): Promise<[Stream, undefined] | [undefined, Error]> {
+		const signal = options?.signal;
 		// §1 Abort before starting: no stream is opened.
 		if (signal?.aborted) {
 			return [undefined, abortError(signal)];
@@ -104,8 +109,9 @@ export class WebTransportSession implements StreamConn {
 	}
 
 	async openUniStream(
-		signal?: AbortSignal,
+		options?: { signal?: AbortSignal },
 	): Promise<[SendStream, undefined] | [undefined, Error]> {
+		const signal = options?.signal;
 		// §1 Abort before starting: no stream is opened.
 		if (signal?.aborted) {
 			return [undefined, abortError(signal)];

--- a/moq-web/src/internal/webtransport/connection.ts
+++ b/moq-web/src/internal/webtransport/connection.ts
@@ -2,10 +2,11 @@ import { ReceiveStream } from "./receive_stream.ts";
 import { Stream } from "./stream.ts";
 import { SendStream } from "./send_stream.ts";
 import { StreamConnError, StreamConnErrorInfo } from "./error.ts";
+import { background, ContextCancelledError, watchSignal } from "@okdaichi/golikejs/context";
 
 export interface StreamConn {
-	openStream(): Promise<[Stream, undefined] | [undefined, Error]>;
-	openUniStream(): Promise<[SendStream, undefined] | [undefined, Error]>;
+	openStream(signal?: AbortSignal): Promise<[Stream, undefined] | [undefined, Error]>;
+	openUniStream(signal?: AbortSignal): Promise<[SendStream, undefined] | [undefined, Error]>;
 	acceptStream(): Promise<[Stream, undefined] | [undefined, Error]>;
 	acceptUniStream(): Promise<[ReceiveStream, undefined] | [undefined, Error]>;
 	close(closeInfo?: WebTransportCloseInfo): void;
@@ -44,44 +45,95 @@ export class WebTransportSession implements StreamConn {
 		return this.#webtransport.protocol || "";
 	}
 
-	async openStream(): Promise<[Stream, undefined] | [undefined, Error]> {
+	async openStream(
+		signal?: AbortSignal,
+	): Promise<[Stream, undefined] | [undefined, Error]> {
+		// §1 Abort before starting: no stream is opened.
+		if (signal?.aborted) {
+			return [undefined, abortError(signal)];
+		}
+
+		// Without a signal, preserve the original behavior exactly.
+		if (!signal) {
+			try {
+				const wtStream = await this.#webtransport.createBidirectionalStream();
+				return [new Stream({ stream: wtStream }), undefined];
+			} catch (err) {
+				return await this.#mapOpenStreamError(err);
+			}
+		}
+
+		// Browser WebTransport createBidirectionalStream() accepts no signal, so
+		// cancellation is external. Race the open against the signal, mirroring
+		// Go's ctx.Done(). If the signal wins, the WT promise may still resolve
+		// later — abandon any late stream so it is never orphaned.
+		const ctx = watchSignal(background(), signal);
+		const createPromise = this.#webtransport.createBidirectionalStream();
+		await Promise.race([createPromise, ctx.done()]);
+		if (ctx.err()) {
+			createPromise.then((late) => abandonRawStream(late)).catch(() => {});
+			return [undefined, ctx.err()!];
+		}
+
 		try {
-			const wtStream = await this.#webtransport.createBidirectionalStream();
-			const stream = new Stream({
-				stream: wtStream,
-			});
-			return [stream, undefined];
+			const wtStream = await createPromise;
+			return [new Stream({ stream: wtStream }), undefined];
 		} catch (err) {
-			if (err instanceof Error) {
-				return [undefined, err];
-			}
-			const wtErr = err as WebTransportError;
-			if (wtErr.source === "session") {
-				const info = await this.#webtransport.closed;
-				if (info.closeCode !== undefined && info.reason !== undefined) {
-					return [
-						undefined,
-						new StreamConnError(
-							info as StreamConnErrorInfo,
-							true,
-						),
-					];
-				}
-			}
-			return [undefined, err as Error];
+			return await this.#mapOpenStreamError(err);
 		}
 	}
 
-	async openUniStream(): Promise<[SendStream, undefined] | [undefined, Error]> {
-		try {
-			const wtStream = await this.#webtransport.createUnidirectionalStream();
-			const stream = new SendStream({
-				stream: wtStream,
-			});
-			return [stream, undefined];
-		} catch (e) {
-			return [undefined, e as Error];
+	async #mapOpenStreamError(err: unknown): Promise<[undefined, Error]> {
+		if (err instanceof Error) {
+			return [undefined, err];
 		}
+		const wtErr = err as WebTransportError;
+		if (wtErr.source === "session") {
+			const info = await this.#webtransport.closed;
+			if (info.closeCode !== undefined && info.reason !== undefined) {
+				return [
+					undefined,
+					new StreamConnError(
+						info as StreamConnErrorInfo,
+						true,
+					),
+				];
+			}
+		}
+		return [undefined, err as Error];
+	}
+
+	async openUniStream(
+		signal?: AbortSignal,
+	): Promise<[SendStream, undefined] | [undefined, Error]> {
+		// §1 Abort before starting: no stream is opened.
+		if (signal?.aborted) {
+			return [undefined, abortError(signal)];
+		}
+
+		// Without a signal, preserve the original behavior exactly.
+		if (!signal) {
+			try {
+				const wtStream = await this.#webtransport.createUnidirectionalStream();
+				return [new SendStream({ stream: wtStream }), undefined];
+			} catch (e) {
+				return [undefined, e as Error];
+			}
+		}
+
+		// Browser WebTransport createUnidirectionalStream() accepts no signal, so
+		// cancellation is external. Race the open against the signal, mirroring
+		// Go's ctx.Done(). If the signal wins, the WT promise may still resolve
+		// later — abandon any late stream so it is never orphaned.
+		const ctx = watchSignal(background(), signal);
+		const createPromise = this.#webtransport.createUnidirectionalStream();
+		await Promise.race([createPromise, ctx.done()]);
+		if (ctx.err()) {
+			createPromise.then((late) => abandonRawStream(late)).catch(() => {});
+			return [undefined, ctx.err()!];
+		}
+
+		return [new SendStream({ stream: await createPromise }), undefined];
 	}
 
 	async acceptStream(): Promise<[Stream, undefined] | [undefined, Error]> {
@@ -121,5 +173,37 @@ export class WebTransportSession implements StreamConn {
 
 	get closed(): Promise<WebTransportCloseInfo> {
 		return this.#webtransport.closed;
+	}
+}
+
+/**
+ * Build the error returned when a caller aborts a stream open. Mirrors
+ * golikejs watchSignal's reason extraction: signal.reason when it is an Error,
+ * otherwise a ContextCancelledError.
+ */
+function abortError(signal: AbortSignal): Error {
+	const reason = (signal as unknown as { reason?: unknown }).reason;
+	return reason instanceof Error ? reason : new ContextCancelledError();
+}
+
+/**
+ * Best-effort cleanup of a WebTransport stream that resolves after its open was
+ * already aborted. Aborts (RESET_STREAM) rather than closing, since a clean
+ * close would flush a FIN for a stream nobody wants and may block on flow
+ * control. Never throws — cleanup must not mask the original abort error.
+ */
+function abandonRawStream(
+	stream: WebTransportBidirectionalStream | WritableStream<Uint8Array>,
+): void {
+	try {
+		if (stream instanceof WritableStream) {
+			stream.abort(new ContextCancelledError()).catch(() => {});
+			return;
+		}
+		const bidi = stream as WebTransportBidirectionalStream;
+		bidi.writable.abort(new ContextCancelledError()).catch(() => {});
+		bidi.readable.cancel().catch(() => {});
+	} catch {
+		// Best-effort cleanup of an orphaned allocation.
 	}
 }

--- a/moq-web/src/internal/webtransport/connection.ts
+++ b/moq-web/src/internal/webtransport/connection.ts
@@ -74,13 +74,15 @@ export class WebTransportSession implements StreamConn {
 		// later — abandon any late stream so it is never orphaned.
 		const ctx = watchSignal(background(), signal);
 		const createPromise = this.#webtransport.createBidirectionalStream();
-		await Promise.race([createPromise, ctx.done()]);
-		if (ctx.err()) {
-			createPromise.then((late) => abandonRawStream(late)).catch(() => {});
-			return [undefined, ctx.err()!];
-		}
-
+		// Race the open against the signal. Wrapped so that a transport
+		// rejection (before the signal fires) is returned as [undefined, err],
+		// never thrown — matching the no-signal path and the tuple contract.
 		try {
+			await Promise.race([createPromise, ctx.done()]);
+			if (ctx.err()) {
+				createPromise.then((late) => abandonRawStream(late)).catch(() => {});
+				return [undefined, ctx.err()!];
+			}
 			const wtStream = await createPromise;
 			return [new Stream({ stream: wtStream }), undefined];
 		} catch (err) {
@@ -133,13 +135,19 @@ export class WebTransportSession implements StreamConn {
 		// later — abandon any late stream so it is never orphaned.
 		const ctx = watchSignal(background(), signal);
 		const createPromise = this.#webtransport.createUnidirectionalStream();
-		await Promise.race([createPromise, ctx.done()]);
-		if (ctx.err()) {
-			createPromise.then((late) => abandonRawStream(late)).catch(() => {});
-			return [undefined, ctx.err()!];
+		// Race the open against the signal. Wrapped so that a transport
+		// rejection (before the signal fires) is returned as [undefined, err],
+		// never thrown — matching the no-signal path and the tuple contract.
+		try {
+			await Promise.race([createPromise, ctx.done()]);
+			if (ctx.err()) {
+				createPromise.then((late) => abandonRawStream(late)).catch(() => {});
+				return [undefined, ctx.err()!];
+			}
+			return [new SendStream({ stream: await createPromise }), undefined];
+		} catch (e) {
+			return [undefined, e as Error];
 		}
-
-		return [new SendStream({ stream: await createPromise }), undefined];
 	}
 
 	async acceptStream(): Promise<[Stream, undefined] | [undefined, Error]> {
@@ -188,7 +196,7 @@ export class WebTransportSession implements StreamConn {
  * otherwise a ContextCancelledError.
  */
 function abortError(signal: AbortSignal): Error {
-	const reason = (signal as unknown as { reason?: unknown }).reason;
+	const reason = signal.reason;
 	return reason instanceof Error ? reason : new ContextCancelledError();
 }
 

--- a/moq-web/src/internal/webtransport/connection_test.ts
+++ b/moq-web/src/internal/webtransport/connection_test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertInstanceOf } from "@std/assert";
 import { WebTransportSession } from "./connection.ts";
 import { StreamConnError } from "./error.ts";
 import { SendStream } from "./send_stream.ts";
+import { ContextCancelledError } from "@okdaichi/golikejs/context";
 
 class FailingMockWebTransport {
 	ready = Promise.resolve();
@@ -298,4 +299,97 @@ Deno.test("WebTransportSession.openUniStream abort mid-wait abandons the late-re
 	await Promise.resolve();
 	await Promise.resolve();
 	assertEquals(lateAborted, true);
+});
+
+Deno.test("WebTransportSession.openStream with a pre-aborted signal does not open a stream", async () => {
+	let createCalled = false;
+	const mock = {
+		incomingBidirectionalStreams: new ReadableStream({ start(_c) {} }),
+		incomingUnidirectionalStreams: new ReadableStream({ start(_c) {} }),
+		ready: Promise.resolve(),
+		closed: Promise.resolve({ closeCode: undefined, reason: undefined }),
+		createBidirectionalStream() {
+			createCalled = true;
+			return new Promise(() => {});
+		},
+	} as unknown as WebTransport;
+
+	const session = new WebTransportSession(mock);
+	const ac = new AbortController();
+	ac.abort(new Error("nope"));
+	const [stream, err] = await session.openStream(ac.signal);
+	assertEquals(stream, undefined);
+	assertInstanceOf(err, Error);
+	assertEquals((err as Error).message, "nope");
+	assertEquals(createCalled, false);
+});
+
+Deno.test("WebTransportSession.openUniStream pre-aborted with a non-Error reason returns a ContextCancelledError", async () => {
+	const mock = {
+		incomingBidirectionalStreams: new ReadableStream({ start(_c) {} }),
+		incomingUnidirectionalStreams: new ReadableStream({ start(_c) {} }),
+		ready: Promise.resolve(),
+		closed: Promise.resolve({ closeCode: undefined, reason: undefined }),
+		createUnidirectionalStream() {
+			return new Promise<WritableStream<Uint8Array>>(() => {});
+		},
+	} as unknown as WebTransport;
+
+	const session = new WebTransportSession(mock);
+	const ac = new AbortController();
+	// A non-Error reason falls back to ContextCancelledError.
+	ac.abort("a string reason");
+	const [stream, err] = await session.openUniStream(ac.signal);
+	assertEquals(stream, undefined);
+	assertInstanceOf(err, ContextCancelledError);
+});
+
+Deno.test("WebTransportSession.openStream abort mid-wait abandons the late-resolving bidirectional stream", async () => {
+	let writableAborted = false;
+	let readableCancelled = false;
+	const lateBidi = {
+		writable: {
+			abort: (_reason?: unknown) => {
+				writableAborted = true;
+				return Promise.resolve();
+			},
+		},
+		readable: {
+			cancel: () => {
+				readableCancelled = true;
+				return Promise.resolve();
+			},
+		},
+	};
+
+	let resolveCreate!: (s: unknown) => void;
+	const createPromise = new Promise<unknown>((r) => {
+		resolveCreate = r;
+	});
+	const mock = {
+		incomingBidirectionalStreams: new ReadableStream({ start(_c) {} }),
+		incomingUnidirectionalStreams: new ReadableStream({ start(_c) {} }),
+		ready: Promise.resolve(),
+		closed: Promise.resolve({ closeCode: undefined, reason: undefined }),
+		createBidirectionalStream() {
+			return createPromise;
+		},
+	} as unknown as WebTransport;
+
+	const session = new WebTransportSession(mock);
+	const ac = new AbortController();
+	const openP = session.openStream(ac.signal);
+	ac.abort(new Error("timeout"));
+
+	const [stream, err] = await openP;
+	assertEquals(stream, undefined);
+	assertInstanceOf(err, Error);
+	assertEquals((err as Error).message, "timeout");
+
+	assertEquals(writableAborted, false);
+	resolveCreate(lateBidi);
+	await Promise.resolve();
+	await Promise.resolve();
+	assertEquals(writableAborted, true);
+	assertEquals(readableCancelled, true);
 });

--- a/moq-web/src/internal/webtransport/connection_test.ts
+++ b/moq-web/src/internal/webtransport/connection_test.ts
@@ -393,3 +393,22 @@ Deno.test("WebTransportSession.openStream abort mid-wait abandons the late-resol
 	assertEquals(writableAborted, true);
 	assertEquals(readableCancelled, true);
 });
+
+Deno.test("WebTransportSession.openUniStream with a signal returns an error, never throws, when createUnidirectionalStream rejects", async () => {
+	const mock = {
+		incomingBidirectionalStreams: new ReadableStream({ start(_c) {} }),
+		incomingUnidirectionalStreams: new ReadableStream({ start(_c) {} }),
+		ready: Promise.resolve(),
+		closed: Promise.resolve({ closeCode: undefined, reason: undefined }),
+		createUnidirectionalStream() {
+			return Promise.reject(new Error("stream limit"));
+		},
+	} as unknown as WebTransport;
+
+	const session = new WebTransportSession(mock);
+	const ac = new AbortController(); // not aborted: transport rejection must still be a tuple, not a throw
+	const [stream, err] = await session.openUniStream({ signal: ac.signal });
+	assertEquals(stream, undefined);
+	assertInstanceOf(err, Error);
+	assertEquals((err as Error).message, "stream limit");
+});

--- a/moq-web/src/internal/webtransport/connection_test.ts
+++ b/moq-web/src/internal/webtransport/connection_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertInstanceOf } from "@std/assert";
 import { WebTransportSession } from "./connection.ts";
 import { StreamConnError } from "./error.ts";
+import { SendStream } from "./send_stream.ts";
 
 class FailingMockWebTransport {
 	ready = Promise.resolve();
@@ -210,4 +211,91 @@ Deno.test("WebTransportSession.ready and closed proxy underlying transport promi
 	const closeInfo = await session.closed;
 	assertEquals(closeInfo.closeCode, 0);
 	assertEquals(closeInfo.reason, "closed");
+});
+
+Deno.test("WebTransportSession.openUniStream with a pre-aborted signal does not open a stream", async () => {
+	let createCalled = false;
+	const mock = {
+		incomingBidirectionalStreams: new ReadableStream({ start(_c) {} }),
+		incomingUnidirectionalStreams: new ReadableStream({ start(_c) {} }),
+		ready: Promise.resolve(),
+		closed: Promise.resolve({ closeCode: undefined, reason: undefined }),
+		createUnidirectionalStream() {
+			createCalled = true;
+			return new Promise<WritableStream<Uint8Array>>(() => {});
+		},
+	} as unknown as WebTransport;
+
+	const session = new WebTransportSession(mock);
+	const ac = new AbortController();
+	ac.abort(new Error("nope"));
+	const [stream, err] = await session.openUniStream(ac.signal);
+	assertEquals(stream, undefined);
+	assertInstanceOf(err, Error);
+	assertEquals((err as Error).message, "nope");
+	assertEquals(createCalled, false);
+});
+
+Deno.test("WebTransportSession.openUniStream happy path with a signal returns a SendStream", async () => {
+	const mock = {
+		incomingBidirectionalStreams: new ReadableStream({ start(_c) {} }),
+		incomingUnidirectionalStreams: new ReadableStream({ start(_c) {} }),
+		ready: Promise.resolve(),
+		closed: Promise.resolve({ closeCode: undefined, reason: undefined }),
+		async createUnidirectionalStream() {
+			return new WritableStream<Uint8Array>();
+		},
+	} as unknown as WebTransport;
+
+	const session = new WebTransportSession(mock);
+	const ac = new AbortController();
+	const [stream, err] = await session.openUniStream(ac.signal);
+	assertEquals(err, undefined);
+	assertInstanceOf(stream, SendStream);
+});
+
+Deno.test("WebTransportSession.openUniStream abort mid-wait abandons the late-resolving stream", async () => {
+	// A real WritableStream instance (so abandonRawStream's instanceof branch
+	// is taken) with a shadowed abort so the cleanup is observable.
+	let lateAborted = false;
+	const lateStream = new WritableStream<Uint8Array>();
+	Object.defineProperty(lateStream, "abort", {
+		value: (_reason?: unknown) => {
+			lateAborted = true;
+			return Promise.resolve();
+		},
+		configurable: true,
+	});
+
+	let resolveCreate!: (s: WritableStream<Uint8Array>) => void;
+	const createPromise = new Promise<WritableStream<Uint8Array>>((r) => {
+		resolveCreate = r;
+	});
+	const mock = {
+		incomingBidirectionalStreams: new ReadableStream({ start(_c) {} }),
+		incomingUnidirectionalStreams: new ReadableStream({ start(_c) {} }),
+		ready: Promise.resolve(),
+		closed: Promise.resolve({ closeCode: undefined, reason: undefined }),
+		createUnidirectionalStream() {
+			return createPromise;
+		},
+	} as unknown as WebTransport;
+
+	const session = new WebTransportSession(mock);
+	const ac = new AbortController();
+	const openP = session.openUniStream(ac.signal);
+	ac.abort(new Error("timeout"));
+
+	const [stream, err] = await openP;
+	assertEquals(stream, undefined);
+	assertInstanceOf(err, Error);
+	assertEquals((err as Error).message, "timeout");
+
+	// The WT open may still settle after the abort; the late stream must be
+	// abandoned rather than orphaned.
+	assertEquals(lateAborted, false);
+	resolveCreate(lateStream);
+	await Promise.resolve();
+	await Promise.resolve();
+	assertEquals(lateAborted, true);
 });

--- a/moq-web/src/internal/webtransport/connection_test.ts
+++ b/moq-web/src/internal/webtransport/connection_test.ts
@@ -230,7 +230,7 @@ Deno.test("WebTransportSession.openUniStream with a pre-aborted signal does not 
 	const session = new WebTransportSession(mock);
 	const ac = new AbortController();
 	ac.abort(new Error("nope"));
-	const [stream, err] = await session.openUniStream(ac.signal);
+	const [stream, err] = await session.openUniStream({ signal: ac.signal });
 	assertEquals(stream, undefined);
 	assertInstanceOf(err, Error);
 	assertEquals((err as Error).message, "nope");
@@ -250,7 +250,7 @@ Deno.test("WebTransportSession.openUniStream happy path with a signal returns a 
 
 	const session = new WebTransportSession(mock);
 	const ac = new AbortController();
-	const [stream, err] = await session.openUniStream(ac.signal);
+	const [stream, err] = await session.openUniStream({ signal: ac.signal });
 	assertEquals(err, undefined);
 	assertInstanceOf(stream, SendStream);
 });
@@ -284,7 +284,7 @@ Deno.test("WebTransportSession.openUniStream abort mid-wait abandons the late-re
 
 	const session = new WebTransportSession(mock);
 	const ac = new AbortController();
-	const openP = session.openUniStream(ac.signal);
+	const openP = session.openUniStream({ signal: ac.signal });
 	ac.abort(new Error("timeout"));
 
 	const [stream, err] = await openP;
@@ -317,7 +317,7 @@ Deno.test("WebTransportSession.openStream with a pre-aborted signal does not ope
 	const session = new WebTransportSession(mock);
 	const ac = new AbortController();
 	ac.abort(new Error("nope"));
-	const [stream, err] = await session.openStream(ac.signal);
+	const [stream, err] = await session.openStream({ signal: ac.signal });
 	assertEquals(stream, undefined);
 	assertInstanceOf(err, Error);
 	assertEquals((err as Error).message, "nope");
@@ -339,7 +339,7 @@ Deno.test("WebTransportSession.openUniStream pre-aborted with a non-Error reason
 	const ac = new AbortController();
 	// A non-Error reason falls back to ContextCancelledError.
 	ac.abort("a string reason");
-	const [stream, err] = await session.openUniStream(ac.signal);
+	const [stream, err] = await session.openUniStream({ signal: ac.signal });
 	assertEquals(stream, undefined);
 	assertInstanceOf(err, ContextCancelledError);
 });
@@ -378,7 +378,7 @@ Deno.test("WebTransportSession.openStream abort mid-wait abandons the late-resol
 
 	const session = new WebTransportSession(mock);
 	const ac = new AbortController();
-	const openP = session.openStream(ac.signal);
+	const openP = session.openStream({ signal: ac.signal });
 	ac.abort(new Error("timeout"));
 
 	const [stream, err] = await openP;

--- a/moq-web/src/session_test.ts
+++ b/moq-web/src/session_test.ts
@@ -110,7 +110,7 @@ class MockWebTransportSession implements StreamConn {
 		}
 	}
 
-	async openStream(): Promise<[Stream, undefined] | [undefined, Error]> {
+	async openStream(_signal?: AbortSignal): Promise<[Stream, undefined] | [undefined, Error]> {
 		if (this.#closed) {
 			return [undefined, new Error("session closed")];
 		}
@@ -148,7 +148,9 @@ class MockWebTransportSession implements StreamConn {
 		return [{ writable, readable }, undefined];
 	}
 
-	async openUniStream(): Promise<[SendStream, undefined] | [undefined, Error]> {
+	async openUniStream(
+		_signal?: AbortSignal,
+	): Promise<[SendStream, undefined] | [undefined, Error]> {
 		if (this.#closed) {
 			return [undefined, new Error("session closed")];
 		}

--- a/moq-web/src/session_test.ts
+++ b/moq-web/src/session_test.ts
@@ -110,7 +110,9 @@ class MockWebTransportSession implements StreamConn {
 		}
 	}
 
-	async openStream(_signal?: AbortSignal): Promise<[Stream, undefined] | [undefined, Error]> {
+	async openStream(
+		_options?: { signal?: AbortSignal },
+	): Promise<[Stream, undefined] | [undefined, Error]> {
 		if (this.#closed) {
 			return [undefined, new Error("session closed")];
 		}
@@ -149,7 +151,7 @@ class MockWebTransportSession implements StreamConn {
 	}
 
 	async openUniStream(
-		_signal?: AbortSignal,
+		_options?: { signal?: AbortSignal },
 	): Promise<[SendStream, undefined] | [undefined, Error]> {
 		if (this.#closed) {
 			return [undefined, new Error("session closed")];

--- a/moq-web/src/track_writer.ts
+++ b/moq-web/src/track_writer.ts
@@ -128,7 +128,10 @@ export class TrackWriter {
 		signal?: AbortSignal,
 	): Promise<[GroupWriter, undefined] | [undefined, Error]> {
 		// Mirror Go openGroupWithSequence (track_writer.go:298): if the track
-		// context is already done, fail fast without opening a stream.
+		// context is already done, fail fast without opening a stream. This
+		// synchronous check is load-bearing — toAbortSignal(this.context) only
+		// reflects cancellation on a later microtask, so the effective.aborted
+		// check below would not yet see it. Do not remove.
 		if (this.context.err()) {
 			return [undefined, this.context.err()!];
 		}
@@ -150,7 +153,7 @@ export class TrackWriter {
 
 		// §1 Abort before starting: do not open a stream.
 		if (effective.aborted) {
-			const reason = (effective as unknown as { reason?: unknown }).reason;
+			const reason = effective.reason;
 			return [
 				undefined,
 				reason instanceof Error ? reason : new ContextCancelledError(),

--- a/moq-web/src/track_writer.ts
+++ b/moq-web/src/track_writer.ts
@@ -21,7 +21,7 @@ export class TrackWriter {
 	/** The track name within the broadcast. */
 	trackName: string;
 	#subscribeStream: ReceiveSubscribeStream;
-	#openUniStreamFunc: (signal?: AbortSignal) => Promise<
+	#openUniStreamFunc: (options?: { signal?: AbortSignal }) => Promise<
 		[SendStream, undefined] | [undefined, Error]
 	>;
 	#groups: GroupWriter[] = [];
@@ -31,7 +31,7 @@ export class TrackWriter {
 		broadcastPath: BroadcastPath,
 		trackName: string,
 		subscribeStream: ReceiveSubscribeStream,
-		openUniStreamFunc: (signal?: AbortSignal) => Promise<
+		openUniStreamFunc: (options?: { signal?: AbortSignal }) => Promise<
 			[SendStream, undefined] | [undefined, Error]
 		>,
 	) {
@@ -160,7 +160,7 @@ export class TrackWriter {
 		// Thread the effective signal down to the stream-open, mirroring Go's
 		// openUniStreamFunc(ctx) (track_writer.go:314).
 		let writer: SendStream | undefined;
-		[writer, err] = await this.#openUniStreamFunc(effective);
+		[writer, err] = await this.#openUniStreamFunc({ signal: effective });
 		if (err) {
 			return [undefined, err];
 		}

--- a/moq-web/src/track_writer.ts
+++ b/moq-web/src/track_writer.ts
@@ -1,6 +1,6 @@
 import { GroupWriter } from "./group_stream.ts";
 import type { Info } from "./info.ts";
-import type { Context } from "@okdaichi/golikejs/context";
+import { type Context, ContextCancelledError, toAbortSignal } from "@okdaichi/golikejs/context";
 import type { ReceiveSubscribeStream, SubscribeDrop, TrackConfig } from "./subscribe_stream.ts";
 import type { SendStream } from "./internal/webtransport/mod.ts";
 import { UniStreamTypes } from "./stream_type.ts";
@@ -21,7 +21,7 @@ export class TrackWriter {
 	/** The track name within the broadcast. */
 	trackName: string;
 	#subscribeStream: ReceiveSubscribeStream;
-	#openUniStreamFunc: () => Promise<
+	#openUniStreamFunc: (signal?: AbortSignal) => Promise<
 		[SendStream, undefined] | [undefined, Error]
 	>;
 	#groups: GroupWriter[] = [];
@@ -31,7 +31,7 @@ export class TrackWriter {
 		broadcastPath: BroadcastPath,
 		trackName: string,
 		subscribeStream: ReceiveSubscribeStream,
-		openUniStreamFunc: () => Promise<
+		openUniStreamFunc: (signal?: AbortSignal) => Promise<
 			[SendStream, undefined] | [undefined, Error]
 		>,
 	) {
@@ -55,22 +55,34 @@ export class TrackWriter {
 
 	/**
 	 * Open a new group with an auto-incremented sequence number.
-	 * @returns A {@link GroupWriter} for writing frames.
+	 *
+	 * The group opens on a fresh unidirectional stream; when the peer's
+	 * concurrent-stream limit is reached this blocks until a stream is granted.
+	 * Pass `options.signal` to cancel or time out the open. If aborted, no group
+	 * stream remains open.
+	 * @param options - Optional cancellation `signal`.
+	 * @returns A {@link GroupWriter} for writing frames, or an error.
 	 */
-	async openGroup(): Promise<[GroupWriter, undefined] | [undefined, Error]> {
+	async openGroup(
+		options?: { signal?: AbortSignal },
+	): Promise<[GroupWriter, undefined] | [undefined, Error]> {
 		this.#groupCount++;
-		return this.#openGroupWithSequence(this.#groupCount);
+		return this.#openGroupWithSequence(this.#groupCount, options?.signal);
 	}
 
 	/**
 	 * Open a new group at a specific sequence number.
 	 * @param seq - The group sequence number.
+	 * @param options - Optional cancellation `signal`.
 	 */
-	async openGroupAt(seq: number): Promise<[GroupWriter, undefined] | [undefined, Error]> {
+	async openGroupAt(
+		seq: number,
+		options?: { signal?: AbortSignal },
+	): Promise<[GroupWriter, undefined] | [undefined, Error]> {
 		if (seq > this.#groupCount) {
 			this.#groupCount = seq;
 		}
-		return this.#openGroupWithSequence(seq);
+		return this.#openGroupWithSequence(seq, options?.signal);
 	}
 
 	/** Advance the group counter by `n` without opening groups. */
@@ -113,21 +125,52 @@ export class TrackWriter {
 
 	async #openGroupWithSequence(
 		seq: number,
+		signal?: AbortSignal,
 	): Promise<[GroupWriter, undefined] | [undefined, Error]> {
+		// Mirror Go openGroupWithSequence (track_writer.go:298): if the track
+		// context is already done, fail fast without opening a stream.
+		if (this.context.err()) {
+			return [undefined, this.context.err()!];
+		}
+
+		// ensureInfo is not raced against the signal (Go passes no ctx here).
 		let err: Error | undefined;
 		err = await this.#subscribeStream.ensureInfo();
 		if (err) {
 			return [undefined, err];
 		}
 
+		// Effective cancellation: the track context OR the caller's signal.
+		// AbortSignal.any composes them; with no caller signal the track context
+		// alone bounds the open (Go's `ctx.Done()==nil → w.Context()`).
+		const trackSignal = toAbortSignal(this.context);
+		const effective: AbortSignal = signal
+			? AbortSignal.any([trackSignal, signal])
+			: trackSignal;
+
+		// §1 Abort before starting: do not open a stream.
+		if (effective.aborted) {
+			const reason = (effective as unknown as { reason?: unknown }).reason;
+			return [
+				undefined,
+				reason instanceof Error ? reason : new ContextCancelledError(),
+			];
+		}
+
+		// Thread the effective signal down to the stream-open, mirroring Go's
+		// openUniStreamFunc(ctx) (track_writer.go:314).
 		let writer: SendStream | undefined;
-		[writer, err] = await this.#openUniStreamFunc();
+		[writer, err] = await this.#openUniStreamFunc(effective);
 		if (err) {
 			return [undefined, err];
 		}
 
+		// §3 A stream is now allocated. Any failure before the group header is
+		// fully written must cancel the stream so it is never left half-open.
+		// (Mirrors Go stream.CancelWrite on encode error; previously leaked.)
 		[, err] = await writeVarint(writer!, UniStreamTypes.GroupStreamType);
 		if (err) {
+			await writer!.cancel(GroupErrorCode.InternalError).catch(() => {});
 			return [undefined, new Error(`Failed to write stream type: ${err}`)];
 		}
 
@@ -137,6 +180,7 @@ export class TrackWriter {
 		});
 		err = await msg.encode(writer!);
 		if (err) {
+			await writer!.cancel(GroupErrorCode.InternalError).catch(() => {});
 			return [undefined, new Error("Failed to create group message")];
 		}
 

--- a/moq-web/src/track_writer_test.ts
+++ b/moq-web/src/track_writer_test.ts
@@ -6,6 +6,7 @@ import { SendStream } from "./internal/webtransport/mod.ts";
 import { MockSendStream, MockStream } from "./mock_stream_test.ts";
 import { ReceiveSubscribeStream } from "./subscribe_stream.ts";
 import { SubscribeMessage } from "./internal/message/mod.ts";
+import { GroupErrorCode } from "./error.ts";
 
 Deno.test("TrackWriter", async (t) => {
 	await t.step(
@@ -162,6 +163,108 @@ Deno.test("TrackWriter", async (t) => {
 			const [group, err] = await tw.openGroup();
 			assertEquals(group, undefined);
 			assertInstanceOf(err, Error);
+		},
+	);
+
+	await t.step(
+		"TrackWriter.openGroup with a pre-aborted signal does not open a stream",
+		async () => {
+			const [ctx] = withCancelCause(background());
+			const stream = new MockStream({});
+			const subscribe = new SubscribeMessage({
+				subscribeId: 99,
+				broadcastPath: "/test",
+				trackName: "test",
+				subscriberPriority: 0,
+			});
+			const rss = new ReceiveSubscribeStream(ctx, stream, subscribe);
+			let openCalled = false;
+			const openUni = async (_signal?: AbortSignal) => {
+				openCalled = true;
+				return [new MockSendStream({}), undefined] as [SendStream, undefined];
+			};
+			const tw = new TrackWriter("/test", "test", rss, openUni);
+
+			const ac = new AbortController();
+			ac.abort(new Error("aborted before start"));
+			const [grp, err] = await tw.openGroup({ signal: ac.signal });
+
+			assertEquals(grp, undefined);
+			assertInstanceOf(err, Error);
+			assertEquals((err as Error).message, "aborted before start");
+			assertEquals(openCalled, false);
+		},
+	);
+
+	await t.step(
+		"TrackWriter.openGroup threads an effective signal to openUniStreamFunc",
+		async () => {
+			const [ctx] = withCancelCause(background());
+			const stream = new MockStream({});
+			const subscribe = new SubscribeMessage({
+				subscribeId: 99,
+				broadcastPath: "/test",
+				trackName: "test",
+				subscriberPriority: 0,
+			});
+			const rss = new ReceiveSubscribeStream(ctx, stream, subscribe);
+			let receivedSignal: AbortSignal | undefined;
+			const openUni = async (signal?: AbortSignal) => {
+				receivedSignal = signal;
+				return [new MockSendStream({}), undefined] as [SendStream, undefined];
+			};
+			const tw = new TrackWriter("/test", "test", rss, openUni);
+
+			const ac = new AbortController();
+			const [grp, err] = await tw.openGroup({ signal: ac.signal });
+			assertEquals(err, undefined);
+			assertEquals(grp !== undefined, true);
+
+			// The signal passed down is the composed effective signal: aborting
+			// the caller's controller is reflected in it.
+			assertEquals(receivedSignal !== undefined, true);
+			assertEquals(receivedSignal!.aborted, false);
+			ac.abort();
+			assertEquals(receivedSignal!.aborted, true);
+		},
+	);
+
+	await t.step(
+		"TrackWriter.openGroup cancels the allocated stream when the header write fails",
+		async () => {
+			const [ctx] = withCancelCause(background());
+			const stream = new MockStream({});
+			const subscribe = new SubscribeMessage({
+				subscribeId: 0,
+				broadcastPath: "/test",
+				trackName: "name",
+				subscriberPriority: 0,
+			});
+			const rss = new ReceiveSubscribeStream(ctx, stream, subscribe);
+
+			const cancelCalls: number[] = [];
+			const mockSend = new MockSendStream({
+				write: spy(async (_p: Uint8Array) =>
+					[0, new Error("group header write failed")] as [
+						number,
+						Error | undefined,
+					]
+				),
+				cancel: spy(async (code: number) => {
+					cancelCalls.push(code);
+				}),
+			});
+			const openUni = async (_signal?: AbortSignal) =>
+				[mockSend, undefined] as [SendStream, undefined];
+			const tw = new TrackWriter("/test", "name", rss, openUni);
+
+			const [group, err] = await tw.openGroup();
+			assertEquals(group, undefined);
+			assertInstanceOf(err, Error);
+			// §3: the allocated stream must be cancelled with InternalError, not
+			// left half-open.
+			assertEquals(cancelCalls.length, 1);
+			assertEquals(cancelCalls[0], GroupErrorCode.InternalError);
 		},
 	);
 });

--- a/moq-web/src/track_writer_test.ts
+++ b/moq-web/src/track_writer_test.ts
@@ -267,4 +267,80 @@ Deno.test("TrackWriter", async (t) => {
 			assertEquals(cancelCalls[0], GroupErrorCode.InternalError);
 		},
 	);
+
+	await t.step(
+		"TrackWriter.openGroup cancels the allocated stream when group message encode fails",
+		async () => {
+			const [ctx] = withCancelCause(background());
+			const stream = new MockStream({});
+			const subscribe = new SubscribeMessage({
+				subscribeId: 0,
+				broadcastPath: "/test",
+				trackName: "name",
+				subscriberPriority: 0,
+			});
+			const rss = new ReceiveSubscribeStream(ctx, stream, subscribe);
+
+			const cancelCalls: number[] = [];
+			let writeCall = 0;
+			const mockSend = new MockSendStream({
+				write: spy(async (p: Uint8Array) => {
+					writeCall++;
+					// Stream-type varint (first write) succeeds; subsequent
+					// writes (GroupMessage encode) fail.
+					if (writeCall >= 2) {
+						return [0, new Error("group message encode failed")] as [
+							number,
+							Error | undefined,
+						];
+					}
+					return [p.length, undefined] as [number, Error | undefined];
+				}),
+				cancel: spy(async (code: number) => {
+					cancelCalls.push(code);
+				}),
+			});
+			const openUni = async (_signal?: AbortSignal) =>
+				[mockSend, undefined] as [SendStream, undefined];
+			const tw = new TrackWriter("/test", "name", rss, openUni);
+
+			const [group, err] = await tw.openGroup();
+			assertEquals(group, undefined);
+			assertInstanceOf(err, Error);
+			assertEquals(cancelCalls.length, 1);
+			assertEquals(cancelCalls[0], GroupErrorCode.InternalError);
+		},
+	);
+
+	await t.step(
+		"TrackWriter.openGroup returns the context error when the track is already cancelled",
+		async () => {
+			const [ctx, cancel] = withCancelCause(background());
+			const stream = new MockStream({});
+			const subscribe = new SubscribeMessage({
+				subscribeId: 99,
+				broadcastPath: "/test",
+				trackName: "test",
+				subscriberPriority: 0,
+			});
+			const rss = new ReceiveSubscribeStream(ctx, stream, subscribe);
+			let openCalled = false;
+			const openUni = async (_signal?: AbortSignal) => {
+				openCalled = true;
+				return [new MockSendStream({}), undefined] as [SendStream, undefined];
+			};
+			const tw = new TrackWriter("/test", "test", rss, openUni);
+
+			cancel(new Error("track closed"));
+			// Parent→child (withCancelCause) cancellation propagates on the
+			// microtask queue; drain it so the track context is observed as
+			// cancelled before openGroup runs.
+			await new Promise((r) => setTimeout(r, 0));
+			const [grp, err] = await tw.openGroup();
+			assertEquals(grp, undefined);
+			assertInstanceOf(err, Error);
+			assertEquals((err as Error).message, "track closed");
+			assertEquals(openCalled, false);
+		},
+	);
 });

--- a/moq-web/src/track_writer_test.ts
+++ b/moq-web/src/track_writer_test.ts
@@ -179,7 +179,7 @@ Deno.test("TrackWriter", async (t) => {
 			});
 			const rss = new ReceiveSubscribeStream(ctx, stream, subscribe);
 			let openCalled = false;
-			const openUni = async (_signal?: AbortSignal) => {
+			const openUni = async (_options?: { signal?: AbortSignal }) => {
 				openCalled = true;
 				return [new MockSendStream({}), undefined] as [SendStream, undefined];
 			};
@@ -209,8 +209,8 @@ Deno.test("TrackWriter", async (t) => {
 			});
 			const rss = new ReceiveSubscribeStream(ctx, stream, subscribe);
 			let receivedSignal: AbortSignal | undefined;
-			const openUni = async (signal?: AbortSignal) => {
-				receivedSignal = signal;
+			const openUni = async (options?: { signal?: AbortSignal }) => {
+				receivedSignal = options?.signal;
 				return [new MockSendStream({}), undefined] as [SendStream, undefined];
 			};
 			const tw = new TrackWriter("/test", "test", rss, openUni);
@@ -254,7 +254,7 @@ Deno.test("TrackWriter", async (t) => {
 					cancelCalls.push(code);
 				}),
 			});
-			const openUni = async (_signal?: AbortSignal) =>
+			const openUni = async (_options?: { signal?: AbortSignal }) =>
 				[mockSend, undefined] as [SendStream, undefined];
 			const tw = new TrackWriter("/test", "name", rss, openUni);
 
@@ -300,7 +300,7 @@ Deno.test("TrackWriter", async (t) => {
 					cancelCalls.push(code);
 				}),
 			});
-			const openUni = async (_signal?: AbortSignal) =>
+			const openUni = async (_options?: { signal?: AbortSignal }) =>
 				[mockSend, undefined] as [SendStream, undefined];
 			const tw = new TrackWriter("/test", "name", rss, openUni);
 
@@ -325,7 +325,7 @@ Deno.test("TrackWriter", async (t) => {
 			});
 			const rss = new ReceiveSubscribeStream(ctx, stream, subscribe);
 			let openCalled = false;
-			const openUni = async (_signal?: AbortSignal) => {
+			const openUni = async (_options?: { signal?: AbortSignal }) => {
 				openCalled = true;
 				return [new MockSendStream({}), undefined] as [SendStream, undefined];
 			};


### PR DESCRIPTION
## Summary

Adds `AbortSignal`-based cancellation to group creation and stream opening in `moq-web`, mirroring how the Go implementation threads `context.Context` into `OpenGroup(ctx)` → `openUniStreamFunc(ctx)`.

The TS `TrackWriter.openGroup()` previously had no cancellation handle and could block indefinitely on WebTransport stream credit; callers had no way to cancel or time out the open.

## API

```ts
TrackWriter.openGroup(options?: { signal?: AbortSignal }): Promise<[GroupWriter, undefined] | [undefined, Error]>
TrackWriter.openGroupAt(seq, options?: { signal?: AbortSignal }): ...
StreamConn.openStream(signal?: AbortSignal) / openUniStream(signal?: AbortSignal)
```

Tuple `[value, undefined] | [undefined, Error]` returns are preserved (consistent with the rest of the library). On abort, `signal.reason` (or `ContextCancelledError`) is returned.

## Behavior

- **Abort before start** → no stream is opened.
- **Abort while waiting for stream credit** → the open is cancelled via `Promise.race`. Browser `create*Stream()` cannot be cancelled, so a cleanup continuation abandons any **late-resolving stream** (RESET via `writable.abort`) — never orphaned.
- **Abort/failure after a stream is allocated** but before the group header is written → the stream is `cancel()`ed. *(This also fixes a pre-existing leak: the old code returned an error without cancelling the allocated stream; Go always did `CancelWrite`.)*
- Effective cancellation fires on **either** the track-context death **or** the caller's abort (`AbortSignal.any([toAbortSignal(this.context), signal])\)), plus Go's upfront `context.err()` check.

Internally the signal is converted to a golikejs `Context` (`watchSignal`) and composed with `Promise.race`, mirroring Go's `ctx.Done()`. `ensureInfo` is intentionally **not** raced (Go passes no ctx there). Self-contained in `moq-web` — **no golikejs changes**.

## Out of scope

Aligning `ensureInfo({ startGroup: seq })` with Go is a separate protocol-level behavior change, not a cancellation concern — left for a follow-up.

## Verification (`moq-web/`)

- `deno check`, `deno lint` (89 files), `deno fmt --check` — all clean
- **Full suite: 164 passed (339 steps), 0 failed**
- New tests: pre-aborted signal, effective-signal threading, §3 cleanup, and abort-mid-wait → late stream abandoned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)