### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix OOM DoS in ReadStringArray allocation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,7 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when decoding payloads. The `ReadMessageLength` parsed varint size (up to 2^62-1) was directly used for a `make([]byte, size)` allocation.
 **Learning:** An attacker can easily trigger massive memory allocation, crashing the application.
 **Prevention:** Apply a size check constraint (e.g. 50MB limit) immediately prior to allocation in `Decode` methods.
+## 2024-06-21 - Fix OOM DoS in ReadStringArray via unconstrained count allocation
+**Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when parsing string arrays. `ReadStringArray` parsed a varint count and directly allocated `make([]string, 0, count)`.
+**Learning:** An attacker can trigger massive slice allocations, causing OOM DoS, by advertising a large element count for an array.
+**Prevention:** Ensure parsed array counts cannot exceed the remaining payload length (e.g. `count > len(b)`) before preallocating slices based on untrusted network input.

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -111,6 +111,10 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 
 	b = b[total:]
 
+	if count > uint64(len(b)) {
+		return nil, 0, ErrMessageTooLarge
+	}
+
 	arr := make([]string, 0, count)
 	for range count {
 		str, n, err := ReadString(b)

--- a/moqt/internal/message/message_reader_test.go
+++ b/moqt/internal/message/message_reader_test.go
@@ -278,6 +278,12 @@ func TestReadStringArray(t *testing.T) {
 		n        int
 		wantErr  bool
 	}{
+		"oversized array count DoS": {
+			input:    []byte{0x80, 0x01, 0x00, 0x00, 0x01}, // count=65536, but len(b)=1
+			expected: nil,
+			n:        0,
+			wantErr:  true,
+		},
 		"empty array": {
 			input:    []byte{0x00},
 			expected: []string{},


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Out-of-memory (OOM) Denial of Service via unconstrained array length allocation in `ReadStringArray`.
🎯 Impact: Attackers can crash the service by sending a small payload with a massive string array count varint.
🔧 Fix: Implemented an explicit boundary check (`count > uint64(len(b))`) prior to slice allocation.
✅ Verification: Added a test verifying oversized counts are rejected with `ErrMessageTooLarge`, and successfully ran the test suite.

---
*PR created automatically by Jules for task [12348462162762901869](https://jules.google.com/task/12348462162762901869) started by @okdaichi*