### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix OOM DoS in ReadStringArray slice pre-allocation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,7 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when decoding payloads. The `ReadMessageLength` parsed varint size (up to 2^62-1) was directly used for a `make([]byte, size)` allocation.
 **Learning:** An attacker can easily trigger massive memory allocation, crashing the application.
 **Prevention:** Apply a size check constraint (e.g. 50MB limit) immediately prior to allocation in `Decode` methods.
+## 2024-06-27 - Fix OOM DoS via unconstrained varint allocation in ReadStringArray
+**Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when pre-allocating string slices in `ReadStringArray`. The parsed varint size was directly used as the capacity for `make([]string, 0, count)`.
+**Learning:** Untrusted length prefixes must always be constrained against the remaining buffer length before any pre-allocation, even for slices with a length of 0, because the capacity allocates memory (each element requires at least one byte).
+**Prevention:** Check `if count > uint64(len(b))` and clamp it before pre-allocating slices from untrusted byte buffers.

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -111,7 +111,12 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 
 	b = b[total:]
 
-	arr := make([]string, 0, count)
+	capSize := count
+	if capSize > uint64(len(b)) {
+		capSize = uint64(len(b))
+	}
+
+	arr := make([]string, 0, capSize)
 	for range count {
 		str, n, err := ReadString(b)
 		if err != nil {

--- a/moqt/internal/message/primitives_benchmark_test.go
+++ b/moqt/internal/message/primitives_benchmark_test.go
@@ -52,10 +52,10 @@ func BenchmarkReadVarint(b *testing.B) {
 		name string
 		val  uint64
 	}{
-		{"1byte", maxVarInt1},     // top-2-bits 0b00
-		{"2byte", maxVarInt2},     // top-2-bits 0b01
-		{"4byte", maxVarInt4},     // top-2-bits 0b10
-		{"8byte", maxVarInt8},     // top-2-bits 0b11
+		{"1byte", maxVarInt1}, // top-2-bits 0b00
+		{"2byte", maxVarInt2}, // top-2-bits 0b01
+		{"4byte", maxVarInt4}, // top-2-bits 0b10
+		{"8byte", maxVarInt8}, // top-2-bits 0b11
 	}
 	for _, w := range widths {
 		b.Run(w.name, func(b *testing.B) {

--- a/moqt/session_test.go
+++ b/moqt/session_test.go
@@ -44,12 +44,12 @@ func (noStatsConn) AcceptStream(context.Context) (transport.Stream, error) { ret
 func (noStatsConn) AcceptUniStream(context.Context) (transport.ReceiveStream, error) {
 	return nil, io.EOF
 }
-func (noStatsConn) CloseWithError(transport.ConnErrorCode, string) error { return nil }
-func (noStatsConn) Context() context.Context                             { return context.Background() }
-func (noStatsConn) LocalAddr() net.Addr                                  { return &net.TCPAddr{} }
-func (noStatsConn) OpenStream() (transport.Stream, error)                { return nil, io.EOF }
+func (noStatsConn) CloseWithError(transport.ConnErrorCode, string) error     { return nil }
+func (noStatsConn) Context() context.Context                                 { return context.Background() }
+func (noStatsConn) LocalAddr() net.Addr                                      { return &net.TCPAddr{} }
+func (noStatsConn) OpenStream() (transport.Stream, error)                    { return nil, io.EOF }
 func (noStatsConn) OpenStreamSync(context.Context) (transport.Stream, error) { return nil, io.EOF }
-func (noStatsConn) OpenUniStream() (transport.SendStream, error)         { return nil, io.EOF }
+func (noStatsConn) OpenUniStream() (transport.SendStream, error)             { return nil, io.EOF }
 func (noStatsConn) OpenUniStreamSync(context.Context) (transport.SendStream, error) {
 	return nil, io.EOF
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: OOM DoS caused by unconstrained varint allocation in `ReadStringArray`
🎯 Impact: Remote attacker can send a large varint prefix with a short payload, causing a multi-GB slice allocation and crashing the process.
🔧 Fix: Clamped the pre-allocation capacity to the length of the remaining buffer size.
✅ Verification: Added bounds checking for capacity in `ReadStringArray`, tests passed.

---
*PR created automatically by Jules for task [12965274790718395727](https://jules.google.com/task/12965274790718395727) started by @okdaichi*