### PR TITLE
⚡ Bolt: Optimize varint decoding to avoid heap allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-06-25 - Exact pre-allocation over fixed bounds
 **Learning:** For variable depth path splitting (e.g. prefix arrays), pre-calculating the exact number of segments via `strings.Count(str, "/")` and allocating the slice exactly (`make([]T, 0, n)`) is measurably faster than fixed pre-allocation (e.g., `make([]T, 0, 8)`). Removing the final `strings.Split` allocation in the `pathSegments` function further reduces GC pressure.
 **Action:** Always count known delimiters in small string parsing rather than falling back to `strings.Split` or using arbitrary fixed pre-allocations when generating slices in hot paths.
+## 2024-05-19 - Safe Varint Decoding Optimization
+**Learning:** In Go, fallback paths (like non-`io.ByteReader` readers) in hot decoding loops shouldn't use dynamic slice allocations (e.g., `make([]byte, size)`) if the maximum size is small and fixed (like an 8-byte varint). Replacing `make()` with a local fixed-size array (e.g., `var buf [8]byte`) and slicing it `buf[:size]` entirely eliminates heap allocations.
+**Action:** When parsing small, bounded objects like varints from an `io.Reader`, use stack-allocated arrays and take their slices (`buf[:length]`) instead of dynamically allocating slices with `make`.

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -52,21 +52,19 @@ func ReadMessageLength(r io.Reader) (uint64, error) {
 	}
 
 	// Fallback for readers that are not io.ByteReader.
-	firstByte := make([]byte, 1)
-	_, err := io.ReadFull(r, firstByte)
+	var buf [8]byte
+	_, err := io.ReadFull(r, buf[:1])
 	if err != nil {
 		return 0, err
 	}
-	l := 1 << ((firstByte[0] & 0xc0) >> 6)
-	buf := make([]byte, l)
-	buf[0] = firstByte[0]
+	l := 1 << ((buf[0] & 0xc0) >> 6)
 	if l > 1 {
-		_, err = io.ReadFull(r, buf[1:])
+		_, err = io.ReadFull(r, buf[1:l])
 		if err != nil {
 			return 0, err
 		}
 	}
-	val, _, err := ReadVarint(buf)
+	val, _, err := ReadVarint(buf[:l])
 	return val, err
 }
 

--- a/moqt/internal/message/primitives_benchmark_test.go
+++ b/moqt/internal/message/primitives_benchmark_test.go
@@ -51,10 +51,10 @@ func BenchmarkReadVarint(b *testing.B) {
 		name string
 		val  uint64
 	}{
-		{"1byte", maxVarInt1},     // top-2-bits 0b00
-		{"2byte", maxVarInt2},     // top-2-bits 0b01
-		{"4byte", maxVarInt4},     // top-2-bits 0b10
-		{"8byte", maxVarInt8},     // top-2-bits 0b11
+		{"1byte", maxVarInt1}, // top-2-bits 0b00
+		{"2byte", maxVarInt2}, // top-2-bits 0b01
+		{"4byte", maxVarInt4}, // top-2-bits 0b10
+		{"8byte", maxVarInt8}, // top-2-bits 0b11
 	}
 	for _, w := range widths {
 		b.Run(w.name, func(b *testing.B) {

--- a/moqt/session_test.go
+++ b/moqt/session_test.go
@@ -44,12 +44,12 @@ func (noStatsConn) AcceptStream(context.Context) (transport.Stream, error) { ret
 func (noStatsConn) AcceptUniStream(context.Context) (transport.ReceiveStream, error) {
 	return nil, io.EOF
 }
-func (noStatsConn) CloseWithError(transport.ConnErrorCode, string) error { return nil }
-func (noStatsConn) Context() context.Context                             { return context.Background() }
-func (noStatsConn) LocalAddr() net.Addr                                  { return &net.TCPAddr{} }
-func (noStatsConn) OpenStream() (transport.Stream, error)                { return nil, io.EOF }
+func (noStatsConn) CloseWithError(transport.ConnErrorCode, string) error     { return nil }
+func (noStatsConn) Context() context.Context                                 { return context.Background() }
+func (noStatsConn) LocalAddr() net.Addr                                      { return &net.TCPAddr{} }
+func (noStatsConn) OpenStream() (transport.Stream, error)                    { return nil, io.EOF }
 func (noStatsConn) OpenStreamSync(context.Context) (transport.Stream, error) { return nil, io.EOF }
-func (noStatsConn) OpenUniStream() (transport.SendStream, error)         { return nil, io.EOF }
+func (noStatsConn) OpenUniStream() (transport.SendStream, error)             { return nil, io.EOF }
 func (noStatsConn) OpenUniStreamSync(context.Context) (transport.SendStream, error) {
 	return nil, io.EOF
 }


### PR DESCRIPTION
💡 What: Optimize `ReadMessageLength` in `moqt/internal/message/message_reader.go` by replacing dynamic `make([]byte, ...)` calls with slices of a stack-allocated array (`var buf [8]byte`).

🎯 Why: In hot decoding loops (like the non-`io.ByteReader` fallback path), dynamic allocations create unnecessary GC pressure. Since we know a QUIC varint length prefix is at most 8 bytes, we can use a pre-sized local array and completely avoid allocating slices on the heap.

📊 Impact: Reduces allocations for varint length decoding on the `io.Reader` fallback path, lowering overhead on bounded reader streams.

🔬 Measurement: Verified using `go test -bench=BenchmarkReadMessageLength` in `moqt/internal/message`.

---
*PR created automatically by Jules for task [16877143609848613479](https://jules.google.com/task/16877143609848613479) started by @okdaichi*