### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix OOM DoS in slice pre-allocations via unconstrained varints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,8 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when decoding payloads. The `ReadMessageLength` parsed varint size (up to 2^62-1) was directly used for a `make([]byte, size)` allocation.
 **Learning:** An attacker can easily trigger massive memory allocation, crashing the application.
 **Prevention:** Apply a size check constraint (e.g. 50MB limit) immediately prior to allocation in `Decode` methods.
+
+## 2024-06-21 - Fix OOM DoS via unconstrained varint array slice pre-allocation
+**Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when pre-allocating slices for variable-length arrays based on an untrusted varint count prefix (e.g., `make([]string, 0, count)` or `make([]uint64, count)`). An attacker can specify a huge count for an array with very few bytes, causing the server to allocate massive amounts of memory and crash before parsing the next item.
+**Learning:** Even if the overall message size is constrained or the buffer is small, `make` pre-allocations using unvalidated array lengths can cause OOM DoS.
+**Prevention:** Compute a clamped capacity based on `len(b)` and the maximum possible count before allocating, and allocate `make([]T, 0, allocCap)`. Let the subsequent decode loop naturally fail with an EOF when the buffer is exhausted.

--- a/moqt/internal/message/announce.go
+++ b/moqt/internal/message/announce.go
@@ -89,13 +89,17 @@ func (am *AnnounceMessage) Decode(src io.Reader) error {
 	}
 	b = b[n:]
 
-	am.HopIDs = make([]uint64, hopCount)
-	for i := range hopCount {
+	allocCap := hopCount
+	if hopCount > uint64(len(b)) {
+		allocCap = uint64(len(b))
+	}
+	am.HopIDs = make([]uint64, 0, allocCap)
+	for range hopCount {
 		num, n, err = ReadVarint(b)
 		if err != nil {
 			return err
 		}
-		am.HopIDs[i] = num
+		am.HopIDs = append(am.HopIDs, num)
 		b = b[n:]
 	}
 

--- a/moqt/internal/message/decode_dos_test.go
+++ b/moqt/internal/message/decode_dos_test.go
@@ -38,3 +38,32 @@ func TestDecode_RejectsOversizedLength(t *testing.T) {
 		})
 	}
 }
+
+func TestDecode_RejectsOversizedArrayCount(t *testing.T) {
+	// 1. AnnounceMessage HopIDs
+	// Create a payload with a large hop count but no actual hop ID bytes
+	b := make([]byte, 0, 8)
+	b, _ = message.WriteVarint(b, 1000000) // HopCount = 1,000,000
+
+	// Create an AnnounceMessage with proper length prefix and structure
+	payload := make([]byte, 0, 64)
+	payload, _ = message.WriteVarint(payload, uint64(message.ACTIVE)) // AnnounceStatus
+	payload, _ = message.WriteString(payload, "test")                 // BroadcastPathSuffix
+	payload = append(payload, b...)                                   // Add the giant HopCount
+
+	msgLen := uint64(len(payload))
+	full := make([]byte, 0, 128)
+	full, _ = message.WriteMessageLength(full, msgLen)
+	full = append(full, payload...)
+
+	am := &message.AnnounceMessage{}
+	err := am.Decode(bytes.NewReader(full))
+	assert.ErrorIs(t, err, io.EOF) // Should fail with EOF reading first missing HopID, NOT OOM crash
+
+	// 2. ReadStringArray count
+	b2 := make([]byte, 0, 8)
+	b2, _ = message.WriteVarint(b2, 1000000) // Count = 1,000,000
+
+	_, _, err2 := message.ReadStringArray(b2)
+	assert.ErrorIs(t, err2, io.EOF) // Should fail with EOF reading first missing string, NOT OOM crash
+}

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -111,7 +111,11 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 
 	b = b[total:]
 
-	arr := make([]string, 0, count)
+	allocCap := count
+	if count > uint64(len(b)) {
+		allocCap = uint64(len(b))
+	}
+	arr := make([]string, 0, allocCap)
 	for range count {
 		str, n, err := ReadString(b)
 		if err != nil {


### PR DESCRIPTION
- 🚨 Severity: CRITICAL
- 💡 Vulnerability: Fix OOM DoS in slice pre-allocations via unconstrained varints.
- 🎯 Impact: An attacker can specify a huge count for an array with very few bytes, causing the server to allocate massive amounts of memory and crash before parsing the next item.
- 🔧 Fix: Compute a clamped capacity based on `len(b)` and the maximum possible count before allocating, and allocate `make([]T, 0, allocCap)`.
- ✅ Verification: Added tests to explicitly verify that reading an `AnnounceMessage` and `ReadStringArray` with a giant `hopCount`/`count` but an empty or small buffer correctly fails with `io.EOF` (or similar) without causing an out-of-memory crash.

---
*PR created automatically by Jules for task [8193347878369782660](https://jules.google.com/task/8193347878369782660) started by @okdaichi*