### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix OOM DoS in ReadStringArray

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,7 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when decoding payloads. The `ReadMessageLength` parsed varint size (up to 2^62-1) was directly used for a `make([]byte, size)` allocation.
 **Learning:** An attacker can easily trigger massive memory allocation, crashing the application.
 **Prevention:** Apply a size check constraint (e.g. 50MB limit) immediately prior to allocation in `Decode` methods.
+## 2024-06-29 - Fix OOM DoS via unconstrained varint allocation in ReadStringArray
+**Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when decoding string arrays. The `ReadVarint` parsed array count was directly used for a `make([]string, 0, count)` allocation.
+**Learning:** An attacker can easily trigger massive memory allocation using a small payload with a huge array count prefix, crashing the application.
+**Prevention:** Verify that the requested `count` does not exceed the remaining buffer length (`count > uint64(len(b))`) before preallocating the slice.

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -111,6 +111,10 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 
 	b = b[total:]
 
+	if count > uint64(len(b)) {
+		return nil, total, ErrMessageTooShort
+	}
+
 	arr := make([]string, 0, count)
 	for range count {
 		str, n, err := ReadString(b)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `ReadStringArray` function parsed a string array `count` directly from a QUIC varint and immediately preallocated a slice using `make([]string, 0, count)`. A malicious actor could send a very small QUIC message with an artificially huge `count` prefix (up to `2^62-1`), causing an unconstrained slice allocation that results in severe memory exhaustion and panics (OOM Denial of Service).
🎯 Impact: An attacker can easily crash the application by sending a few bytes over an untrusted QUIC stream.
🔧 Fix: We added a safety constraint `if count > uint64(len(b))` before preallocating the slice. Since each array element requires at least one byte in the buffer for its varint length prefix, a valid payload's buffer length must be greater than or equal to `count`. If not, we return `ErrMessageTooShort`.
✅ Verification: We ran the full Go test suite locally. Additionally, test scripts confirmed that without this fix, a manually crafted byte payload triggers a panic, and with this fix, the application gracefully returns an `ErrMessageTooShort` error. Code review marked this as `#Correct#`.

---
*PR created automatically by Jules for task [12940926756819478062](https://jules.google.com/task/12940926756819478062) started by @okdaichi*