### PR TITLE
fix(moq-web): bound readFrame length to prevent OOM DoS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **moqt:** Removed the empty `group_manager.go` — a dead leftover from the refactor that renamed `groupManager` to `groupReaderManager`/`groupWriterManager` (eb00586). It declared nothing; the types live in `group_reader.go`/`group_writer.go`.
 
+### Fixed
+
+- **Security (moq-web):** `GroupReader.readFrame` now rejects a frame whose varint length prefix exceeds `MAX_FRAME_SIZE` (50 MB) before allocating, closing an out-of-memory denial-of-service vector — the buffer was sized straight from an untrusted peer's length, so a single packet could request a multi-gigabyte allocation. Mirrors the Go implementation's `message.MaxMessageSize` guard (`moqt/frame.go`).
+
 ## [v0.16.0] - 2026-06-26
 
 ### Added

--- a/moq-web/src/group_stream.ts
+++ b/moq-web/src/group_stream.ts
@@ -10,6 +10,17 @@ import { ByteSink, ByteSinkFunc, ByteSource, Frame } from "./frame.ts";
 import { EOFError } from "@okdaichi/golikejs/io";
 
 /**
+ * Maximum frame payload size accepted by {@link GroupReader.readFrame} (50 MB).
+ *
+ * `readFrame` allocates a buffer sized by a varint length prefix taken straight
+ * from the peer, so an unbounded length is an out-of-memory denial-of-service
+ * vector: one packet can ask for a multi-gigabyte allocation. Lengths above
+ * this limit are rejected before allocating. Mirrors the Go implementation's
+ * `message.MaxMessageSize` (`moqt/frame.go`).
+ */
+export const MAX_FRAME_SIZE = 50 * 1024 * 1024;
+
+/**
  * Writes frames to a single group within a track.
  *
  * Obtained from {@link TrackWriter.openGroup}. Each frame is length-prefixed
@@ -122,6 +133,14 @@ export class GroupReader {
 		// and break out of their read loops (see `frames()` below).
 		if (err1) {
 			return err1;
+		}
+
+		// Reject an oversized length before allocating — guards against an
+		// out-of-memory DoS from an untrusted peer (see {@link MAX_FRAME_SIZE}).
+		if (len > MAX_FRAME_SIZE) {
+			return new Error(
+				`moq: frame length ${len} exceeds maximum ${MAX_FRAME_SIZE}`,
+			);
 		}
 
 		try {

--- a/moq-web/src/group_stream_test.ts
+++ b/moq-web/src/group_stream_test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, assertInstanceOf } from "@std/assert";
 import { spy } from "@std/testing/mock";
-import { GroupReader, GroupWriter } from "./group_stream.ts";
+import { GroupReader, GroupWriter, MAX_FRAME_SIZE } from "./group_stream.ts";
 import { GroupMessage, writeVarint } from "./internal/message/mod.ts";
 import { Buffer } from "@okdaichi/golikejs/bytes";
 import { Frame } from "./frame.ts";
@@ -242,6 +242,32 @@ Deno.test("GroupReader", async (t) => {
 		const fr = new Frame(new ArrayBuffer(1));
 		const errRes = await gr.readFrame(fr);
 		assertInstanceOf(errRes, Error);
+	});
+
+	await t.step("readFrame rejects a frame larger than MAX_FRAME_SIZE", async () => {
+		// A length one byte over the limit is rejected before any allocation, so
+		// the stream needs only the length prefix (no payload follows).
+		const lenBuf = Buffer.make(8);
+		await writeVarint(lenBuf, MAX_FRAME_SIZE + 1);
+		const lenBytes = new Uint8Array(lenBuf.bytes());
+
+		const readable = new ReadableStream<Uint8Array>({
+			start(c) {
+				c.enqueue(lenBytes);
+				c.close();
+			},
+		});
+
+		const reader = new ReceiveStream({ stream: readable });
+		const gr = new GroupReader(
+			background(),
+			reader,
+			new GroupMessage({ sequence: 1 }),
+		);
+
+		const err = await gr.readFrame(new Frame(new ArrayBuffer(0)));
+		assertInstanceOf(err, Error);
+		assertEquals(err.message.includes("exceeds maximum"), true);
 	});
 
 	await t.step(


### PR DESCRIPTION
## Summary

Security hardening surfaced while reviewing the receive path (#276). `GroupReader.readFrame` sizes its read buffer **straight from the peer's varint length prefix** with no upper bound:

```ts
const [len] = await readVarint(this.#reader);
const buf = new Uint8Array(len);   // len is attacker-controlled
```

So an untrusted peer can request a multi-gigabyte allocation with a single small packet — an out-of-memory denial-of-service. This is **pre-existing** (independent of #276; the optimized in-place path has the same exposure).

## Fix

Reject a frame whose length exceeds **`MAX_FRAME_SIZE` (50 MB)** *before* allocating, mirroring the Go implementation's `message.MaxMessageSize` guard (`moqt/frame.go:98`). 50 MB matches the reference impl, so the two interop consistently.

```ts
if (len > MAX_FRAME_SIZE) {
  return new Error(`moq: frame length ${len} exceeds maximum ${MAX_FRAME_SIZE}`);
}
```

## Scope / safety
- Returns an error (the existing `readFrame` contract) — no throw, no behavior change for valid frames.
- `MAX_FRAME_SIZE` is exported so consumers/tests can reference it.
- Added a test that feeds a length one byte over the limit and asserts the rejection (no payload needed — it's rejected before reading data).

## Test plan
- `deno test --allow-all` → 176 passed, 0 failed; `deno check`/`lint`/`fmt` clean.

> Note: this touches `readFrame`, which #276 also edits. Whichever merges first, the other needs a trivial rebase (the bound check sits just after the `readVarint`, above #276's in-place fast path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)