### PR TITLE
chore: update Go to 1.26.4

### DIFF
--- a/.github/workflows/benchmark-label.yml
+++ b/.github/workflows/benchmark-label.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.26.0"
+          go-version: "1.26.4"
           cache: true # reuse the Go build cache -> faster cold compile of base + PR test binaries
 
       - name: Install benchstat

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.26.0"
+          go-version: "1.26.4"
 
       - name: Test
         run: go test -v ./...
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.26.0"
+          go-version: "1.26.4"
 
       - name: Test with -race
         env:
@@ -95,7 +95,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.26.0"
+          go-version: "1.26.4"
 
       - name: Run integration benchmarks
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.26
+          go-version: 1.26.4
 
       - name: Lint
         uses: reviewdog/action-golangci-lint@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.26.4"
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v4

--- a/docs/moqt/go.mod
+++ b/docs/moqt/go.mod
@@ -1,5 +1,5 @@
 module github.com/qumo-dev/gomoqt/moqt
 
-go 1.26
+go 1.26.4
 
 require github.com/imfing/hextra v0.12.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qumo-dev/gomoqt
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/okdaichi/webtransport-go v0.10.2-okdaichi.1

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -1,5 +1,5 @@
 module github.com/qumo-dev/gomoqt/magefiles
 
-go 1.25.0
+go 1.26.4
 
 require github.com/magefile/mage v1.15.0


### PR DESCRIPTION
Bumps the Go toolchain from **1.26.0 → 1.26.4** (latest 1.26 patch).

## Changes
- `go.mod`, `magefiles/go.mod`, `docs/moqt/go.mod`: `go` directive → `1.26.4` (magefiles also moves up from `1.25.0` to standardize on one toolchain)
- CI `setup-go` pins → `1.26.4` (`go.yml` ×3, `benchmark-label.yml`, `lint.yml`, `pages.yml`)
- `lint.yml` `go_version: ^1.26` (golangci-lint-action range) left as-is

## Verification
`go build ./...` and `go vet ./...` pass on go1.26.4 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)