### PR TITLE
chore(moq-web): bump @qumo/moq to 0.16.1 for TS release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> **TS release — `@qumo/moq` v0.16.1 (JSR, 2026-06-30).** Patch bump of the TypeScript (`moq-web`) package only. The Go module (`moqt`) is unchanged and **not** re-released; the `moqt` entries below remain unreleased. This JSR release publishes every `moq-web` entry below (the `### Added`, `### Changed`, and `### Fixed (Security)` bullets) — notably `Session.closed`/`MOQCloseInfo`, the message-codec `MessageEncoder`/`MessageDecoder`, and the `GroupReader.readFrame` buffer-reuse + `MAX_FRAME_SIZE` OOM guard.
+
 ### Added
 
 - **moqt:** New benchmark coverage for previously-unbenched routing/path primitives: `BenchmarkPrefixSegments` (the `prefixSegments` sibling of `pathSegments` — rewritten in #253 but, unlike `pathSegments`, had no dedicated benchmark), `BenchmarkBroadcastPath_HasPrefix/GetSuffix/Extension/Equal`, and `BenchmarkVarintLen/StringLen/BytesLen/StringArrayLen` (the message pre-sizing helpers called by every Encode). All report 0 allocs/op except `prefixSegments`, which allocates one segment slice scaling with depth.

--- a/moq-web/deno.json
+++ b/moq-web/deno.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
 	"name": "@qumo/moq",
-	"version": "0.16.0",
+	"version": "0.16.1",
 	"exports": {
 		".": "./src/mod.ts",
 		"./msf": "./src/msf/mod.ts"


### PR DESCRIPTION
Bumps the TypeScript package (`@qumo/moq`) **0.16.0 → 0.16.1** ahead of a `deno publish` to JSR.

- `moq-web/deno.json`: `version` → `0.16.1`
- `CHANGELOG.md`: adds a release note under `[Unreleased]` clarifying this is a **TS-only** publish (the Go `moqt` module is unchanged and not re-released; `moqt` entries stay unreleased), and that this JSR release ships the `moq-web` entries below — `Session.closed`/`MOQCloseInfo`, the message-codec `MessageEncoder`/`MessageDecoder`, and the `GroupReader.readFrame` buffer-reuse + `MAX_FRAME_SIZE` OOM guard.

## Verification
- `deno publish --dry-run` → **Success** (no slow-type/export blockers).
- Semver: patch bump on a 0.x package; the new public API (`Session.closed`/`MOQCloseInfo`) is additive, no breaking changes.

After this merges, run `deno publish` from a clean checkout of main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)