### PR TITLE
fix(moqt): propagate Session close cancellation to Tracks and Groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **moqt:** `Session.CloseWithError` now makes teardown cancellation gomoqt-owned rather than dependent on the transport propagating connection-close into blocked stream reads. It cancels the session's own context (so `AcceptStream`/`OpenUniStream` calls return) and cascades `CancelRead`/`CancelWrite` onto every outstanding group stream before `wg.Wait()`. Both transports guarantee `CancelRead`/`CancelWrite` unblocks an in-flight `Read`/`Write` immediately, so a goroutine parked in `GroupReader.ReadFrame` (a consumer's `for frame := range gr.Frames(buf)`) or a publisher parked in a group `Write` exits deterministically on close. This is gomoqt-side hardening on top of the transport fix: qumo #205's *root* cause was `webtransport-go`'s `handleSessionGoneError` self-removal deadlock, fixed upstream in #267 and pulled in by the `webtransport-go` v0.11.0 bump in v0.16.1; this change ensures the teardown wait drains regardless of how (or whether) the transport surfaces the close to a blocked read.
+- **moqt:** `TrackReader.Close` and `CloseWithError` now cancel already-accepted (in-progress) group reads, not just queued ones. The `dequeued` field that was meant to track accepted groups for cancellation was never populated — `AcceptGroup` didn't add to it — so an accepted `GroupReader` was tracked nowhere and a consumer parked in its `ReadFrame` was not unblocked when the track was closed. Cancel now routes through the already-maintained `groupReaderManager` active-group set; the dead `dequeued` field is removed.
+
 ## [v0.16.1] - 2026-07-01
 
 > **Dual release.** `v0.16.1` ships both packages at the same version: the Go module (`moqt`, consumed via `go get github.com/qumo-dev/gomoqt@v0.16.1`) and the TypeScript package (`@qumo/moq` on JSR). The `moq-web` bullets below were published via the JSR release; the `moqt` and `deps` bullets ship via this Go tag — notably the `webtransport-go` → `v0.11.0-okdaichi.1` bump (which brings upstream #267, the transport-layer fix for the qumo #205 close-cancellation stall) and the accumulated `moqt` benchmark / dead-code / security work.

--- a/moqt/session.go
+++ b/moqt/session.go
@@ -25,6 +25,7 @@ const (
 // announcements for a single peer connection.
 type Session struct {
 	ctx    context.Context // Context for the session
+	cancel context.CancelFunc
 	config *Config
 
 	wg sync.WaitGroup // WaitGroup for session cleanup
@@ -77,8 +78,15 @@ func newSession(
 	}
 
 	connCtx := conn.Context()
+	// Derive an owned, independently-cancelable context from the connection's
+	// so Session.CloseWithError can cancel in-flight AcceptStream/OpenUniStream
+	// calls and signal handlers without waiting for connection-close to
+	// propagate through the transport (which is unreliable on some transports;
+	// see qumo #205).
+	ctx, cancel := context.WithCancel(connCtx)
 	sess := &Session{
-		ctx:             connCtx,
+		ctx:             ctx,
+		cancel:          cancel,
 		config:          config.Clone(),
 		conn:            conn,
 		mux:             mux,
@@ -181,6 +189,14 @@ func (s *Session) Stats() SessionStats {
 }
 
 // CloseWithError closes the session with an error code and message.
+//
+// It cascades cancellation to every Track and Group before waiting for in-flight
+// stream handlers to finish: each reader's outstanding group reads and each
+// writer's outstanding group writes are canceled (CancelRead/CancelWrite), which
+// the transport guarantees unblocks an in-flight Read/Write immediately. This
+// makes the teardown wait drain deterministically regardless of whether the
+// connection-close propagates into blocked stream reads on the underlying
+// transport (see qumo #205).
 func (s *Session) CloseWithError(code SessionErrorCode, msg string) error {
 	if s.terminating() {
 		return nil
@@ -196,6 +212,13 @@ func (s *Session) CloseWithError(code SessionErrorCode, msg string) error {
 		s.connManager = nil
 		defer connManager.removeConn(s.conn)
 	}
+
+	// Cancel the session context and cascade CancelRead/CancelWrite onto every
+	// in-flight group stream first, so parked stream-handler goroutines
+	// (processBiStream/processUniStream and any ServeTrack they invoked) unblock
+	// before we join them via wg.Wait below.
+	s.cancel()
+	s.cancelAllTracks()
 
 	err := s.conn.CloseWithError(transport.ConnErrorCode(code), msg)
 	if err != nil {
@@ -215,6 +238,32 @@ func (s *Session) CloseWithError(code SessionErrorCode, msg string) error {
 	close(s.probeTargetsCh)
 
 	return nil
+}
+
+// cancelAllTracks cancels every outstanding group read on each TrackReader and
+// every outstanding group write on each TrackWriter. It snapshots the track
+// maps under their locks and then cancels without holding them, so it cannot
+// deadlock with a handler that holds a track lock.
+func (s *Session) cancelAllTracks() {
+	s.trackReaderMapLocker.RLock()
+	readers := make([]*TrackReader, 0, len(s.trackReaders))
+	for _, r := range s.trackReaders {
+		readers = append(readers, r)
+	}
+	s.trackReaderMapLocker.RUnlock()
+	for _, r := range readers {
+		r.cancelGroupReads(SubscribeCanceledErrorCode)
+	}
+
+	s.trackWriterMapLocker.RLock()
+	writers := make([]*TrackWriter, 0, len(s.trackWriters))
+	for _, w := range s.trackWriters {
+		writers = append(writers, w)
+	}
+	s.trackWriterMapLocker.RUnlock()
+	for _, w := range writers {
+		w.cancelActiveGroups()
+	}
 }
 
 // Subscribe sends SUBSCRIBE and waits for SUBSCRIBE_OK.

--- a/moqt/session_test.go
+++ b/moqt/session_test.go
@@ -38,6 +38,54 @@ func newTestSessionWithConn(tb testing.TB, opts ...func(*FakeStreamConn)) (*Sess
 	return session, conn
 }
 
+// TestSession_CloseWithError_PropagatesToGroupReads is a regression test for
+// qumo #205: closing a Session with an in-flight group read must cascade
+// CancelRead onto the group stream so a consumer parked in GroupReader.ReadFrame
+// (e.g. `for frame := range gr.Frames(buf)`) unblocks immediately, instead of
+// relying on connection-close to propagate into the blocked read.
+func TestSession_CloseWithError_PropagatesToGroupReads(t *testing.T) {
+	conn := &FakeStreamConn{}
+	session := newTestSession(conn)
+
+	// A track reader with an accepted, in-progress group owned by this session.
+	receiver, _ := newTestTrackReader(t)
+	var canceled atomic.Bool
+	groupStream := blockingReceiveStream(&canceled)
+	receiver.enqueueGroup(GroupSequence(1), groupStream)
+	gr, err := receiver.AcceptGroup(context.Background())
+	require.NoError(t, err)
+	session.addTrackReader(SubscribeID(1), receiver)
+
+	// Park a consumer on the group read.
+	readDone := make(chan error, 1)
+	go func() {
+		readDone <- gr.ReadFrame(NewFrame(0))
+	}()
+
+	// CloseWithError must return (not hang) and must cancel the group read.
+	closeDone := make(chan struct{})
+	go func() {
+		_ = session.CloseWithError(NoError, "")
+		close(closeDone)
+	}()
+	select {
+	case <-closeDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("CloseWithError hung; group cancel did not propagate")
+	}
+
+	assert.True(t, canceled.Load(), "session close should cascade CancelRead to the group stream")
+	select {
+	case err := <-readDone:
+		assert.Error(t, err, "parked group read should unblock on session close")
+	case <-time.After(2 * time.Second):
+		t.Fatal("parked ReadFrame did not unblock after CloseWithError")
+	}
+
+	// The owned session context is canceled after close.
+	assert.NotNil(t, session.Context().Err(), "Session.Context() should be canceled after close")
+}
+
 type noStatsConn struct{}
 
 func (noStatsConn) AcceptStream(context.Context) (transport.Stream, error) { return nil, io.EOF }

--- a/moqt/track_reader.go
+++ b/moqt/track_reader.go
@@ -37,6 +37,37 @@ func (m *groupReaderManager) removeGroup(group *GroupReader) {
 	delete(m.activeGroups, group)
 }
 
+// cancelAll cancels every tracked (accepted) GroupReader's read and drops them
+// from the manager. It is the lever Session.CloseWithError uses to unblock a
+// consumer parked in GroupReader.ReadFrame on close: CancelRead makes the
+// stream's in-flight Read return a StreamError immediately (quic-go/webtransport
+// guarantee this), so frame.decode returns and the draining goroutine exits
+// without depending on connection-close propagation.
+func (m *groupReaderManager) cancelAll(code GroupErrorCode) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return
+	}
+	m.closed = true
+	groups := make([]*GroupReader, 0, len(m.activeGroups))
+	for g := range m.activeGroups {
+		groups = append(groups, g)
+	}
+	m.activeGroups = nil
+	m.mu.Unlock()
+
+	errCode := transport.StreamErrorCode(code)
+	for _, g := range groups {
+		// Cancel the read directly rather than via g.CancelRead so we control
+		// the code; g.CancelRead would also re-enter removeGroup (a no-op now).
+		g.stream.CancelRead(errCode)
+	}
+}
+
 func newTrackReader(path BroadcastPath, name TrackName, subscribeStream *sendSubscribeStream, onCloseFunc func()) *TrackReader {
 	track := &TrackReader{
 		BroadcastPath:       path,
@@ -47,7 +78,6 @@ func newTrackReader(path BroadcastPath, name TrackName, subscribeStream *sendSub
 			sequence GroupSequence
 			stream   transport.ReceiveStream
 		}, 0, 1<<3),
-		dequeued:     make(map[*GroupReader]struct{}),
 		groupManager: newGroupReaderManager(),
 		onCloseFunc:  onCloseFunc,
 		ctx:          context.WithValue(subscribeStream.stream.Context(), biStreamTypeCtxKey, message.StreamTypeSubscribe),
@@ -76,8 +106,6 @@ type TrackReader struct {
 	}
 	queuedCh chan struct{}
 	trackMu  sync.Mutex
-
-	dequeued map[*GroupReader]struct{}
 
 	groupManager *groupReaderManager
 	onCloseFunc  func()
@@ -174,29 +202,39 @@ func (r *TrackReader) Context() context.Context {
 	return r.ctx
 }
 
+// cancelGroupReads cancels every outstanding group read — both queued (not yet
+// accepted) and accepted (tracked by the groupManager) — so any goroutine parked
+// in GroupReader.ReadFrame unblocks immediately via the stream's StreamError.
+//
+// It does not touch the subscribe stream. Session.CloseWithError uses it during
+// teardown, where the connection is already gone and the goal is to unblock
+// in-flight reads rather than negotiate a graceful unsubscribe. Any group stream
+// enqueued concurrently after queueing is cleared self-cancels in enqueueGroup.
+func (r *TrackReader) cancelGroupReads(code GroupErrorCode) {
+	r.trackMu.Lock()
+	queued := r.queueing
+	r.queueing = nil
+	r.trackMu.Unlock()
+
+	errCode := transport.StreamErrorCode(code)
+	for _, entry := range queued {
+		entry.stream.CancelRead(errCode)
+	}
+
+	r.groupManager.cancelAll(code)
+}
+
 // Close cancels queued groups, closes the queued channel, and terminates
 // the subscription stream gracefully.
 func (r *TrackReader) Close() error {
+	r.cancelGroupReads(SubscribeCanceledErrorCode)
+
 	r.trackMu.Lock()
-	defer r.trackMu.Unlock()
-
-	// Cancel all pending groups first
-	errCode := transport.StreamErrorCode(SubscribeCanceledErrorCode)
-	for _, entry := range r.queueing {
-		entry.stream.CancelRead(errCode)
-	}
-	r.queueing = nil
-
-	// Cancel all dequeued groups
-	for stream := range r.dequeued {
-		stream.CancelRead(SubscribeCanceledErrorCode)
-	}
-	r.dequeued = nil
-
 	if r.queuedCh != nil {
 		close(r.queuedCh)
 		r.queuedCh = nil
 	}
+	r.trackMu.Unlock()
 
 	r.onCloseFunc()
 
@@ -205,26 +243,14 @@ func (r *TrackReader) Close() error {
 
 // CloseWithError cancels the subscription with the provided SubscribeErrorCode and terminates the subscription.
 func (r *TrackReader) CloseWithError(code SubscribeErrorCode) {
+	r.cancelGroupReads(SubscribeCanceledErrorCode)
+
 	r.trackMu.Lock()
-	defer r.trackMu.Unlock()
-
-	// Cancel all pending groups first
-	errCode := transport.StreamErrorCode(code)
-	for _, entry := range r.queueing {
-		entry.stream.CancelRead(errCode)
-	}
-	r.queueing = nil
-
-	// Cancel all dequeued groups
-	for stream := range r.dequeued {
-		stream.CancelRead(SubscribeCanceledErrorCode)
-	}
-	r.dequeued = nil
-
 	if r.queuedCh != nil {
 		close(r.queuedCh)
 		r.queuedCh = nil
 	}
+	r.trackMu.Unlock()
 
 	r.onCloseFunc()
 

--- a/moqt/track_reader_test.go
+++ b/moqt/track_reader_test.go
@@ -3,10 +3,12 @@ package moqt
 import (
 	"bytes"
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/qumo-dev/gomoqt/moqt/internal/message"
+	"github.com/qumo-dev/gomoqt/transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,6 +20,59 @@ func newTestTrackReader(tb testing.TB) (*TrackReader, *FakeQUICStream) {
 	substr := newTestSendSubscribeStreamFromStream(mockStream, &SubscribeConfig{})
 	receiver := newTrackReader("/test", "video", substr, func() {})
 	return receiver, mockStream
+}
+
+// blockingReceiveStream is a FakeQUICReceiveStream whose Read blocks until
+// CancelRead is invoked, then returns a *transport.StreamError — modeling the
+// quic-go/webtransport guarantee that CancelRead unblocks an in-flight Read.
+func blockingReceiveStream(canceled *atomic.Bool) *FakeQUICReceiveStream {
+	release := make(chan struct{})
+	return &FakeQUICReceiveStream{
+		ReadFunc: func(p []byte) (int, error) {
+			<-release
+			return 0, &transport.StreamError{ErrorCode: transport.StreamErrorCode(SubscribeCanceledErrorCode)}
+		},
+		CancelReadFunc: func(code transport.StreamErrorCode) {
+			canceled.Store(true)
+			select {
+			case <-release:
+			default:
+				close(release)
+			}
+		},
+	}
+}
+
+// TestTrackReader_Close_CancelsAcceptedGroup is a regression test for the dead
+// `dequeued` tracking: an already-accepted GroupReader was tracked nowhere, so
+// Close could not cancel it and a consumer parked in ReadFrame blocked forever.
+// It must now be canceled via the groupManager.
+func TestTrackReader_Close_CancelsAcceptedGroup(t *testing.T) {
+	receiver, _ := newTestTrackReader(t)
+
+	var canceled atomic.Bool
+	groupStream := blockingReceiveStream(&canceled)
+
+	receiver.enqueueGroup(GroupSequence(1), groupStream)
+
+	gr, err := receiver.AcceptGroup(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, gr)
+
+	readDone := make(chan error, 1)
+	go func() {
+		readDone <- gr.ReadFrame(NewFrame(0))
+	}()
+
+	require.NoError(t, receiver.Close())
+
+	assert.True(t, canceled.Load(), "accepted group stream should be canceled on Close")
+	select {
+	case err := <-readDone:
+		assert.Error(t, err, "parked ReadFrame should unblock after Close")
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReadFrame did not unblock after Close (deadlock regression)")
+	}
 }
 
 func TestNewTrackReader(t *testing.T) {
@@ -32,7 +87,7 @@ func TestNewTrackReader(t *testing.T) {
 	assert.Equal(t, PublishInfo{}, substr.ReadInfo(), "sendSubscribeStream should return the Info passed at construction")
 	assert.NotNil(t, receiver.queueing, "queue should be initialized")
 	assert.NotNil(t, receiver.queuedCh, "queuedCh should be initialized")
-	assert.NotNil(t, receiver.dequeued, "dequeued should be initialized")
+	assert.NotNil(t, receiver.groupManager, "groupManager should be initialized")
 }
 
 func TestTrackReader_AcceptGroup(t *testing.T) {

--- a/moqt/track_writer.go
+++ b/moqt/track_writer.go
@@ -103,6 +103,34 @@ type TrackWriter struct {
 	ctx context.Context
 }
 
+// cancelActiveGroups cancels every active group write without touching the
+// subscribe stream. Session.CloseWithError uses it during teardown to unblock a
+// publisher parked in a group Write (e.g. a ServeTrack handler), mirroring
+// TrackReader.cancelGroupReads on the receive side. It is safe to call
+// concurrently with OpenGroup/Close, which also nil out groupManager under w.mu.
+func (w *TrackWriter) cancelActiveGroups() {
+	w.mu.Lock()
+	gm := w.groupManager
+	w.groupManager = nil
+	w.mu.Unlock()
+	if gm == nil {
+		return
+	}
+
+	gm.mu.Lock()
+	groups := make([]*GroupWriter, 0, len(gm.activeGroups))
+	for g := range gm.activeGroups {
+		groups = append(groups, g)
+	}
+	gm.closed = true
+	gm.activeGroups = nil
+	gm.mu.Unlock()
+
+	for _, g := range groups {
+		g.CancelWrite(PublishAbortedErrorCode)
+	}
+}
+
 // Close stops publishing and cancels active groups.
 func (w *TrackWriter) Close() error {
 	// Take the write lock to ensure Close is exclusive with OpenGroup calls.


### PR DESCRIPTION
## What

gomoqt-side teardown cancellation hardening on top of the `webtransport-go` v0.11.0 bump (v0.16.1): `Session.CloseWithError` now makes session/track/group cancellation **gomoqt-owned** instead of dependent on the transport propagating connection-close into blocked stream reads. Fresh PR for the work that was in #284, rebased onto current main (#286 / v0.16.1).

## Why

qumo #205's *root* cause was upstream `webtransport-go`'s `handleSessionGoneError` self-removal deadlock — the stream removed itself from the close-notification map (`s.onClose()`) *before* blocking on `<-s.closed`, so `streamsMap.CloseSession` could never reach it. Fixed upstream in **#267** (the `onClose`-after-`handleSessionGoneError` reorder) and pulled in by the `webtransport-go` v0.11.0 bump in v0.16.1.

This PR is the complementary gomoqt-side change so the teardown wait drains **regardless of how (or whether) the transport surfaces the close** to a blocked read — i.e. it doesn't rely on transport-layer propagation at all.

## How

- `Session.CloseWithError` cancels the session's own context (so `AcceptStream`/`OpenUniStream` return) and **cascades `CancelRead`/`CancelWrite` onto every outstanding group stream before `wg.Wait()`**. Both transports guarantee `CancelRead`/`CancelWrite` unblocks an in-flight `Read`/`Write` immediately, so parked consumers (`for frame := range gr.Frames(buf)`) and publishers (a group `Write` inside `ServeTrack`) exit deterministically.
- The session context is now derived (`context.WithCancel(conn.Context())`) so it cancels on explicit close without waiting for the transport.
- `cancelAllTracks` / `TrackReader.cancelGroupReads` / `TrackWriter.cancelActiveGroups` route through the already-maintained `groupReaderManager` / `groupWriterManager` active-group sets.
- **Fixes `TrackReader.dequeued`**: the field meant to track accepted groups for cancellation was never populated (`AcceptGroup` didn't add to it), so an accepted `GroupReader` was tracked nowhere and a consumer parked in its `ReadFrame` wasn't unblocked on track close. The dead field is removed; cancel now reaches accepted groups via the manager.

## Verification

- Regression tests: `TestSession_CloseWithError_PropagatesToGroupReads` (parks a reader in `ReadFrame`; asserts `CloseWithError` returns within a deadline, the group stream is `CancelRead`'d, the read unblocks, and `Session.Context()` is canceled) and `TestTrackReader_Close_CancelsAcceptedGroup` (regression for the dead `dequeued`).
- `go test ./...` ✅ ; `go vet ./...` ✅ ; gofmt clean (modulo CRLF on the Windows checkout).
- Built and tested against `webtransport-go v0.11.0-okdaichi.1` (rebased onto current main).
- `-race` not runnable locally (no `gcc` on this Windows host); CI's race job covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
