### PR TITLE
chore(msf): use builtin new(true/false) in catalog benchmark

### DIFF
--- a/msf/catalog_benchmark_test.go
+++ b/msf/catalog_benchmark_test.go
@@ -2,8 +2,6 @@ package msf
 
 import "testing"
 
-func boolPtrBench(b bool) *bool { return &b }
-
 // BenchmarkCatalog_Validate measures the happy-path (no errors) cost of
 // Catalog.Validate, where per-track fmt.Sprintf prefix formatting is paid on
 // every iteration regardless of whether problems exist.
@@ -12,9 +10,9 @@ func BenchmarkCatalog_Validate(b *testing.B) {
 		Version:          1,
 		DefaultNamespace: "live/demo",
 		Tracks: []Track{
-			{Name: "video", Packaging: PackagingLOC, IsLive: boolPtrBench(true)},
-			{Name: "audio", Packaging: PackagingLOC, IsLive: boolPtrBench(true)},
-			{Name: "text", Packaging: PackagingLOC, IsLive: boolPtrBench(false)},
+			{Name: "video", Packaging: PackagingLOC, IsLive: new(true)},
+			{Name: "audio", Packaging: PackagingLOC, IsLive: new(true)},
+			{Name: "text", Packaging: PackagingLOC, IsLive: new(false)},
 		},
 	}
 	b.ReportAllocs()
@@ -29,8 +27,8 @@ func BenchmarkCatalog_Validate(b *testing.B) {
 func BenchmarkCatalogDelta_Validate(b *testing.B) {
 	delta := CatalogDelta{
 		AddTracks: []Track{
-			{Name: "video", Packaging: PackagingLOC, IsLive: boolPtrBench(true)},
-			{Name: "audio", Packaging: PackagingLOC, IsLive: boolPtrBench(false)},
+			{Name: "video", Packaging: PackagingLOC, IsLive: new(true)},
+			{Name: "audio", Packaging: PackagingLOC, IsLive: new(false)},
 		},
 		RemoveTracks: []TrackRef{{Name: "old"}},
 	}


### PR DESCRIPTION
Follow-up to #267. The benchmark I added used a local `boolPtrBench` helper, but the `msf` package already uses the go1.26 builtin `new(true)`/`new(false)` throughout its tests. Drop the helper for consistency.

No behavior change — verified the benchmark still compiles and reports the same numbers (~180 ns/op `Catalog_Validate`, ~31 ns/op `CatalogDelta_Validate`, 0 allocs/op both).

`no-changelog` — test-only cleanup.