### PR TITLE
🧪 [testing improvement] Add table-driven tests for GroupWriter CancelWrite

### DIFF
--- a/moqt/group_writer_test.go
+++ b/moqt/group_writer_test.go
@@ -224,12 +224,48 @@ func TestGroupWriter_Context(t *testing.T) {
 }
 
 func TestGroupWriter_CancelWrite(t *testing.T) {
-	mockStream := &FakeQUICSendStream{}
+	tests := map[string]struct {
+		hasManager bool
+		errorCode  GroupErrorCode
+	}{
+		"with group manager": {
+			hasManager: true,
+			errorCode:  GroupErrorCode(123),
+		},
+		"without group manager": {
+			hasManager: false,
+			errorCode:  GroupErrorCode(456),
+		},
+	}
 
-	groupManager := newGroupWriterManager()
-	sgs := newGroupWriter(mockStream, GroupSequence(1), groupManager)
-	groupManager.addGroup(sgs)
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var capturedCode transport.StreamErrorCode
+			mockStream := &FakeQUICSendStream{
+				CancelWriteFunc: func(code transport.StreamErrorCode) {
+					capturedCode = code
+				},
+			}
 
-	sgs.CancelWrite(1)
-	assert.Equal(t, 0, groupManager.countGroups())
+			var groupManager *groupWriterManager
+			if tt.hasManager {
+				groupManager = newGroupWriterManager()
+			}
+
+			sgs := newGroupWriter(mockStream, GroupSequence(1), groupManager)
+
+			if tt.hasManager {
+				// newGroupWriter adds to manager if not nil, but let's double check it's there
+				assert.Equal(t, 1, groupManager.countGroups())
+			}
+
+			sgs.CancelWrite(tt.errorCode)
+
+			assert.Equal(t, transport.StreamErrorCode(tt.errorCode), capturedCode)
+
+			if tt.hasManager {
+				assert.Equal(t, 0, groupManager.countGroups())
+			}
+		})
+	}
 }


### PR DESCRIPTION
🎯 **What:** The `CancelWrite` method on `GroupWriter` only had a basic test that checked group manager removal but didn't verify the error code or handle scenarios where the manager is `nil`.

📊 **Coverage:** The new table-driven test covers two specific scenarios:
1. "with group manager": Verifies that `CancelWrite` forwards the correct `transport.StreamErrorCode` to the underlying stream and successfully removes the group from the manager.
2. "without group manager": Verifies that `CancelWrite` handles a `nil` `groupManager` safely without panicking, while still forwarding the correct error code to the stream.

✨ **Result:** Improved test reliability and comprehensive branch coverage for `GroupWriter.CancelWrite`. The test guarantees that both stream cancellation and manager updates occur as expected in different initialization states.

---
*PR created automatically by Jules for task [11705297096029184847](https://jules.google.com/task/11705297096029184847) started by @okdaichi*