### PR TITLE
🧪 Add test for Broadcast.Remove

### DIFF
--- a/moqt/broadcast_test.go
+++ b/moqt/broadcast_test.go
@@ -258,6 +258,74 @@ func TestBroadcastClose_MultipleHandlers(t *testing.T) {
 }
 
 
+func TestBroadcast_Remove(t *testing.T) {
+	dummyHandler := TrackHandlerFunc(func(*TrackWriter) {})
+
+	tests := []struct {
+		name      string
+		broadcast *Broadcast
+		setup     func(*Broadcast)
+		trackName TrackName
+		want      bool
+	}{
+		{
+			name:      "nil broadcast",
+			broadcast: nil,
+			setup:     func(*Broadcast) {},
+			trackName: "video",
+			want:      false,
+		},
+		{
+			name:      "empty track name",
+			broadcast: NewBroadcast(),
+			setup:     func(*Broadcast) {},
+			trackName: "",
+			want:      false,
+		},
+		{
+			name:      "track not found",
+			broadcast: NewBroadcast(),
+			setup:     func(*Broadcast) {},
+			trackName: "audio",
+			want:      false,
+		},
+		{
+			name:      "track removed successfully",
+			broadcast: NewBroadcast(),
+			setup: func(b *Broadcast) {
+				_ = b.Register("video", dummyHandler)
+			},
+			trackName: "video",
+			want:      true,
+		},
+		{
+			name:      "multiple removes of same track",
+			broadcast: NewBroadcast(),
+			setup: func(b *Broadcast) {
+				_ = b.Register("video", dummyHandler)
+				b.Remove("video")
+			},
+			trackName: "video",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup(tt.broadcast)
+			}
+			got := tt.broadcast.Remove(tt.trackName)
+			assert.Equal(t, tt.want, got)
+
+			if tt.broadcast != nil && got {
+				// Verify it's actually removed
+				assert.Equal(t, reflect.ValueOf(NotFoundTrackHandler).Pointer(), reflect.ValueOf(tt.broadcast.Handler(tt.trackName)).Pointer())
+			}
+		})
+	}
+}
+
 func TestBroadcast_Register(t *testing.T) {
 	dummyHandler := TrackHandlerFunc(func(*TrackWriter) {})
 


### PR DESCRIPTION
🎯 **What:** Add a table-driven test `TestBroadcast_Remove` for `Broadcast.Remove`.
📊 **Coverage:** Cover nil broadcast, empty track name, track not found, track successfully removed, and multiple removes of the same track.
✨ **Result:** Improved test coverage and reliability for `Broadcast.Remove`.

---
*PR created automatically by Jules for task [2774067272976806058](https://jules.google.com/task/2774067272976806058) started by @okdaichi*