### PR TITLE
🧪 Add test for NewBroadcast

### DIFF
--- a/moqt/broadcast_test.go
+++ b/moqt/broadcast_test.go
@@ -326,3 +326,10 @@ func TestBroadcast_Register(t *testing.T) {
 		})
 	}
 }
+
+func TestNewBroadcast(t *testing.T) {
+	b := NewBroadcast()
+	assert.NotNil(t, b)
+	assert.NotNil(t, b.trackHandlers)
+	assert.Empty(t, b.trackHandlers)
+}


### PR DESCRIPTION
🎯 **What:** Added a unit test for the `NewBroadcast` constructor function in `moqt/broadcast.go`.
📊 **Coverage:** Tests that the constructor returns a valid `Broadcast` object and correctly initializes the internal `trackHandlers` map to an empty state.
✨ **Result:** Increases confidence in the core initialization logic of the broadcast package and improves overall test coverage.

---
*PR created automatically by Jules for task [14755248647776766602](https://jules.google.com/task/14755248647776766602) started by @okdaichi*