### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix remote DoS via panic on oversized untrusted network input

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,7 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when pre-allocating slices for variable-length arrays based on an untrusted varint count prefix (e.g., `make([]string, 0, count)` or `make([]uint64, count)`). An attacker can specify a huge count for an array with very few bytes, causing the server to allocate massive amounts of memory and crash before parsing the next item.
 **Learning:** Even if the overall message size is constrained or the buffer is small, `make` pre-allocations using unvalidated array lengths can cause OOM DoS.
 **Prevention:** Compute a clamped capacity based on `len(b)` and the maximum possible count before allocating, and allocate `make([]T, 0, allocCap)`. Let the subsequent decode loop naturally fail with an EOF when the buffer is exhausted.
+## 2024-07-04 - Fix remote DoS via panic on oversized untrusted network input
+**Vulnerability:** The application panics when parsing network lengths that exceed math.MaxInt.
+**Learning:** Using `panic()` for malformed or oversized untrusted network input introduces a remote Denial of Service (DoS) vulnerability.
+**Prevention:** Always return proper errors (e.g., `ErrMessageTooLarge`) instead to fail securely.

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -79,7 +79,7 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 	}
 	b = b[n:]
 	if num > math.MaxInt {
-		panic("byte slice too large")
+		return nil, 0, ErrMessageTooLarge
 	}
 
 	if uint64(len(b)) < num {
@@ -104,7 +104,7 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 	}
 
 	if count > math.MaxInt {
-		panic("string array too large")
+		return nil, 0, ErrMessageTooLarge
 	}
 
 	b = b[total:]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application panics when parsing network lengths that exceed math.MaxInt.
🎯 Impact: Remote attackers can cause a Denial of Service by sending crafted payloads.
🔧 Fix: Replaced panics with safe error returns.
✅ Verification: Verified locally via test suite and inspection.

---
*PR created automatically by Jules for task [2783751372877183018](https://jules.google.com/task/2783751372877183018) started by @okdaichi*