### PR TITLE
chore(moq-web): bump dependencies (golikejs 0.10, zod v4)

### DIFF
--- a/moq-web/deno.json
+++ b/moq-web/deno.json
@@ -23,12 +23,12 @@
 		"verbatimModuleSyntax": false
 	},
 	"imports": {
-		"@okdaichi/golikejs": "jsr:@okdaichi/golikejs@0.9.0",
-		"@std/assert": "jsr:@std/assert@^1.0.16",
-		"@std/cli": "jsr:@std/cli@^1.0.24",
-		"@std/path": "jsr:@std/path@^1.1.3",
-		"@std/testing": "jsr:@std/testing@^1.0.16",
-		"zod": "npm:zod@^3.24.2"
+		"@okdaichi/golikejs": "jsr:@okdaichi/golikejs@0.10.0",
+		"@std/assert": "jsr:@std/assert@^1.0.19",
+		"@std/cli": "jsr:@std/cli@^1.0.32",
+		"@std/path": "jsr:@std/path@^1.1.6",
+		"@std/testing": "jsr:@std/testing@^1.0.19",
+		"zod": "npm:zod@^4.4.3"
 	},
 	"tasks": {
 		"test": "deno test --allow-all",

--- a/moq-web/deno.lock
+++ b/moq-web/deno.lock
@@ -1,72 +1,71 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@okdaichi/golikejs@0.9.0": "0.9.0",
-    "jsr:@std/assert@^1.0.15": "1.0.16",
-    "jsr:@std/assert@^1.0.16": "1.0.16",
-    "jsr:@std/async@^1.0.15": "1.0.15",
-    "jsr:@std/cli@^1.0.24": "1.0.24",
-    "jsr:@std/data-structures@^1.0.9": "1.0.9",
-    "jsr:@std/fs@^1.0.19": "1.0.19",
-    "jsr:@std/internal@^1.0.12": "1.0.12",
-    "jsr:@std/path@^1.1.1": "1.1.3",
-    "jsr:@std/path@^1.1.2": "1.1.3",
-    "jsr:@std/path@^1.1.3": "1.1.3",
-    "jsr:@std/testing@^1.0.16": "1.0.16",
-    "npm:zod@^3.24.2": "3.25.76"
+    "jsr:@okdaichi/golikejs@0.10.0": "0.10.0",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/cli@^1.0.32": "1.0.32",
+    "jsr:@std/data-structures@^1.1.0": "1.1.0",
+    "jsr:@std/fmt@^1.0.10": "1.0.10",
+    "jsr:@std/fs@^1.0.24": "1.0.24",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@^1.1.5": "1.1.6",
+    "jsr:@std/path@^1.1.6": "1.1.6",
+    "jsr:@std/testing@^1.0.19": "1.0.19",
+    "npm:zod@^4.4.3": "4.4.3"
   },
   "jsr": {
-    "@okdaichi/golikejs@0.9.0": {
-      "integrity": "9e99fab2a4a96c6b04143b37ecd5d18e9783fce4b5cdb716a3cabdb44fc5c00e"
+    "@okdaichi/golikejs@0.10.0": {
+      "integrity": "761440b50ff8bc21df1061e3361c6542208e0f4f434da4b1494a9b1bb5ab73d3"
     },
-    "@std/assert@1.0.16": {
-      "integrity": "6a7272ed1eaa77defe76e5ff63ca705d9c495077e2d5fd0126d2b53fc5bd6532",
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.12"
       ]
     },
-    "@std/async@1.0.15": {
-      "integrity": "55d1d9d04f99403fe5730ab16bdcc3c47f658a6bf054cafb38a50f046238116e"
-    },
-    "@std/cli@1.0.24": {
-      "integrity": "b655a5beb26aa94f98add6bc8889f5fb9bc3ee2cc3fc954e151201f4c4200a5e",
+    "@std/cli@1.0.32": {
+      "integrity": "188b3a100d6202d64e3f5bd3d799c7fa4f6d77f92cc65eb7f641c1fa0aa92a66",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/fmt",
+        "jsr:@std/internal@^1.0.14"
       ]
     },
-    "@std/data-structures@1.0.9": {
-      "integrity": "033d6e17e64bf1f84a614e647c1b015fa2576ae3312305821e1a4cb20674bb4d"
+    "@std/data-structures@1.1.0": {
+      "integrity": "c35ae4ad5d8e41a38573c2fe3e19b18ea2505f63cfea201edcb8720aca1f7f58"
     },
-    "@std/fs@1.0.19": {
-      "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06",
+    "@std/fmt@1.0.10": {
+      "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
+    },
+    "@std/fs@1.0.24": {
+      "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
       "dependencies": [
-        "jsr:@std/path@^1.1.1"
+        "jsr:@std/path@^1.1.5"
       ]
     },
-    "@std/internal@1.0.12": {
-      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
     },
-    "@std/path@1.1.3": {
-      "integrity": "b015962d82a5e6daea980c32b82d2c40142149639968549c649031a230b1afb3",
+    "@std/path@1.1.6": {
+      "integrity": "c68485c2a4dfbb5ae3cc74fae4e8c4e5d874cf8a8ed12927917235c758b46cbe",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.14"
       ]
     },
-    "@std/testing@1.0.16": {
-      "integrity": "a917ffdeb5924c9be436dc78bc32e511760e14d3a96e49c607fc5ecca86d0092",
+    "@std/testing@1.0.19": {
+      "integrity": "f4236172365b216728dc3cc8b5e80a9f4c33083d1e4ede7613d5b25b4014898e",
       "dependencies": [
-        "jsr:@std/assert@^1.0.15",
-        "jsr:@std/async",
+        "jsr:@std/assert",
         "jsr:@std/data-structures",
         "jsr:@std/fs",
-        "jsr:@std/internal",
-        "jsr:@std/path@^1.1.2"
+        "jsr:@std/internal@^1.0.14",
+        "jsr:@std/path@^1.1.5"
       ]
     }
   },
   "npm": {
-    "zod@3.25.76": {
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
+    "zod@4.4.3": {
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
     }
   },
   "remote": {
@@ -111,12 +110,12 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@okdaichi/golikejs@0.9.0",
-      "jsr:@std/assert@^1.0.16",
-      "jsr:@std/cli@^1.0.24",
-      "jsr:@std/path@^1.1.3",
-      "jsr:@std/testing@^1.0.16",
-      "npm:zod@^3.24.2"
+      "jsr:@okdaichi/golikejs@0.10.0",
+      "jsr:@std/assert@^1.0.19",
+      "jsr:@std/cli@^1.0.32",
+      "jsr:@std/path@^1.1.6",
+      "jsr:@std/testing@^1.0.19",
+      "npm:zod@^4.4.3"
     ]
   }
 }


### PR DESCRIPTION
Bumps every `moq-web` dependency to latest, including the `zod` v3 → v4 major.

## Changes (`moq-web/deno.json` + regenerated `deno.lock`)

| Package | Before | After |
|---|---|---|
| `@okdaichi/golikejs` | 0.9.0 | **0.10.0** |
| `@std/assert` | ^1.0.16 | ^1.0.19 |
| `@std/cli` | ^1.0.24 | ^1.0.32 |
| `@std/path` | ^1.1.3 | ^1.1.6 |
| `@std/testing` | ^1.0.16 | ^1.0.19 |
| `zod` | ^3.24.2 | **^4.4.3** (major) |

## zod v3 → v4

`zod` is the only major bump. The zod API surface this repo uses — `z.object/string/number/boolean/array/unknown/literal/tuple`, `.optional()`, `.catchall(z.unknown())`, `safeParse()`, and `error.issues[0].path/.message` — is unchanged in v4, so **no source changes were required**. The most v4-sensitive code path (`.catchall(z.unknown())` + the `extraFields` round-trip in the MSF catalog/timeline parsers) is covered by the `src/msf/` tests, including `parseEventTimelineRecord preserves extraFields`.

## Go module — no changes

All direct Go deps are already current: `webtransport-go v0.11.0-okdaichi.1` (latest fork tag), `quic-go v0.60.0`, `testify v1.11.1`. Only transitive `golang.org/x/*` packages have newer releases; intentionally left untouched.

## Verification

- `deno check` clean across `src/**` and `cli/**`
- `deno test --allow-all` → **177 passed / 0 failed**
- `deno test src/msf/` → **78 passed / 0 failed**
- `deno outdated` → only the (now-intentional) zod entry remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)
