### PR TITLE
⚡ [performance improvement description]

### DIFF
--- a/moqt/internal/message/message.go
+++ b/moqt/internal/message/message.go
@@ -31,7 +31,17 @@ func BytesLen(b []byte) int {
 func StringArrayLen(arr []string) int {
 	total := VarintLen(uint64(len(arr)))
 	for _, s := range arr {
-		total += StringLen(s)
+		l := len(s)
+		total += l
+		if uint64(l) <= maxVarInt1 {
+			total += 1
+		} else if uint64(l) <= maxVarInt2 {
+			total += 2
+		} else if uint64(l) <= maxVarInt4 {
+			total += 4
+		} else {
+			total += 8
+		}
 	}
 	return total
 }


### PR DESCRIPTION
💡 **What:**
Inlined the variable integer size calculation for strings inside `StringArrayLen`.

🎯 **Why:**
Previously, `StringArrayLen` iterated over the input array and called `StringLen` for each string. `StringLen` subsequently called `VarintLen(uint64(len(s))) + len(s)`. This extra level of indirection meant calculating `len(s)` multiple times, paying for function call overhead on every iteration, and processing an unnecessary bounds check/panic since Go string lengths can't exceed maxInt (which fits in 62-bits anyway). Inlining the simple addition logic avoids these overheads entirely.

📊 **Measured Improvement:**
Running `go test -bench=BenchmarkStringArrayLen` against the `moqt/internal/message` package shows roughly a 50% performance improvement on multi-element arrays.

Baseline:
`BenchmarkStringArrayLen/8-short-4       	40776520	        30.29 ns/op`
`BenchmarkStringArrayLen/8-long-4        	41070812	        30.32 ns/op`

After Optimization:
`BenchmarkStringArrayLen/8-short-4       	88233139	        13.88 ns/op`
`BenchmarkStringArrayLen/8-long-4        	89348949	        13.42 ns/op`

Both variants demonstrate speedups of approximately 55%.

---
*PR created automatically by Jules for task [5128769744577948900](https://jules.google.com/task/5128769744577948900) started by @okdaichi*