### PR TITLE
🔒 Fix DoS vulnerability in WriteVarint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,7 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when pre-allocating slices for variable-length arrays based on an untrusted varint count prefix (e.g., `make([]string, 0, count)` or `make([]uint64, count)`). An attacker can specify a huge count for an array with very few bytes, causing the server to allocate massive amounts of memory and crash before parsing the next item.
 **Learning:** Even if the overall message size is constrained or the buffer is small, `make` pre-allocations using unvalidated array lengths can cause OOM DoS.
 **Prevention:** Compute a clamped capacity based on `len(b)` and the maximum possible count before allocating, and allocate `make([]T, 0, allocCap)`. Let the subsequent decode loop naturally fail with an EOF when the buffer is exhausted.
+## 2025-02-27 - 🛡️ Sentinel: [HIGH] Fix DoS vulnerability in WriteVarint via Panic
+**Vulnerability:** Untrusted network input triggering a `panic` in varint parsing or encoding (e.g., values exceeding 62-bits) causes application crashes, leading to a remote Denial of Service (DoS).
+**Learning:** Returning a propagated error instead of using `panic` on unexpected values avoids dropping the process entirely. While `panic()` is useful for fatal programmer errors, untrusted input must be handled cleanly.
+**Prevention:** Always parse varints safely and ensure encoding functions return `(n, err)` rather than panicking on out-of-bounds numbers.

--- a/fix_ignored_err.py
+++ b/fix_ignored_err.py
@@ -1,0 +1,20 @@
+import os
+import re
+
+def process_file(filepath):
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    original = content
+
+    if filepath.endswith('moqt/frame.go'):
+        content = content.replace(
+            'header, _, _ := message.WriteMessageLength(f.header[:0], l)',
+            'header, _, err := message.WriteMessageLength(f.header[:0], l)\n\tif err != nil {\n\t\treturn err\n\t}'
+        )
+
+    if original != content:
+        with open(filepath, 'w') as f:
+            f.write(content)
+
+process_file('moqt/frame.go')

--- a/moqt/broadcast_test.go
+++ b/moqt/broadcast_test.go
@@ -29,7 +29,6 @@ func TestBroadcastRegisterAndServeTrack(t *testing.T) {
 	}
 }
 
-
 func TestBroadcastRemoveClosesActiveTracks(t *testing.T) {
 	broadcast := NewBroadcast()
 
@@ -257,16 +256,15 @@ func TestBroadcastClose_MultipleHandlers(t *testing.T) {
 	assert.Equal(t, reflect.ValueOf(NotFoundTrackHandler).Pointer(), reflect.ValueOf(broadcast.Handler("audio")).Pointer())
 }
 
-
 func TestBroadcast_Register(t *testing.T) {
 	dummyHandler := TrackHandlerFunc(func(*TrackWriter) {})
 
 	tests := []struct {
-		name         string
-		broadcast    *Broadcast
-		trackName    TrackName
-		handler      TrackHandler
-		wantErr      string
+		name      string
+		broadcast *Broadcast
+		trackName TrackName
+		handler   TrackHandler
+		wantErr   string
 	}{
 		{
 			name:      "valid registration",

--- a/moqt/frame.go
+++ b/moqt/frame.go
@@ -70,11 +70,14 @@ func (f *Frame) Cap() int {
 // The length is encoded into the header buffer to minimize allocations.
 func (f *Frame) encode(w io.Writer) error {
 	l := uint64(len(f.body))
-	header, _ := message.WriteMessageLength(f.header[:0], l)
+	header, _, err := message.WriteMessageLength(f.header[:0], l)
+	if err != nil {
+		return err
+	}
 	start := 8 - len(header)
 	copy(f.buf[start:], header)
 	end := 8 + len(f.body)
-	_, err := w.Write(f.buf[start:end])
+	_, err = w.Write(f.buf[start:end])
 	return err
 }
 

--- a/moqt/frame_test.go
+++ b/moqt/frame_test.go
@@ -293,7 +293,7 @@ func TestFrame_Encode(t *testing.T) {
 			require.NoError(t, frame.encode(&buf))
 
 			// Build expected bytes: varint(length) followed by payload
-			expectedHeader, _ := message.WriteMessageLength(nil, uint64(len(tt.payload)))
+			expectedHeader, _, _ := message.WriteMessageLength(nil, uint64(len(tt.payload)))
 			expected := append(expectedHeader, tt.payload...)
 
 			got := buf.Bytes()
@@ -310,7 +310,7 @@ func TestFrame_Encode(t *testing.T) {
 func TestFrame_decode_RejectsOversizedLength(t *testing.T) {
 	// Largest value expressible in a QUIC varint (uint62 max), encoded as the
 	// payload length prefix. No payload bytes follow.
-	lengthPrefix, _ := message.WriteMessageLength(nil, 1<<62-1)
+	lengthPrefix, _, _ := message.WriteMessageLength(nil, 1<<62-1)
 
 	f := NewFrame(0)
 	err := f.decode(bytes.NewReader(lengthPrefix))

--- a/moqt/internal/message/announce.go
+++ b/moqt/internal/message/announce.go
@@ -35,19 +35,35 @@ func (am AnnounceMessage) Len() int {
 }
 
 func (am AnnounceMessage) Encode(w io.Writer) error {
+	var err error
 	msgLen := am.Len()
 
 	b := make([]byte, 0, msgLen+VarintLen(uint64(msgLen)))
 
-	b, _ = WriteMessageLength(b, uint64(msgLen))
-	b, _ = WriteVarint(b, uint64(am.AnnounceStatus))
-	b, _ = WriteString(b, am.BroadcastPathSuffix)
-	b, _ = WriteVarint(b, uint64(len(am.HopIDs)))
+	b, _, err = WriteMessageLength(b, uint64(msgLen))
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, uint64(am.AnnounceStatus))
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteString(b, am.BroadcastPathSuffix)
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, uint64(len(am.HopIDs)))
+	if err != nil {
+		return err
+	}
 	for _, id := range am.HopIDs {
-		b, _ = WriteVarint(b, id)
+		b, _, err = WriteVarint(b, id)
+		if err != nil {
+			return err
+		}
 	}
 
-	_, err := w.Write(b)
+	_, err = w.Write(b)
 
 	return err
 }

--- a/moqt/internal/message/announce_interest.go
+++ b/moqt/internal/message/announce_interest.go
@@ -21,14 +21,24 @@ func (aim AnnounceInterestMessage) Len() int {
 }
 
 func (aim AnnounceInterestMessage) Encode(w io.Writer) error {
+	var err error
 	msgLen := aim.Len()
 	b := make([]byte, 0, msgLen+VarintLen(uint64(msgLen)))
 
-	b, _ = WriteMessageLength(b, uint64(msgLen))
-	b, _ = WriteString(b, aim.BroadcastPathPrefix)
-	b, _ = WriteVarint(b, aim.ExcludeHop)
+	b, _, err = WriteMessageLength(b, uint64(msgLen))
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteString(b, aim.BroadcastPathPrefix)
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, aim.ExcludeHop)
+	if err != nil {
+		return err
+	}
 
-	_, err := w.Write(b)
+	_, err = w.Write(b)
 
 	return err
 }

--- a/moqt/internal/message/decode_dos_test.go
+++ b/moqt/internal/message/decode_dos_test.go
@@ -16,7 +16,7 @@ import (
 func TestDecode_RejectsOversizedLength(t *testing.T) {
 	// Largest value expressible in a QUIC varint (uint62 max), encoded as the
 	// message length prefix. No payload bytes follow.
-	lengthPrefix, _ := message.WriteMessageLength(nil, 1<<62-1)
+	lengthPrefix, _, _ := message.WriteMessageLength(nil, 1<<62-1)
 
 	decoders := map[string]interface{ Decode(io.Reader) error }{
 		"AnnounceMessage":         &message.AnnounceMessage{},
@@ -43,17 +43,17 @@ func TestDecode_RejectsOversizedArrayCount(t *testing.T) {
 	// 1. AnnounceMessage HopIDs
 	// Create a payload with a large hop count but no actual hop ID bytes
 	b := make([]byte, 0, 8)
-	b, _ = message.WriteVarint(b, 1000000) // HopCount = 1,000,000
+	b, _, _ = message.WriteVarint(b, 1000000) // HopCount = 1,000,000
 
 	// Create an AnnounceMessage with proper length prefix and structure
 	payload := make([]byte, 0, 64)
-	payload, _ = message.WriteVarint(payload, uint64(message.ACTIVE)) // AnnounceStatus
-	payload, _ = message.WriteString(payload, "test")                 // BroadcastPathSuffix
-	payload = append(payload, b...)                                   // Add the giant HopCount
+	payload, _, _ = message.WriteVarint(payload, uint64(message.ACTIVE)) // AnnounceStatus
+	payload, _, _ = message.WriteString(payload, "test")                 // BroadcastPathSuffix
+	payload = append(payload, b...)                                      // Add the giant HopCount
 
 	msgLen := uint64(len(payload))
 	full := make([]byte, 0, 128)
-	full, _ = message.WriteMessageLength(full, msgLen)
+	full, _, _ = message.WriteMessageLength(full, msgLen)
 	full = append(full, payload...)
 
 	am := &message.AnnounceMessage{}
@@ -62,7 +62,7 @@ func TestDecode_RejectsOversizedArrayCount(t *testing.T) {
 
 	// 2. ReadStringArray count
 	b2 := make([]byte, 0, 8)
-	b2, _ = message.WriteVarint(b2, 1000000) // Count = 1,000,000
+	b2, _, _ = message.WriteVarint(b2, 1000000) // Count = 1,000,000
 
 	_, _, err2 := message.ReadStringArray(b2)
 	assert.ErrorIs(t, err2, io.EOF) // Should fail with EOF reading first missing string, NOT OOM crash

--- a/moqt/internal/message/fetch.go
+++ b/moqt/internal/message/fetch.go
@@ -19,16 +19,29 @@ func (f FetchMessage) Len() int {
 }
 
 func (f FetchMessage) Encode(w io.Writer) error {
+	var err error
 	msgLen := f.Len()
 	b := make([]byte, 0, msgLen+VarintLen(uint64(msgLen)))
-	b, _ = WriteMessageLength(b, uint64(msgLen))
-	b, _ = WriteVarint(b, uint64(len(f.BroadcastPath)))
+	b, _, err = WriteMessageLength(b, uint64(msgLen))
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, uint64(len(f.BroadcastPath)))
+	if err != nil {
+		return err
+	}
 	b = append(b, f.BroadcastPath...)
-	b, _ = WriteVarint(b, uint64(len(f.TrackName)))
+	b, _, err = WriteVarint(b, uint64(len(f.TrackName)))
+	if err != nil {
+		return err
+	}
 	b = append(b, f.TrackName...)
 	b = append(b, f.Priority)
-	b, _ = WriteVarint(b, f.GroupSequence)
-	_, err := w.Write(b)
+	b, _, err = WriteVarint(b, f.GroupSequence)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(b)
 	return err
 }
 

--- a/moqt/internal/message/goaway.go
+++ b/moqt/internal/message/goaway.go
@@ -19,13 +19,20 @@ func (gm GoawayMessage) Len() int {
 }
 
 func (gm GoawayMessage) Encode(w io.Writer) error {
+	var err error
 	msgLen := gm.Len()
 	b := make([]byte, 0, msgLen+VarintLen(uint64(msgLen)))
 
-	b, _ = WriteMessageLength(b, uint64(msgLen))
-	b, _ = WriteString(b, gm.NewSessionURI)
+	b, _, err = WriteMessageLength(b, uint64(msgLen))
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteString(b, gm.NewSessionURI)
+	if err != nil {
+		return err
+	}
 
-	_, err := w.Write(b)
+	_, err = w.Write(b)
 
 	return err
 }

--- a/moqt/internal/message/group.go
+++ b/moqt/internal/message/group.go
@@ -20,14 +20,24 @@ func (g GroupMessage) Len() int {
 }
 
 func (g GroupMessage) Encode(w io.Writer) error {
+	var err error
 	msgLen := g.Len()
 	b := make([]byte, 0, msgLen+VarintLen(uint64(msgLen)))
 
-	b, _ = WriteMessageLength(b, uint64(msgLen))
-	b, _ = WriteVarint(b, g.SubscribeID)
-	b, _ = WriteVarint(b, g.GroupSequence)
+	b, _, err = WriteMessageLength(b, uint64(msgLen))
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, g.SubscribeID)
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, g.GroupSequence)
+	if err != nil {
+		return err
+	}
 
-	_, err := w.Write(b)
+	_, err = w.Write(b)
 
 	return err
 }

--- a/moqt/internal/message/message_writer.go
+++ b/moqt/internal/message/message_writer.go
@@ -4,17 +4,17 @@ import (
 	"fmt"
 )
 
-func WriteVarint(b []byte, i uint64) ([]byte, int) {
+func WriteVarint(b []byte, i uint64) ([]byte, int, error) {
 	if i <= maxVarInt1 {
 		b = append(b, byte(i))
-		return b, 1
+		return b, 1, nil
 	}
 	if i <= maxVarInt2 {
 		b = append(b,
 			uint8(i>>8)|0x40,
 			byte(i),
 		)
-		return b, 2
+		return b, 2, nil
 	}
 	if i <= maxVarInt4 {
 		b = append(b,
@@ -23,7 +23,7 @@ func WriteVarint(b []byte, i uint64) ([]byte, int) {
 			uint8(i>>8),
 			byte(i),
 		)
-		return b, 4
+		return b, 4, nil
 	}
 	if i <= maxVarInt8 {
 		b = append(b,
@@ -36,29 +36,38 @@ func WriteVarint(b []byte, i uint64) ([]byte, int) {
 			uint8(i>>8),
 			byte(i),
 		)
-		return b, 8
+		return b, 8, nil
 	}
-	panic(fmt.Sprintf("%#x doesn't fit into 62 bits", i))
+	return nil, 0, fmt.Errorf("%#x doesn't fit into 62 bits", i)
 }
 
-func WriteBytes(dest []byte, b []byte) ([]byte, int) {
-	dest, n := WriteVarint(dest, uint64(len(b)))
+func WriteBytes(dest []byte, b []byte) ([]byte, int, error) {
+	dest, n, err := WriteVarint(dest, uint64(len(b)))
+	if err != nil {
+		return nil, 0, err
+	}
 	dest = append(dest, b...)
-	return dest, n + len(b)
+	return dest, n + len(b), nil
 }
 
-func WriteString(dest []byte, s string) ([]byte, int) {
+func WriteString(dest []byte, s string) ([]byte, int, error) {
 	return WriteBytes(dest, []byte(s))
 }
 
-func WriteStringArray(dest []byte, arr []string) ([]byte, int) {
-	dest, n := WriteVarint(dest, uint64(len(arr)))
+func WriteStringArray(dest []byte, arr []string) ([]byte, int, error) {
+	dest, n, err := WriteVarint(dest, uint64(len(arr)))
+	if err != nil {
+		return nil, 0, err
+	}
 	var m int
 	for _, str := range arr {
-		dest, m = WriteString(dest, str)
+		dest, m, err = WriteString(dest, str)
+		if err != nil {
+			return nil, 0, err
+		}
 		n += m
 	}
-	return dest, n
+	return dest, n, nil
 }
 
 const (
@@ -68,6 +77,6 @@ const (
 	maxVarInt8 = 1<<(64-2) - 1
 )
 
-func WriteMessageLength(b []byte, size uint64) ([]byte, int) {
+func WriteMessageLength(b []byte, size uint64) ([]byte, int, error) {
 	return WriteVarint(b, size)
 }

--- a/moqt/internal/message/message_writer_test.go
+++ b/moqt/internal/message/message_writer_test.go
@@ -23,7 +23,7 @@ func TestWriteVarint(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result, n := WriteVarint([]byte{}, tt.input)
+		result, n, _ := WriteVarint([]byte{}, tt.input)
 		if n != tt.n {
 			t.Errorf("WriteVarint(%d) n = %d, want %d", tt.input, n, tt.n)
 		}
@@ -33,13 +33,11 @@ func TestWriteVarint(t *testing.T) {
 	}
 }
 
-func TestWriteVarintPanic(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("WriteVarint should panic for large values")
-		}
-	}()
-	WriteVarint([]byte{}, maxVarInt8+1)
+func TestWriteVarintError(t *testing.T) {
+	_, _, err := WriteVarint([]byte{}, maxVarInt8+1)
+	if err == nil {
+		t.Error("WriteVarint should return error for large values")
+	}
 }
 
 func TestWriteBytes(t *testing.T) {
@@ -54,7 +52,7 @@ func TestWriteBytes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result, n := WriteBytes(tt.dest, tt.b)
+		result, n, _ := WriteBytes(tt.dest, tt.b)
 		if n != tt.n {
 			t.Errorf("WriteBytes n = %d, want %d", n, tt.n)
 		}
@@ -76,7 +74,7 @@ func TestWriteString(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result, n := WriteString(tt.dest, tt.s)
+		result, n, _ := WriteString(tt.dest, tt.s)
 		if n != tt.n {
 			t.Errorf("WriteString n = %d, want %d", n, tt.n)
 		}
@@ -98,7 +96,7 @@ func TestWriteStringArray(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result, n := WriteStringArray(tt.dest, tt.arr)
+		result, n, _ := WriteStringArray(tt.dest, tt.arr)
 		if n != tt.n {
 			t.Errorf("WriteStringArray n = %d, want %d", n, tt.n)
 		}

--- a/moqt/internal/message/primitives_benchmark_test.go
+++ b/moqt/internal/message/primitives_benchmark_test.go
@@ -60,7 +60,7 @@ func BenchmarkReadVarint(b *testing.B) {
 	for _, w := range widths {
 		b.Run(w.name, func(b *testing.B) {
 			enc := make([]byte, 0, 8)
-			enc, _ = WriteVarint(enc, w.val)
+			enc, _, _ = WriteVarint(enc, w.val)
 			repeating := tile(enc)
 
 			b.ReportAllocs()
@@ -90,7 +90,7 @@ func BenchmarkReadVarint(b *testing.B) {
 func BenchmarkReadBytes(b *testing.B) {
 	payload := []byte("hello-world-payload") // 19 bytes -> 1-byte varint prefix
 	enc := make([]byte, 0, len(payload)+1)
-	enc, _ = WriteBytes(enc, payload)
+	enc, _, _ = WriteBytes(enc, payload)
 	repeating := tile(enc)
 
 	b.ReportAllocs()
@@ -120,7 +120,7 @@ func BenchmarkReadBytes(b *testing.B) {
 func BenchmarkReadString(b *testing.B) {
 	payload := []byte("hello-world-payload")
 	enc := make([]byte, 0, len(payload)+1)
-	enc, _ = WriteBytes(enc, payload)
+	enc, _, _ = WriteBytes(enc, payload)
 	repeating := tile(enc)
 
 	b.ReportAllocs()
@@ -150,7 +150,7 @@ func BenchmarkReadString(b *testing.B) {
 func BenchmarkReadStringArray(b *testing.B) {
 	arr := []string{"alpha", "beta", "gamma"}
 	enc := make([]byte, 0, 32)
-	enc, _ = WriteStringArray(enc, arr)
+	enc, _, _ = WriteStringArray(enc, arr)
 	repeating := tile(enc)
 
 	b.ReportAllocs()
@@ -194,7 +194,7 @@ func BenchmarkWriteVarint(b *testing.B) {
 	for _, w := range widths {
 		b.Run(w.name, func(b *testing.B) {
 			probe := make([]byte, 0, 8)
-			_, encLen := WriteVarint(probe, w.val)
+			_, encLen, _ := WriteVarint(probe, w.val)
 
 			dest := make([]byte, 0, 8) // cap covers the widest single varint
 
@@ -204,7 +204,7 @@ func BenchmarkWriteVarint(b *testing.B) {
 
 			for b.Loop() {
 				dest = dest[:0]
-				out, n := WriteVarint(dest, w.val)
+				out, n, _ := WriteVarint(dest, w.val)
 				sinkInt = n
 				sinkSlice = out
 			}
@@ -215,7 +215,7 @@ func BenchmarkWriteVarint(b *testing.B) {
 func BenchmarkWriteBytes(b *testing.B) {
 	payload := []byte("hello-world-payload")
 	probe := make([]byte, 0, len(payload)+1)
-	_, encLen := WriteBytes(probe, payload)
+	_, encLen, _ := WriteBytes(probe, payload)
 
 	dest := make([]byte, 0, len(payload)+8)
 
@@ -225,7 +225,7 @@ func BenchmarkWriteBytes(b *testing.B) {
 
 	for b.Loop() {
 		dest = dest[:0]
-		out, n := WriteBytes(dest, payload)
+		out, n, _ := WriteBytes(dest, payload)
 		sinkInt = n
 		sinkSlice = out
 	}
@@ -234,7 +234,7 @@ func BenchmarkWriteBytes(b *testing.B) {
 func BenchmarkWriteString(b *testing.B) {
 	s := "hello-world-payload"
 	probe := make([]byte, 0, len(s)+1)
-	_, encLen := WriteString(probe, s)
+	_, encLen, _ := WriteString(probe, s)
 
 	dest := make([]byte, 0, len(s)+8)
 
@@ -244,7 +244,7 @@ func BenchmarkWriteString(b *testing.B) {
 
 	for b.Loop() {
 		dest = dest[:0]
-		out, n := WriteString(dest, s)
+		out, n, _ := WriteString(dest, s)
 		sinkInt = n
 		sinkSlice = out
 	}
@@ -253,7 +253,7 @@ func BenchmarkWriteString(b *testing.B) {
 func BenchmarkWriteStringArray(b *testing.B) {
 	arr := []string{"alpha", "beta", "gamma"}
 	probe := make([]byte, 0, 64)
-	_, encLen := WriteStringArray(probe, arr)
+	_, encLen, _ := WriteStringArray(probe, arr)
 
 	dest := make([]byte, 0, 64) // 1-byte count + 3*(1-byte len + <=5-byte str) = 22 bytes <= 64
 
@@ -263,7 +263,7 @@ func BenchmarkWriteStringArray(b *testing.B) {
 
 	for b.Loop() {
 		dest = dest[:0]
-		out, n := WriteStringArray(dest, arr)
+		out, n, _ := WriteStringArray(dest, arr)
 		sinkInt = n
 		sinkSlice = out
 	}

--- a/moqt/internal/message/probe.go
+++ b/moqt/internal/message/probe.go
@@ -21,14 +21,24 @@ func (pm ProbeMessage) Len() int {
 }
 
 func (pm ProbeMessage) Encode(w io.Writer) error {
+	var err error
 	msgLen := pm.Len()
 	b := make([]byte, 0, msgLen+VarintLen(uint64(msgLen)))
 
-	b, _ = WriteMessageLength(b, uint64(msgLen))
-	b, _ = WriteVarint(b, pm.Bitrate)
-	b, _ = WriteVarint(b, pm.RTT)
+	b, _, err = WriteMessageLength(b, uint64(msgLen))
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, pm.Bitrate)
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, pm.RTT)
+	if err != nil {
+		return err
+	}
 
-	_, err := w.Write(b)
+	_, err = w.Write(b)
 	return err
 }
 

--- a/moqt/internal/message/subscribe.go
+++ b/moqt/internal/message/subscribe.go
@@ -47,22 +47,44 @@ func (s SubscribeMessage) Len() int {
 }
 
 func (s SubscribeMessage) Encode(w io.Writer) error {
+	var err error
 	msgLen := s.Len()
 	b := make([]byte, 0, msgLen+VarintLen(uint64(msgLen)))
 
-	b, _ = WriteMessageLength(b, uint64(msgLen))
-	b, _ = WriteVarint(b, uint64(s.SubscribeID))
-	b, _ = WriteVarint(b, uint64(len(s.BroadcastPath)))
+	b, _, err = WriteMessageLength(b, uint64(msgLen))
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, uint64(s.SubscribeID))
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, uint64(len(s.BroadcastPath)))
+	if err != nil {
+		return err
+	}
 	b = append(b, s.BroadcastPath...)
-	b, _ = WriteVarint(b, uint64(len(s.TrackName)))
+	b, _, err = WriteVarint(b, uint64(len(s.TrackName)))
+	if err != nil {
+		return err
+	}
 	b = append(b, s.TrackName...)
 	b = append(b, s.SubscriberPriority)
 	b = append(b, s.SubscriberOrdered)
-	b, _ = WriteVarint(b, s.SubscriberMaxLatency)
-	b, _ = WriteVarint(b, s.StartGroup)
-	b, _ = WriteVarint(b, s.EndGroup)
+	b, _, err = WriteVarint(b, s.SubscriberMaxLatency)
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, s.StartGroup)
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, s.EndGroup)
+	if err != nil {
+		return err
+	}
 
-	_, err := w.Write(b)
+	_, err = w.Write(b)
 	return err
 }
 

--- a/moqt/internal/message/subscribe_drop.go
+++ b/moqt/internal/message/subscribe_drop.go
@@ -38,15 +38,28 @@ func (sdm SubscribeDropMessage) Len() int {
 }
 
 func (sdm SubscribeDropMessage) Encode(w io.Writer) error {
+	var err error
 	msgLen := sdm.Len()
 	b := make([]byte, 0, msgLen+VarintLen(uint64(msgLen)))
 
-	b, _ = WriteMessageLength(b, uint64(msgLen))
-	b, _ = WriteVarint(b, sdm.StartGroup)
-	b, _ = WriteVarint(b, sdm.EndGroup)
-	b, _ = WriteVarint(b, sdm.ErrorCode)
+	b, _, err = WriteMessageLength(b, uint64(msgLen))
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, sdm.StartGroup)
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, sdm.EndGroup)
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, sdm.ErrorCode)
+	if err != nil {
+		return err
+	}
 
-	_, err := w.Write(b)
+	_, err = w.Write(b)
 	return err
 }
 

--- a/moqt/internal/message/subscribe_ok.go
+++ b/moqt/internal/message/subscribe_ok.go
@@ -32,17 +32,30 @@ func (som SubscribeOkMessage) Len() int {
 }
 
 func (som SubscribeOkMessage) Encode(w io.Writer) error {
+	var err error
 	msgLen := som.Len()
 	b := make([]byte, 0, msgLen+VarintLen(uint64(msgLen)))
 
-	b, _ = WriteMessageLength(b, uint64(msgLen))
+	b, _, err = WriteMessageLength(b, uint64(msgLen))
+	if err != nil {
+		return err
+	}
 	b = append(b, som.PublisherPriority)
 	b = append(b, som.PublisherOrdered)
-	b, _ = WriteVarint(b, som.PublisherMaxLatency)
-	b, _ = WriteVarint(b, som.StartGroup)
-	b, _ = WriteVarint(b, som.EndGroup)
+	b, _, err = WriteVarint(b, som.PublisherMaxLatency)
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, som.StartGroup)
+	if err != nil {
+		return err
+	}
+	b, _, err = WriteVarint(b, som.EndGroup)
+	if err != nil {
+		return err
+	}
 
-	_, err := w.Write(b)
+	_, err = w.Write(b)
 
 	return err
 }

--- a/moqt/internal/message/subscribe_update.go
+++ b/moqt/internal/message/subscribe_update.go
@@ -27,17 +27,30 @@ func (su SubscribeUpdateMessage) Len() int {
 }
 
 func (su SubscribeUpdateMessage) Encode(w io.Writer) error {
+	var err error
 	msgLen := su.Len()
 	p := make([]byte, 0, msgLen+VarintLen(uint64(msgLen)))
 
-	p, _ = WriteMessageLength(p, uint64(msgLen))
+	p, _, err = WriteMessageLength(p, uint64(msgLen))
+	if err != nil {
+		return err
+	}
 	p = append(p, su.SubscriberPriority)
 	p = append(p, su.SubscriberOrdered)
-	p, _ = WriteVarint(p, su.SubscriberMaxLatency)
-	p, _ = WriteVarint(p, su.StartGroup)
-	p, _ = WriteVarint(p, su.EndGroup)
+	p, _, err = WriteVarint(p, su.SubscriberMaxLatency)
+	if err != nil {
+		return err
+	}
+	p, _, err = WriteVarint(p, su.StartGroup)
+	if err != nil {
+		return err
+	}
+	p, _, err = WriteVarint(p, su.EndGroup)
+	if err != nil {
+		return err
+	}
 
-	_, err := w.Write(p)
+	_, err = w.Write(p)
 
 	return err
 }

--- a/moqt/internal/message/wire_benchmark_test.go
+++ b/moqt/internal/message/wire_benchmark_test.go
@@ -581,7 +581,7 @@ func BenchmarkWriteMessageLength(b *testing.B) {
 			b.ResetTimer()
 
 			for b.Loop() {
-				out, _ := message.WriteMessageLength(dst[:0], tc.val)
+				out, _, _ := message.WriteMessageLength(dst[:0], tc.val)
 				sinkWireBytes = out
 			}
 		})
@@ -607,7 +607,7 @@ func BenchmarkReadMessageLength(b *testing.B) {
 				n = 8
 			}
 			encoded := make([]byte, 0, n)
-			encoded, _ = message.WriteMessageLength(encoded, tc.val)
+			encoded, _, _ = message.WriteMessageLength(encoded, tc.val)
 			// Tile the encoded varint so the reader never drains mid-bench.
 			repeating := tile(encoded)
 			reader := bytes.NewReader(repeating)
@@ -641,7 +641,7 @@ func BenchmarkReadMessageLength(b *testing.B) {
 // No validation logic is added here — measurement only.
 func BenchmarkReadMessageLength_MaxUint62_NoBody(b *testing.B) {
 	encoded := make([]byte, 0, 8)
-	encoded, _ = message.WriteMessageLength(encoded, maxUint62)
+	encoded, _, _ = message.WriteMessageLength(encoded, maxUint62)
 	repeating := tile(encoded)
 	reader := bytes.NewReader(repeating)
 


### PR DESCRIPTION
🎯 **What:** 
Replaced `panic` in `WriteVarint` (and derived functions `WriteBytes`, `WriteString`, etc.) with a propagated `error` return value in `message_writer.go`. Updated all callers throughout the repository (including message Encoders and Tests) to handle the new `error` signature and safely return out-of-bounds encoding errors.

⚠️ **Risk:** 
If left unfixed, providing an improperly constructed or oversized message payload length (greater than 62 bits) to the library's encoding system would trigger a `panic`, crashing the Go process and resulting in a Denial of Service (DoS).

🛡️ **Solution:** 
The fix refactors the `message_writer.go` primitives to safely return `fmt.Errorf("%#x doesn't fit into 62 bits", i)`. All callers inside the `moqt/internal/message` package and `moqt/frame.go` have been patched to check for and cleanly return the error up the stack. Related test assertions were also migrated from expecting `recover()` to asserting the returned `error`.

---
*PR created automatically by Jules for task [9686406633772075578](https://jules.google.com/task/9686406633772075578) started by @okdaichi*