### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix panic on large message sizes (DoS)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,8 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when pre-allocating slices for variable-length arrays based on an untrusted varint count prefix (e.g., `make([]string, 0, count)` or `make([]uint64, count)`). An attacker can specify a huge count for an array with very few bytes, causing the server to allocate massive amounts of memory and crash before parsing the next item.
 **Learning:** Even if the overall message size is constrained or the buffer is small, `make` pre-allocations using unvalidated array lengths can cause OOM DoS.
 **Prevention:** Compute a clamped capacity based on `len(b)` and the maximum possible count before allocating, and allocate `make([]T, 0, allocCap)`. Let the subsequent decode loop naturally fail with an EOF when the buffer is exhausted.
+
+## 2024-07-09 - Fix DoS via panic on oversized network inputs
+**Vulnerability:** A Denial of Service (DoS) vulnerability caused by using `panic()` when decoding oversized variable-length arrays and strings exceeding `math.MaxInt`. On 32-bit systems, a valid QUIC varint (up to 2^62) can exceed `math.MaxInt` (2^31), allowing remote attackers to reliably crash the server by sending large count prefixes.
+**Learning:** Never use `panic()` to handle untrusted network bounds checks. Even if a bound seems unreachable on 64-bit systems, the application must fail gracefully to protect 32-bit deployments and satisfy secure coding principles.
+**Prevention:** Always return proper error values (e.g., `ErrMessageTooLarge`) instead of panicking when handling malformed or oversized network input bounds.

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -79,7 +79,7 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 	}
 	b = b[n:]
 	if num > math.MaxInt {
-		panic("byte slice too large")
+		return nil, 0, ErrMessageTooLarge
 	}
 
 	if uint64(len(b)) < num {
@@ -104,7 +104,7 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 	}
 
 	if count > math.MaxInt {
-		panic("string array too large")
+		return nil, 0, ErrMessageTooLarge
 	}
 
 	b = b[total:]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A Denial of Service (DoS) vulnerability caused by panicking on malformed or oversized network inputs when decoding variable-length strings and arrays exceeding `math.MaxInt`. On 32-bit systems, a valid QUIC varint can exceed `math.MaxInt`, crashing the server instead of failing gracefully.
🎯 Impact: A remote attacker could send a large size prefix within QUIC bounds that exceeds the 32-bit `math.MaxInt` limit, causing the server process to panic and crash, resulting in a Denial of Service.
🔧 Fix: Replaced the unhandled `panic("byte slice too large")` and `panic("string array too large")` calls with `ErrMessageTooLarge` error returns to fail gracefully and securely.
✅ Verification: Tested against the full test suite locally. No panics remain when bounds are exceeded. Added to `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [8809627083995909087](https://jules.google.com/task/8809627083995909087) started by @okdaichi*