### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix remote DoS in message reader panicking on invalid data length

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,8 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when pre-allocating slices for variable-length arrays based on an untrusted varint count prefix (e.g., `make([]string, 0, count)` or `make([]uint64, count)`). An attacker can specify a huge count for an array with very few bytes, causing the server to allocate massive amounts of memory and crash before parsing the next item.
 **Learning:** Even if the overall message size is constrained or the buffer is small, `make` pre-allocations using unvalidated array lengths can cause OOM DoS.
 **Prevention:** Compute a clamped capacity based on `len(b)` and the maximum possible count before allocating, and allocate `make([]T, 0, allocCap)`. Let the subsequent decode loop naturally fail with an EOF when the buffer is exhausted.
+## 2024-07-10 - [CRITICAL] Remote DoS vulnerability via unchecked varint decodes causing panic
+
+**Vulnerability:** Untrusted network input decoding functions `ReadBytes` and `ReadStringArray` paniced when presented with varints exceeding `math.MaxInt`.
+**Learning:** Using `panic()` to handle malformed or oversized untrusted network input introduces a remote Denial of Service (DoS) vulnerability. We should never panic on untrusted data.
+**Prevention:** Return proper errors (e.g., `ErrMessageTooLarge`) instead of panicking to fail securely when encountering excessively large lengths in untrusted input.

--- a/moqt/broadcast_test.go
+++ b/moqt/broadcast_test.go
@@ -29,7 +29,6 @@ func TestBroadcastRegisterAndServeTrack(t *testing.T) {
 	}
 }
 
-
 func TestBroadcastRemoveClosesActiveTracks(t *testing.T) {
 	broadcast := NewBroadcast()
 
@@ -257,16 +256,15 @@ func TestBroadcastClose_MultipleHandlers(t *testing.T) {
 	assert.Equal(t, reflect.ValueOf(NotFoundTrackHandler).Pointer(), reflect.ValueOf(broadcast.Handler("audio")).Pointer())
 }
 
-
 func TestBroadcast_Register(t *testing.T) {
 	dummyHandler := TrackHandlerFunc(func(*TrackWriter) {})
 
 	tests := []struct {
-		name         string
-		broadcast    *Broadcast
-		trackName    TrackName
-		handler      TrackHandler
-		wantErr      string
+		name      string
+		broadcast *Broadcast
+		trackName TrackName
+		handler   TrackHandler
+		wantErr   string
 	}{
 		{
 			name:      "valid registration",

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -79,7 +79,7 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 	}
 	b = b[n:]
 	if num > math.MaxInt {
-		panic("byte slice too large")
+		return nil, 0, ErrMessageTooLarge
 	}
 
 	if uint64(len(b)) < num {
@@ -104,7 +104,7 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 	}
 
 	if count > math.MaxInt {
-		panic("string array too large")
+		return nil, 0, ErrMessageTooLarge
 	}
 
 	b = b[total:]


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Untrusted network input decoding functions `ReadBytes` and `ReadStringArray` in `moqt/internal/message/message_reader.go` panic when presented with varints exceeding `math.MaxInt`.
🎯 **Impact:** An attacker can trigger a remote Denial of Service (DoS) by sending maliciously crafted, excessively large varint lengths (e.g. `0xffffffffffffffff`), instantly crashing the application.
🔧 **Fix:** Replaced the `panic("byte slice too large")` and `panic("string array too large")` calls with proper error returns: `return nil, 0, ErrMessageTooLarge`.
✅ **Verification:** Ran the full test suite (`go test ./...`) which successfully passed. Also locally created and ran targeted tests confirming that attempting to decode `0xffffffffffffffff` varints safely returns `ErrMessageTooLarge` instead of crashing.

---
*PR created automatically by Jules for task [16497544035293428157](https://jules.google.com/task/16497544035293428157) started by @okdaichi*