### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS panic in message reader

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,7 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when pre-allocating slices for variable-length arrays based on an untrusted varint count prefix (e.g., `make([]string, 0, count)` or `make([]uint64, count)`). An attacker can specify a huge count for an array with very few bytes, causing the server to allocate massive amounts of memory and crash before parsing the next item.
 **Learning:** Even if the overall message size is constrained or the buffer is small, `make` pre-allocations using unvalidated array lengths can cause OOM DoS.
 **Prevention:** Compute a clamped capacity based on `len(b)` and the maximum possible count before allocating, and allocate `make([]T, 0, allocCap)`. Let the subsequent decode loop naturally fail with an EOF when the buffer is exhausted.
+## 2024-05-18 - Fix DoS Panics in Message Reader
+**Vulnerability:** Untrusted network input exceeding `math.MaxInt` in size caused a `panic()` in `message_reader.go`, leading to a remote Denial of Service (DoS) vulnerability.
+**Learning:** `panic()` must not be used to handle malformed or oversized untrusted network input.
+**Prevention:** Always return proper errors (e.g., `ErrMessageTooLarge`) instead of panicking to fail securely.

--- a/moqt/broadcast_test.go
+++ b/moqt/broadcast_test.go
@@ -29,7 +29,6 @@ func TestBroadcastRegisterAndServeTrack(t *testing.T) {
 	}
 }
 
-
 func TestBroadcastRemoveClosesActiveTracks(t *testing.T) {
 	broadcast := NewBroadcast()
 
@@ -257,16 +256,15 @@ func TestBroadcastClose_MultipleHandlers(t *testing.T) {
 	assert.Equal(t, reflect.ValueOf(NotFoundTrackHandler).Pointer(), reflect.ValueOf(broadcast.Handler("audio")).Pointer())
 }
 
-
 func TestBroadcast_Register(t *testing.T) {
 	dummyHandler := TrackHandlerFunc(func(*TrackWriter) {})
 
 	tests := []struct {
-		name         string
-		broadcast    *Broadcast
-		trackName    TrackName
-		handler      TrackHandler
-		wantErr      string
+		name      string
+		broadcast *Broadcast
+		trackName TrackName
+		handler   TrackHandler
+		wantErr   string
 	}{
 		{
 			name:      "valid registration",

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -79,7 +79,7 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 	}
 	b = b[n:]
 	if num > math.MaxInt {
-		panic("byte slice too large")
+		return nil, 0, ErrMessageTooLarge
 	}
 
 	if uint64(len(b)) < num {
@@ -104,7 +104,7 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 	}
 
 	if count > math.MaxInt {
-		panic("string array too large")
+		return nil, 0, ErrMessageTooLarge
 	}
 
 	b = b[total:]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Untrusted network input exceeding `math.MaxInt` in size caused a `panic()` in `message_reader.go` when parsing varints for `ReadBytes` and `ReadStringArray`, leading to a remote Denial of Service (DoS) vulnerability.
🎯 Impact: A malicious peer could send an oversized message length prefix, causing the server to immediately panic and crash, halting all sessions.
🔧 Fix: Replaced `panic` statements with returning `ErrMessageTooLarge` error, allowing the server to gracefully fail and close the offending connection without crashing the application.
✅ Verification: Ran `go test ./...` and `go vet ./...` to verify no regressions. Code review confirmed the fix is correct and secure.

---
*PR created automatically by Jules for task [6266686669009403459](https://jules.google.com/task/6266686669009403459) started by @okdaichi*