### PR TITLE
fix(session): signal Tracks/Groups on CloseWithError so Shutdown drains (qumo #286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **TS release — `@qumo/moq` v0.16.2 (JSR, 2026-07-07).** Patch bump of the TypeScript (`moq-web`) package only: dependency updates, no `@qumo/moq` API or behavior change. The Go module (`moqt`) is unchanged and **not** re-released; the `moqt` entries below remain unreleased. This JSR release publishes the `moq-web` dependency bumps from #307: `@okdaichi/golikejs` `0.9.0` → `0.10.0`, the `@std/{assert,cli,path,testing}` minor bumps, and `zod` `^3.24.2` → `^4.4.3` (a major dependency bump; the zod API surface `@qumo/moq` uses is unchanged in v4, so no source changes were needed — verified by the `src/msf/` catalog/timeline/delta tests).
 
+### Fixed
+
+- **moqt:** `Session.CloseWithError` now signals active Tracks and Groups (closes all `TrackWriter`/`TrackReader`) before waiting on the stream-handling `WaitGroup`. Previously, a handler blocked on a Track that didn't poll its connection/stream context (e.g. a relay's per-subscriber egress in a "subscriber fell behind" busy-loop) never noticed the session was tearing down, so `wg.Wait()` hung, `CloseWithError` never returned, the connection was never removed from the manager, and `Server.Shutdown` hung on `<-connManager.Done()` (qumo #286). Each `Close` is best-effort (recovered) so one bad track cannot abort session teardown. Added `TestServer_Shutdown_ReturnsWithActiveSession` — the Shutdown analogue of the #181 regression test for `Close`.
+
+
 ## [v0.16.1] - 2026-07-01
 
 > **Dual release.** `v0.16.1` ships both packages at the same version: the Go module (`moqt`, consumed via `go get github.com/qumo-dev/gomoqt@v0.16.1`) and the TypeScript package (`@qumo/moq` on JSR). The `moq-web` bullets below were published via the JSR release; the `moqt` and `deps` bullets ship via this Go tag — notably the `webtransport-go` → `v0.11.0-okdaichi.1` bump (which brings upstream #267, the transport-layer fix for the qumo #205 close-cancellation stall) and the accumulated `moqt` benchmark / dead-code / security work.

--- a/moqt/server.go
+++ b/moqt/server.go
@@ -544,7 +544,10 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		}(conn)
 	}
 
-	// Wait for all sessions to close
+	// Wait for all sessions to close. The per-connection goAway calls above
+	// force-close any connection still open when ctx expires (the graceful drain
+	// window), so its session runs CloseWithError -> removeConn and the
+	// connManager drains within the window.
 	<-connManager.Done()
 
 	// Close WebTransport server (guard against panics from underlying implementations)

--- a/moqt/server_test.go
+++ b/moqt/server_test.go
@@ -466,6 +466,68 @@ func TestServer_Close_ReturnsWithActiveSession(t *testing.T) {
 	}
 }
 
+// TestServer_Shutdown_ReturnsWithActiveSession is the Shutdown analogue of the
+// #181 regression test for Close. With an active client session that does not
+// disconnect on its own, Shutdown(ctx) must return within the ctx drain window:
+// the per-conn goAway force-closes the connection when ctx expires, the session
+// runs CloseWithError (which signals its Tracks/Groups so handler goroutines
+// exit and the WaitGroup drains), and the connManager empties. Previously the
+// lack of a Track/Group signal let CloseWithError's wg.Wait() hang on handler
+// goroutines that never noticed the connection was gone (qumo #286).
+func TestServer_Shutdown_ReturnsWithActiveSession(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := pc.LocalAddr().String()
+	_ = pc.Close()
+
+	server := &Server{
+		Addr: addr,
+		TLSConfig: &tls.Config{
+			NextProtos:         []string{NextProtoH3, NextProtoMOQ},
+			Certificates:       []tls.Certificate{generateTestCert(t)},
+			InsecureSkipVerify: true,
+		},
+		Handler: HandleFunc(func(sess *Session) { <-sess.Context().Done() }),
+	}
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, ErrServerClosed) {
+			t.Logf("server: %v", err)
+		}
+	}()
+
+	client := &Dialer{TLSConfig: &tls.Config{InsecureSkipVerify: true}}
+	var active *Session
+	require.Eventually(t, func() bool {
+		s, derr := client.Dial(context.Background(), "https://"+addr+"/moqt", nil)
+		if derr != nil {
+			return false
+		}
+		active = s
+		return true
+	}, 5*time.Second, 50*time.Millisecond, "listener should accept a dial")
+	defer func() {
+		if active != nil {
+			_ = active.CloseWithError(NoError, "test done")
+		}
+	}()
+
+	// Short drain window: goAway force-closes on ctx expiry, CloseWithError
+	// signals Tracks/Groups, the session unblocks, connManager drains.
+	done := make(chan struct{})
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(6 * time.Second):
+		t.Fatal("Server.Shutdown(ctx) hung with an active connection (qumo #286)")
+	}
+}
+
 func TestServer_Shutdown_NoSessions(t *testing.T) {
 	s := &Server{}
 	s.init()

--- a/moqt/session.go
+++ b/moqt/session.go
@@ -208,6 +208,13 @@ func (s *Session) CloseWithError(code SessionErrorCode, msg string) error {
 		return fmt.Errorf("session termination failed: %w", err)
 	}
 
+	// Signal active Tracks and Groups to terminate so the stream-handling
+	// goroutines waiting on them (e.g. a relay's per-subscriber egress) exit and
+	// wg.Wait() below can complete. Without this, a handler blocked on a track
+	// the session is tearing down pins the WaitGroup, so CloseWithError never
+	// returns and the conn never leaves the connManager — hanging Server.Shutdown.
+	s.closeTracksAndGroups()
+
 	// Wait for finishing handling streams
 	s.wg.Wait()
 
@@ -798,6 +805,47 @@ func (s *Session) addTrackReader(id SubscribeID, reader *TrackReader) {
 	defer s.trackReaderMapLocker.Unlock()
 
 	s.trackReaders[id] = reader
+}
+
+// closeTracksAndGroups signals all active TrackWriters (server-side tracks being
+// served to subscribers) and TrackReaders (client-side subscriptions) to
+// terminate by closing them. Closing a track cancels its stream context and
+// closes its groups, which unblocks any per-track handler goroutine waiting on
+// that context (e.g. a relay's subscriber egress blocked in a select or in the
+// next OpenGroupAt/WriteFrame). Called from CloseWithError so the session's
+// stream-handling WaitGroup drains instead of hanging on handlers that are
+// waiting on tracks the session is tearing down.
+//
+// Each Close is best-effort: a shutdown path must not abort because one track's
+// Close fails or panics (e.g. a placeholder/malformed track), so the remaining
+// tracks still get signaled.
+func (s *Session) closeTracksAndGroups() {
+	closeSafe := func(c func() error) {
+		defer func() { recover() }()
+		_ = c()
+	}
+
+	s.trackWriterMapLocker.Lock()
+	writers := make([]*TrackWriter, 0, len(s.trackWriters))
+	for _, tw := range s.trackWriters {
+		writers = append(writers, tw)
+	}
+	s.trackWriters = make(map[SubscribeID]*TrackWriter)
+	s.trackWriterMapLocker.Unlock()
+	for _, tw := range writers {
+		closeSafe(tw.Close)
+	}
+
+	s.trackReaderMapLocker.Lock()
+	readers := make([]*TrackReader, 0, len(s.trackReaders))
+	for _, tr := range s.trackReaders {
+		readers = append(readers, tr)
+	}
+	s.trackReaders = make(map[SubscribeID]*TrackReader)
+	s.trackReaderMapLocker.Unlock()
+	for _, tr := range readers {
+		closeSafe(tr.Close)
+	}
 }
 
 func (s *Session) removeTrackReader(id SubscribeID) {


### PR DESCRIPTION
## What

`Server.Shutdown` could hang indefinitely with an active session whose stream handlers didn't notice the connection was gone — e.g. a relay's per-subscriber egress in a tight "subscriber fell behind" loop, or any handler that doesn't poll the connection/stream context. This is the root cause of **qumo #286** (`Server.Shutdown` hangs for minutes during multi-subscriber teardown; `CloseWithError` never returns; goroutines leak under churn).

## Root cause

`Server.Shutdown` sends GOAWAY; each per-conn `goAway` force-closes its connection when `ctx` (the drain window) expires, so the session runs `CloseWithError` → `removeConn` and the `connManager` drains. So far so good.

But `Session.CloseWithError` ends with `s.wg.Wait()` on the stream-handling goroutines. A handler blocked on a **Track** (waiting in a `select` on a stream context it isn't re-checking, or busy-looping) never notices the connection closed, so it never returns, `wg.Wait()` blocks, `CloseWithError` never returns, the conn is never removed from the manager, and `Server.Shutdown` hangs on `<-connManager.Done()`.

## Fix

Signal **Tracks and Groups** from `CloseWithError` before `wg.Wait()`:

- New `Session.closeTracksAndGroups()` closes every active `TrackWriter` (server-side, served to subscribers) and `TrackReader` (client-side subscription). Closing a track cancels its stream context and closes its groups, which unblocks any handler waiting on it — so the WaitGroup drains and `CloseWithError` returns.
- Each `Close` is best-effort (recovered): a shutdown path must not abort because one track's `Close` fails or panics (e.g. a placeholder/malformed track); the remaining tracks still get signaled.

This is the missing "signal to Track and Group" during the shutdown drain window.

Also:
- Document the ctx-bounded drain mechanism on `Server.Shutdown`'s `<-connManager.Done()` (the per-conn `goAway` force-close is what bounds it to `ctx`).
- Add `TestServer_Shutdown_ReturnsWithActiveSession` — the Shutdown analogue of the #181 regression test for `Close` (active client session that doesn't disconnect on its own; `Shutdown(ctx)` must return within the drain window).

## Verification

- `go vet ./moqt/` clean; full `go test ./moqt/` green (including the new test and the existing #181 Close regression).
- The new `TestServer_Shutdown_ReturnsWithActiveSession` passes (returns after the 1s drain window via goAway force-close → CloseWithError → track signal → drain).

## Note on qumo #286 repro

The exact qumo #286 hang (multi-relay `TestRelayChain_FanoutStress` K≥8 teardown on a 2-core Linux runner) is timing/platform-dependent and does **not** reproduce on Windows, so it could not be A/B-verified locally end-to-end. The fix is justified by design: `CloseWithError`'s `wg.Wait()` demonstrably cannot complete while a handler is blocked on a track the session is tearing down, and closing the track is the deterministic signal that unblocks it. qumo #286 carries the deeper analysis and the deterministic (qumo-side) repro for follow-up.

## Follow-up (qumo side)

Once this lands and ships in a release, qumo bumps its gomoqt dependency; the `TestRelayChain_*` teardown hang (#286) and the reconnect-storm goroutine leak should resolve, unblocking the fan-out capacity investigation (#287).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
