### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS panic in message decoding

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,7 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when pre-allocating slices for variable-length arrays based on an untrusted varint count prefix (e.g., `make([]string, 0, count)` or `make([]uint64, count)`). An attacker can specify a huge count for an array with very few bytes, causing the server to allocate massive amounts of memory and crash before parsing the next item.
 **Learning:** Even if the overall message size is constrained or the buffer is small, `make` pre-allocations using unvalidated array lengths can cause OOM DoS.
 **Prevention:** Compute a clamped capacity based on `len(b)` and the maximum possible count before allocating, and allocate `make([]T, 0, allocCap)`. Let the subsequent decode loop naturally fail with an EOF when the buffer is exhausted.
+## YYYY-MM-DD - [CRITICAL] Fix DoS panic in message decoding
+**Vulnerability:** Found `panic` calls in `ReadBytes` and `ReadStringArray` when handling length fields from untrusted network input.
+**Learning:** Using `panic` to handle malformed or oversized untrusted network input introduces a remote Denial of Service (DoS) vulnerability.
+**Prevention:** Always return proper errors (e.g., `ErrMessageTooLarge`) instead to fail securely.

--- a/moqt/broadcast_test.go
+++ b/moqt/broadcast_test.go
@@ -29,7 +29,6 @@ func TestBroadcastRegisterAndServeTrack(t *testing.T) {
 	}
 }
 
-
 func TestBroadcastRemoveClosesActiveTracks(t *testing.T) {
 	broadcast := NewBroadcast()
 
@@ -257,16 +256,15 @@ func TestBroadcastClose_MultipleHandlers(t *testing.T) {
 	assert.Equal(t, reflect.ValueOf(NotFoundTrackHandler).Pointer(), reflect.ValueOf(broadcast.Handler("audio")).Pointer())
 }
 
-
 func TestBroadcast_Register(t *testing.T) {
 	dummyHandler := TrackHandlerFunc(func(*TrackWriter) {})
 
 	tests := []struct {
-		name         string
-		broadcast    *Broadcast
-		trackName    TrackName
-		handler      TrackHandler
-		wantErr      string
+		name      string
+		broadcast *Broadcast
+		trackName TrackName
+		handler   TrackHandler
+		wantErr   string
 	}{
 		{
 			name:      "valid registration",

--- a/moqt/internal/message/decode_dos_test.go
+++ b/moqt/internal/message/decode_dos_test.go
@@ -11,7 +11,7 @@ import (
 
 // TestDecode_RejectsOversizedLength ensures every length-prefixed message rejects
 // an attacker-controlled length prefix that exceeds MaxMessageSize, returning
-// ErrMessageTooLarge before allocating the payload buffer. Without this guard a peer
+// message.ErrMessageTooLarge before allocating the payload buffer. Without this guard a peer
 // can advertise a maxUint62 length and force make([]byte, ~4.6e18) -> OOM crash.
 func TestDecode_RejectsOversizedLength(t *testing.T) {
 	// Largest value expressible in a QUIC varint (uint62 max), encoded as the
@@ -60,10 +60,23 @@ func TestDecode_RejectsOversizedArrayCount(t *testing.T) {
 	err := am.Decode(bytes.NewReader(full))
 	assert.ErrorIs(t, err, io.EOF) // Should fail with EOF reading first missing HopID, NOT OOM crash
 
-	// 2. ReadStringArray count
+	// 2. message.ReadStringArray count
 	b2 := make([]byte, 0, 8)
 	b2, _ = message.WriteVarint(b2, 1000000) // Count = 1,000,000
 
 	_, _, err2 := message.ReadStringArray(b2)
 	assert.ErrorIs(t, err2, io.EOF) // Should fail with EOF reading first missing string, NOT OOM crash
+}
+
+func TestReadBytes_RejectsOversizedLength(t *testing.T) {
+	// Largest value expressible in a QUIC varint (uint62 max)
+	lengthPrefix, _ := message.WriteMessageLength(nil, 1<<62-1)
+	_, _, err := message.ReadBytes(lengthPrefix)
+	assert.ErrorIs(t, err, message.ErrMessageTooLarge)
+}
+
+func TestReadStringArray_RejectsOversizedCount(t *testing.T) {
+	lengthPrefix, _ := message.WriteMessageLength(nil, 1<<62-1)
+	_, _, err := message.ReadStringArray(lengthPrefix)
+	assert.ErrorIs(t, err, message.ErrMessageTooLarge)
 }

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -3,7 +3,6 @@ package message
 import (
 	"errors"
 	"io"
-	"math"
 )
 
 func ReadVarint(b []byte) (uint64, int, error) {
@@ -78,8 +77,8 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 		return nil, 0, err
 	}
 	b = b[n:]
-	if num > math.MaxInt {
-		panic("byte slice too large")
+	if num > MaxMessageSize {
+		return nil, 0, ErrMessageTooLarge
 	}
 
 	if uint64(len(b)) < num {
@@ -103,8 +102,8 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 		return nil, 0, err
 	}
 
-	if count > math.MaxInt {
-		panic("string array too large")
+	if count > MaxMessageSize {
+		return nil, 0, ErrMessageTooLarge
 	}
 
 	b = b[total:]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Found `panic` calls in `ReadBytes` and `ReadStringArray` when handling length fields from untrusted network input.
🎯 Impact: A remote attacker could send oversized lengths causing a panic, resulting in a Denial of Service (DoS).
🔧 Fix: Replaced `panic` with proper error handling by returning `ErrMessageTooLarge`.
✅ Verification: Tests have been updated to check for `ErrMessageTooLarge` on oversized inputs and the full test suite has been run.

---
*PR created automatically by Jules for task [13628096006836272361](https://jules.google.com/task/13628096006836272361) started by @okdaichi*