### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerability by replacing panics with errors on untrusted input

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,8 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when pre-allocating slices for variable-length arrays based on an untrusted varint count prefix (e.g., `make([]string, 0, count)` or `make([]uint64, count)`). An attacker can specify a huge count for an array with very few bytes, causing the server to allocate massive amounts of memory and crash before parsing the next item.
 **Learning:** Even if the overall message size is constrained or the buffer is small, `make` pre-allocations using unvalidated array lengths can cause OOM DoS.
 **Prevention:** Compute a clamped capacity based on `len(b)` and the maximum possible count before allocating, and allocate `make([]T, 0, allocCap)`. Let the subsequent decode loop naturally fail with an EOF when the buffer is exhausted.
+## YYYY-MM-DD - DoS via Untrusted Message Length Varints
+
+**Vulnerability:** Parsing malicious message components (strings, byte slices) on 32-bit architectures could panic when processing valid QUIC varints that exceed `math.MaxInt` causing a Denial of Service.
+**Learning:** Using `panic()` in parsing routines for untrusted network input introduces a DoS vector. Errors should be securely propagated instead of failing hard.
+**Prevention:** Always return proper error values (e.g. `ErrMessageTooLarge`) from parsers and sanitize network data systematically before casting/using for allocation bounds.

--- a/moqt/broadcast_test.go
+++ b/moqt/broadcast_test.go
@@ -29,7 +29,6 @@ func TestBroadcastRegisterAndServeTrack(t *testing.T) {
 	}
 }
 
-
 func TestBroadcastRemoveClosesActiveTracks(t *testing.T) {
 	broadcast := NewBroadcast()
 
@@ -257,16 +256,15 @@ func TestBroadcastClose_MultipleHandlers(t *testing.T) {
 	assert.Equal(t, reflect.ValueOf(NotFoundTrackHandler).Pointer(), reflect.ValueOf(broadcast.Handler("audio")).Pointer())
 }
 
-
 func TestBroadcast_Register(t *testing.T) {
 	dummyHandler := TrackHandlerFunc(func(*TrackWriter) {})
 
 	tests := []struct {
-		name         string
-		broadcast    *Broadcast
-		trackName    TrackName
-		handler      TrackHandler
-		wantErr      string
+		name      string
+		broadcast *Broadcast
+		trackName TrackName
+		handler   TrackHandler
+		wantErr   string
 	}{
 		{
 			name:      "valid registration",

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -79,7 +79,7 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 	}
 	b = b[n:]
 	if num > math.MaxInt {
-		panic("byte slice too large")
+		return nil, 0, ErrMessageTooLarge
 	}
 
 	if uint64(len(b)) < num {
@@ -104,7 +104,7 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 	}
 
 	if count > math.MaxInt {
-		panic("string array too large")
+		return nil, 0, ErrMessageTooLarge
 	}
 
 	b = b[total:]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Parsing untrusted length prefixes on 32-bit architectures panics when the value exceeds `math.MaxInt`, allowing an attacker to DoS the application.
🎯 Impact: A remote attacker can crash the process via specially crafted packets.
🔧 Fix: Substituted `panic()` with `ErrMessageTooLarge` to fail securely on invalid sizing.
✅ Verification: Ensured full test suite passes. Note that branches are unreachable on 64-bit architectures but protect 32-bit deployments.

---
*PR created automatically by Jules for task [11514416158046066380](https://jules.google.com/task/11514416158046066380) started by @okdaichi*