### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerability in message parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,7 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when pre-allocating slices for variable-length arrays based on an untrusted varint count prefix (e.g., `make([]string, 0, count)` or `make([]uint64, count)`). An attacker can specify a huge count for an array with very few bytes, causing the server to allocate massive amounts of memory and crash before parsing the next item.
 **Learning:** Even if the overall message size is constrained or the buffer is small, `make` pre-allocations using unvalidated array lengths can cause OOM DoS.
 **Prevention:** Compute a clamped capacity based on `len(b)` and the maximum possible count before allocating, and allocate `make([]T, 0, allocCap)`. Let the subsequent decode loop naturally fail with an EOF when the buffer is exhausted.
+## YYYY-MM-DD - Fix Remote DoS Panic in Message Reader
+**Vulnerability:** Parsing maliciously large lengths from QUIC varints directly triggered `panic` calls.
+**Learning:** Using `panic()` to handle malformed or oversized untrusted network input introduces a remote Denial of Service (DoS) vulnerability.
+**Prevention:** Always return proper errors (e.g., `ErrMessageTooLarge`) and bound allocations/checks to safe maximums (e.g., `MaxMessageSize`) to fail securely.

--- a/moqt/broadcast_test.go
+++ b/moqt/broadcast_test.go
@@ -29,7 +29,6 @@ func TestBroadcastRegisterAndServeTrack(t *testing.T) {
 	}
 }
 
-
 func TestBroadcastRemoveClosesActiveTracks(t *testing.T) {
 	broadcast := NewBroadcast()
 
@@ -257,16 +256,15 @@ func TestBroadcastClose_MultipleHandlers(t *testing.T) {
 	assert.Equal(t, reflect.ValueOf(NotFoundTrackHandler).Pointer(), reflect.ValueOf(broadcast.Handler("audio")).Pointer())
 }
 
-
 func TestBroadcast_Register(t *testing.T) {
 	dummyHandler := TrackHandlerFunc(func(*TrackWriter) {})
 
 	tests := []struct {
-		name         string
-		broadcast    *Broadcast
-		trackName    TrackName
-		handler      TrackHandler
-		wantErr      string
+		name      string
+		broadcast *Broadcast
+		trackName TrackName
+		handler   TrackHandler
+		wantErr   string
 	}{
 		{
 			name:      "valid registration",

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -3,7 +3,6 @@ package message
 import (
 	"errors"
 	"io"
-	"math"
 )
 
 func ReadVarint(b []byte) (uint64, int, error) {
@@ -78,8 +77,8 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 		return nil, 0, err
 	}
 	b = b[n:]
-	if num > math.MaxInt {
-		panic("byte slice too large")
+	if num > MaxMessageSize {
+		return nil, 0, ErrMessageTooLarge
 	}
 
 	if uint64(len(b)) < num {
@@ -103,8 +102,8 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 		return nil, 0, err
 	}
 
-	if count > math.MaxInt {
-		panic("string array too large")
+	if count > MaxMessageSize {
+		return nil, 0, ErrMessageTooLarge
 	}
 
 	b = b[total:]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Parsing maliciously large lengths from QUIC varints directly triggered `panic` calls.
🎯 Impact: A malicious peer could cause the server or client to crash by sending a crafted packet with extremely large length prefixes, resulting in a remote Denial of Service (DoS).
🔧 Fix: Replaced `panic` with returning `ErrMessageTooLarge` and bounded length checks to `MaxMessageSize` (50MB) instead of `math.MaxInt`.
✅ Verification: Ran `go test ./...` which passes successfully, indicating that parsing handles overly large sizes gracefully without panicking.

---
*PR created automatically by Jules for task [14772397062104230506](https://jules.google.com/task/14772397062104230506) started by @okdaichi*