### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerability via panic on large varints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,8 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when pre-allocating slices for variable-length arrays based on an untrusted varint count prefix (e.g., `make([]string, 0, count)` or `make([]uint64, count)`). An attacker can specify a huge count for an array with very few bytes, causing the server to allocate massive amounts of memory and crash before parsing the next item.
 **Learning:** Even if the overall message size is constrained or the buffer is small, `make` pre-allocations using unvalidated array lengths can cause OOM DoS.
 **Prevention:** Compute a clamped capacity based on `len(b)` and the maximum possible count before allocating, and allocate `make([]T, 0, allocCap)`. Let the subsequent decode loop naturally fail with an EOF when the buffer is exhausted.
+
+## 2024-07-19 - Fix DoS via panic on large varints
+**Vulnerability:** A Denial of Service (DoS) vulnerability caused by `panic()` calls when untrusted network input contained varint lengths exceeding `math.MaxInt`.
+**Learning:** Using `panic()` to handle malformed or oversized untrusted network input (e.g., lengths exceeding `math.MaxInt`) introduces a remote DoS vulnerability. The application will crash.
+**Prevention:** Always return proper errors (e.g., `ErrMessageTooLarge`) instead of panicking to fail securely.

--- a/moqt/broadcast_test.go
+++ b/moqt/broadcast_test.go
@@ -29,7 +29,6 @@ func TestBroadcastRegisterAndServeTrack(t *testing.T) {
 	}
 }
 
-
 func TestBroadcastRemoveClosesActiveTracks(t *testing.T) {
 	broadcast := NewBroadcast()
 
@@ -257,16 +256,15 @@ func TestBroadcastClose_MultipleHandlers(t *testing.T) {
 	assert.Equal(t, reflect.ValueOf(NotFoundTrackHandler).Pointer(), reflect.ValueOf(broadcast.Handler("audio")).Pointer())
 }
 
-
 func TestBroadcast_Register(t *testing.T) {
 	dummyHandler := TrackHandlerFunc(func(*TrackWriter) {})
 
 	tests := []struct {
-		name         string
-		broadcast    *Broadcast
-		trackName    TrackName
-		handler      TrackHandler
-		wantErr      string
+		name      string
+		broadcast *Broadcast
+		trackName TrackName
+		handler   TrackHandler
+		wantErr   string
 	}{
 		{
 			name:      "valid registration",

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -3,7 +3,6 @@ package message
 import (
 	"errors"
 	"io"
-	"math"
 )
 
 func ReadVarint(b []byte) (uint64, int, error) {
@@ -78,8 +77,8 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 		return nil, 0, err
 	}
 	b = b[n:]
-	if num > math.MaxInt {
-		panic("byte slice too large")
+	if num > MaxMessageSize {
+		return nil, 0, ErrMessageTooLarge
 	}
 
 	if uint64(len(b)) < num {
@@ -103,8 +102,8 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 		return nil, 0, err
 	}
 
-	if count > math.MaxInt {
-		panic("string array too large")
+	if count > MaxMessageSize {
+		return nil, 0, ErrMessageTooLarge
 	}
 
 	b = b[total:]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Network packets with untrusted sizes exceeding max bounds caused panics.
🎯 Impact: Remote Denial of Service crashing the server.
🔧 Fix: Replaced panics with safe `ErrMessageTooLarge` error returns.
✅ Verification: Ensured unit tests pass and panics are mitigated.

---
*PR created automatically by Jules for task [12983027942107920827](https://jules.google.com/task/12983027942107920827) started by @okdaichi*