### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Remote DoS Vulnerability via Panic on Oversized Network Messages

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,10 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when pre-allocating slices for variable-length arrays based on an untrusted varint count prefix (e.g., `make([]string, 0, count)` or `make([]uint64, count)`). An attacker can specify a huge count for an array with very few bytes, causing the server to allocate massive amounts of memory and crash before parsing the next item.
 **Learning:** Even if the overall message size is constrained or the buffer is small, `make` pre-allocations using unvalidated array lengths can cause OOM DoS.
 **Prevention:** Compute a clamped capacity based on `len(b)` and the maximum possible count before allocating, and allocate `make([]T, 0, allocCap)`. Let the subsequent decode loop naturally fail with an EOF when the buffer is exhausted.
+## 2025-02-20 - DoS Vulnerability via Panic on Oversized Messages
+
+**Vulnerability:** In `moqt/internal/message/message_reader.go`, an untrusted network payload with a size field exceeding `math.MaxInt` causes an explicit `panic()` ("byte slice too large" or "string array too large"). This enables a remote attacker to easily trigger a Denial-of-Service (DoS) condition by sending maliciously crafted oversized lengths.
+
+**Learning:** Using `panic()` in Go to handle invalid or unexpectedly large input from untrusted network sources is a common security pitfall. While intended to catch out-of-bounds inputs, panicking tears down the entire application or goroutine, resulting in a remote DoS vector. Parsers should return appropriate typed errors instead.
+
+**Prevention:** Never use `panic()` for control flow or input validation on untrusted data. Always return a proper error (`errors.New`) and gracefully terminate the connection or reject the message. When parsing variable-length fields, safely fail validation instead of causing a panic that interrupts server execution flow.

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -79,7 +79,7 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 	}
 	b = b[n:]
 	if num > math.MaxInt {
-		panic("byte slice too large")
+		return nil, 0, errors.New("byte slice too large")
 	}
 
 	if uint64(len(b)) < num {
@@ -104,7 +104,7 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 	}
 
 	if count > math.MaxInt {
-		panic("string array too large")
+		return nil, 0, errors.New("string array too large")
 	}
 
 	b = b[total:]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The message parser panicked when receiving untrusted network messages with lengths exceeding math.MaxInt. An attacker could craft arbitrary lengths to crash the server (DoS).
🎯 Impact: Remote Denial of Service (DoS).
🔧 Fix: Replaced `panic` with proper typed error return (`errors.New`), handling the error gracefully without terminating execution flow.
✅ Verification: Checked code compiles and tests pass successfully.

---
*PR created automatically by Jules for task [1612445915805772638](https://jules.google.com/task/1612445915805772638) started by @okdaichi*