### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,7 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when pre-allocating slices for variable-length arrays based on an untrusted varint count prefix (e.g., `make([]string, 0, count)` or `make([]uint64, count)`). An attacker can specify a huge count for an array with very few bytes, causing the server to allocate massive amounts of memory and crash before parsing the next item.
 **Learning:** Even if the overall message size is constrained or the buffer is small, `make` pre-allocations using unvalidated array lengths can cause OOM DoS.
 **Prevention:** Compute a clamped capacity based on `len(b)` and the maximum possible count before allocating, and allocate `make([]T, 0, allocCap)`. Let the subsequent decode loop naturally fail with an EOF when the buffer is exhausted.
+## 2025-01-20 - Fix Denial of Service in Message Reader
+**Vulnerability:** Untrusted network payloads contained QUIC varint length prefixes that were previously verified against `math.MaxInt` causing `panic()` when exceeding integer size on 32-bit systems, creating a remote Denial-of-Service vector.
+**Learning:** Panicking on invalid or excessive inputs from network peers provides a trivial method for attackers to crash the server, even if the limit is architecture-dependent.
+**Prevention:** Always fail securely by returning appropriate errors for invalid bounds rather than panicking, explicitly maintaining the application's stability against malicious payloads.

--- a/moqt/broadcast_test.go
+++ b/moqt/broadcast_test.go
@@ -29,7 +29,6 @@ func TestBroadcastRegisterAndServeTrack(t *testing.T) {
 	}
 }
 
-
 func TestBroadcastRemoveClosesActiveTracks(t *testing.T) {
 	broadcast := NewBroadcast()
 
@@ -257,16 +256,15 @@ func TestBroadcastClose_MultipleHandlers(t *testing.T) {
 	assert.Equal(t, reflect.ValueOf(NotFoundTrackHandler).Pointer(), reflect.ValueOf(broadcast.Handler("audio")).Pointer())
 }
 
-
 func TestBroadcast_Register(t *testing.T) {
 	dummyHandler := TrackHandlerFunc(func(*TrackWriter) {})
 
 	tests := []struct {
-		name         string
-		broadcast    *Broadcast
-		trackName    TrackName
-		handler      TrackHandler
-		wantErr      string
+		name      string
+		broadcast *Broadcast
+		trackName TrackName
+		handler   TrackHandler
+		wantErr   string
 	}{
 		{
 			name:      "valid registration",

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -79,7 +79,7 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 	}
 	b = b[n:]
 	if num > math.MaxInt {
-		panic("byte slice too large")
+		return nil, 0, errors.New("byte slice too large")
 	}
 
 	if uint64(len(b)) < num {
@@ -104,7 +104,7 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 	}
 
 	if count > math.MaxInt {
-		panic("string array too large")
+		return nil, 0, errors.New("string array too large")
 	}
 
 	b = b[total:]

--- a/moqt/internal/message/message_reader_large_test.go
+++ b/moqt/internal/message/message_reader_large_test.go
@@ -1,0 +1,49 @@
+package message
+
+import (
+	"github.com/stretchr/testify/assert"
+	"math"
+	"testing"
+)
+
+func TestReadBytes_TooLargeError(t *testing.T) {
+	val := uint64(0x3fffffffffffffff)
+	var b [8]byte
+	b[0] = byte((val>>56)&0x3f | 0xc0)
+	b[1] = byte(val >> 48)
+	b[2] = byte(val >> 40)
+	b[3] = byte(val >> 32)
+	b[4] = byte(val >> 24)
+	b[5] = byte(val >> 16)
+	b[6] = byte(val >> 8)
+	b[7] = byte(val)
+
+	_, _, err := ReadBytes(b[:])
+
+	if val > math.MaxInt {
+		assert.EqualError(t, err, "byte slice too large")
+	} else {
+		assert.EqualError(t, err, "EOF")
+	}
+}
+
+func TestReadStringArray_TooLargeError(t *testing.T) {
+	val := uint64(0x3fffffffffffffff)
+	var b [8]byte
+	b[0] = byte((val>>56)&0x3f | 0xc0)
+	b[1] = byte(val >> 48)
+	b[2] = byte(val >> 40)
+	b[3] = byte(val >> 32)
+	b[4] = byte(val >> 24)
+	b[5] = byte(val >> 16)
+	b[6] = byte(val >> 8)
+	b[7] = byte(val)
+
+	_, _, err := ReadStringArray(b[:])
+
+	if val > math.MaxInt {
+		assert.EqualError(t, err, "string array too large")
+	} else {
+		assert.Error(t, err)
+	}
+}


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Untrusted network payloads contained QUIC varint length prefixes that were verified against `math.MaxInt` and caused a `panic()` on 32-bit architectures, creating a remote DoS vector.
🎯 **Impact:** An attacker could send malformed varints to instantly crash the server.
🔧 **Fix:** Replaced `panic()` calls with `errors.New()` to fail securely.
✅ **Verification:** Verified by adding bounds-check tests and running `go test`.

---
*PR created automatically by Jules for task [421547689954018732](https://jules.google.com/task/421547689954018732) started by @okdaichi*