### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerability via panic on oversized lengths

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,8 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when pre-allocating slices for variable-length arrays based on an untrusted varint count prefix (e.g., `make([]string, 0, count)` or `make([]uint64, count)`). An attacker can specify a huge count for an array with very few bytes, causing the server to allocate massive amounts of memory and crash before parsing the next item.
 **Learning:** Even if the overall message size is constrained or the buffer is small, `make` pre-allocations using unvalidated array lengths can cause OOM DoS.
 **Prevention:** Compute a clamped capacity based on `len(b)` and the maximum possible count before allocating, and allocate `make([]T, 0, allocCap)`. Let the subsequent decode loop naturally fail with an EOF when the buffer is exhausted.
+
+## 2024-06-21 - Fix DoS via panic on oversized lengths
+**Vulnerability:** A Denial of Service (DoS) vulnerability caused by `panic()` calls when untrusted network length prefixes for byte slices or string arrays exceeded `math.MaxInt`.
+**Learning:** Using `panic()` for unbounded length validation in network parsing introduces a remote DoS vulnerability where malicious actors can crash the server with oversized prefixes.
+**Prevention:** Fail securely by returning appropriate errors instead of panicking when bounded validation constraints are unmet.

--- a/moqt/broadcast_test.go
+++ b/moqt/broadcast_test.go
@@ -29,7 +29,6 @@ func TestBroadcastRegisterAndServeTrack(t *testing.T) {
 	}
 }
 
-
 func TestBroadcastRemoveClosesActiveTracks(t *testing.T) {
 	broadcast := NewBroadcast()
 
@@ -257,16 +256,15 @@ func TestBroadcastClose_MultipleHandlers(t *testing.T) {
 	assert.Equal(t, reflect.ValueOf(NotFoundTrackHandler).Pointer(), reflect.ValueOf(broadcast.Handler("audio")).Pointer())
 }
 
-
 func TestBroadcast_Register(t *testing.T) {
 	dummyHandler := TrackHandlerFunc(func(*TrackWriter) {})
 
 	tests := []struct {
-		name         string
-		broadcast    *Broadcast
-		trackName    TrackName
-		handler      TrackHandler
-		wantErr      string
+		name      string
+		broadcast *Broadcast
+		trackName TrackName
+		handler   TrackHandler
+		wantErr   string
 	}{
 		{
 			name:      "valid registration",

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -79,7 +79,7 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 	}
 	b = b[n:]
 	if num > math.MaxInt {
-		panic("byte slice too large")
+		return nil, 0, errors.New("byte slice too large")
 	}
 
 	if uint64(len(b)) < num {
@@ -104,7 +104,7 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 	}
 
 	if count > math.MaxInt {
-		panic("string array too large")
+		return nil, 0, errors.New("string array too large")
 	}
 
 	b = b[total:]

--- a/moqt/internal/message/message_reader_test.go
+++ b/moqt/internal/message/message_reader_test.go
@@ -212,6 +212,12 @@ func TestReadBytes(t *testing.T) {
 			input:   []byte{0x05, 0x41, 0x42},
 			wantErr: true,
 		},
+		"too large": {
+			input:    []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			expected: nil,
+			n:        0,
+			wantErr:  true,
+		},
 		"invalid varint": {
 			input:   []byte{},
 			wantErr: true,
@@ -299,6 +305,12 @@ func TestReadStringArray(t *testing.T) {
 		"incomplete array": {
 			input:   []byte{0x01, 0x05, 0x68, 0x65},
 			wantErr: true,
+		},
+		"too large": {
+			input:    []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			expected: nil,
+			n:        0,
+			wantErr:  true,
 		},
 		"invalid count": {
 			input:   []byte{},


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Parsing network prefixes over math.MaxInt triggers a panic.
🎯 Impact: Remote DoS vulnerability crashing the application.
🔧 Fix: Replace panic with error return.
✅ Verification: Passed tests via unit test addition.

---
*PR created automatically by Jules for task [6246885714859421724](https://jules.google.com/task/6246885714859421724) started by @okdaichi*