### PR TITLE
⚡ Bolt: Optimize duplicate track detection in Catalog.Validate

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -14,3 +14,6 @@
 **Learning:** In Go, fallback paths (like non-`io.ByteReader` readers) in hot decoding loops shouldn't use dynamic slice allocations (e.g., `make([]byte, size)`) if the maximum size is small and fixed (like an 8-byte varint). Replacing `make()` with a local fixed-size array (e.g., `var buf [8]byte`) and slicing it `buf[:size]` entirely eliminates heap allocations.
 **Action:** When parsing small, bounded objects like varints from an `io.Reader`, use stack-allocated arrays and take their slices (`buf[:length]`) instead of dynamically allocating slices with `make()`.
 
+## YYYY-MM-DD - Small Slice Deduplication
+**Learning:** For finding duplicates or validating uniqueness in very small slices (e.g., N <= 16), an O(N^2) nested loop comparison against a stack-allocated array is measurably faster than using a `map[T]struct{}`. Even if escape analysis optimizes the map to the stack (0 allocs/op), the nested loop avoids map initialization and element hashing overhead on the happy path. Provide a fallback map for larger sizes.
+**Action:** When deduplicating small bounded collections, consider using a stack-allocated array `[16]T` with a nested `O(N^2)` check before resorting to map initialization, particularly in hot paths like `Validate`.

--- a/moqt/broadcast_test.go
+++ b/moqt/broadcast_test.go
@@ -29,7 +29,6 @@ func TestBroadcastRegisterAndServeTrack(t *testing.T) {
 	}
 }
 
-
 func TestBroadcastRemoveClosesActiveTracks(t *testing.T) {
 	broadcast := NewBroadcast()
 
@@ -257,16 +256,15 @@ func TestBroadcastClose_MultipleHandlers(t *testing.T) {
 	assert.Equal(t, reflect.ValueOf(NotFoundTrackHandler).Pointer(), reflect.ValueOf(broadcast.Handler("audio")).Pointer())
 }
 
-
 func TestBroadcast_Register(t *testing.T) {
 	dummyHandler := TrackHandlerFunc(func(*TrackWriter) {})
 
 	tests := []struct {
-		name         string
-		broadcast    *Broadcast
-		trackName    TrackName
-		handler      TrackHandler
-		wantErr      string
+		name      string
+		broadcast *Broadcast
+		trackName TrackName
+		handler   TrackHandler
+		wantErr   string
 	}{
 		{
 			name:      "valid registration",

--- a/msf/catalog.go
+++ b/msf/catalog.go
@@ -248,14 +248,36 @@ func (c Catalog) Validate() error {
 			}
 		}
 	}
-	seen := make(map[TrackID]struct{}, len(c.Tracks))
-	for i, track := range c.Tracks {
-		id := track.ID(c.DefaultNamespace)
-		if _, ok := seen[id]; ok {
-			problems = append(problems, fmt.Sprintf("tracks[%d]: duplicate track identity %q", i, id.String()))
-			continue
+	n := len(c.Tracks)
+	if n <= 16 {
+		var seen [16]TrackID
+		var numSeen int
+		for i, track := range c.Tracks {
+			id := track.ID(c.DefaultNamespace)
+			duplicate := false
+			for j := 0; j < numSeen; j++ {
+				if seen[j] == id {
+					problems = append(problems, fmt.Sprintf("tracks[%d]: duplicate track identity %q", i, id.String()))
+					duplicate = true
+					break
+				}
+			}
+			if duplicate {
+				continue
+			}
+			seen[numSeen] = id
+			numSeen++
 		}
-		seen[id] = struct{}{}
+	} else {
+		seen := make(map[TrackID]struct{}, n)
+		for i, track := range c.Tracks {
+			id := track.ID(c.DefaultNamespace)
+			if _, ok := seen[id]; ok {
+				problems = append(problems, fmt.Sprintf("tracks[%d]: duplicate track identity %q", i, id.String()))
+				continue
+			}
+			seen[id] = struct{}{}
+		}
 	}
 
 	return newValidationError(problems)


### PR DESCRIPTION
💡 What: Replaced map-based duplicate detection with an O(N^2) stack-array loop for slices with <= 16 elements.
🎯 Why: Avoids map initialization and hashing overhead on the happy path, which is measurably slower even with 0 allocations.
📊 Impact: BenchmarkCatalog_Validate execution time reduced from ~222.7 ns/op to ~192.8 ns/op.
🔬 Measurement: Verified with `go test -bench=BenchmarkCatalog_Validate ./msf/... -benchtime=1s`.

---
*PR created automatically by Jules for task [8659591047094124497](https://jules.google.com/task/8659591047094124497) started by @okdaichi*