### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix remote DoS in message parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,7 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when pre-allocating slices for variable-length arrays based on an untrusted varint count prefix (e.g., `make([]string, 0, count)` or `make([]uint64, count)`). An attacker can specify a huge count for an array with very few bytes, causing the server to allocate massive amounts of memory and crash before parsing the next item.
 **Learning:** Even if the overall message size is constrained or the buffer is small, `make` pre-allocations using unvalidated array lengths can cause OOM DoS.
 **Prevention:** Compute a clamped capacity based on `len(b)` and the maximum possible count before allocating, and allocate `make([]T, 0, allocCap)`. Let the subsequent decode loop naturally fail with an EOF when the buffer is exhausted.
+## YYYY-MM-DD - Fix Remote DoS in Message Parsing
+**Vulnerability:** panic() used to handle oversized bounds when parsing untrusted input.
+**Learning:** Panics in network packet parsing functions allow attackers to crash the server with maliciously crafted payload sizes.
+**Prevention:** Always return proper error values for validation failures on untrusted input instead of panicking.

--- a/moqt/broadcast_test.go
+++ b/moqt/broadcast_test.go
@@ -29,7 +29,6 @@ func TestBroadcastRegisterAndServeTrack(t *testing.T) {
 	}
 }
 
-
 func TestBroadcastRemoveClosesActiveTracks(t *testing.T) {
 	broadcast := NewBroadcast()
 
@@ -257,16 +256,15 @@ func TestBroadcastClose_MultipleHandlers(t *testing.T) {
 	assert.Equal(t, reflect.ValueOf(NotFoundTrackHandler).Pointer(), reflect.ValueOf(broadcast.Handler("audio")).Pointer())
 }
 
-
 func TestBroadcast_Register(t *testing.T) {
 	dummyHandler := TrackHandlerFunc(func(*TrackWriter) {})
 
 	tests := []struct {
-		name         string
-		broadcast    *Broadcast
-		trackName    TrackName
-		handler      TrackHandler
-		wantErr      string
+		name      string
+		broadcast *Broadcast
+		trackName TrackName
+		handler   TrackHandler
+		wantErr   string
 	}{
 		{
 			name:      "valid registration",

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -79,7 +79,8 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 	}
 	b = b[n:]
 	if num > math.MaxInt {
-		panic("byte slice too large")
+		// SECURITY: return error instead of panicking on untrusted input to prevent remote DoS
+		return nil, 0, errors.New("byte slice too large")
 	}
 
 	if uint64(len(b)) < num {
@@ -104,7 +105,8 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 	}
 
 	if count > math.MaxInt {
-		panic("string array too large")
+		// SECURITY: return error instead of panicking on untrusted input to prevent remote DoS
+		return nil, 0, errors.New("string array too large")
 	}
 
 	b = b[total:]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: panic() was used to handle oversized bounds when parsing untrusted input.
🎯 Impact: Attackers can crash the server (Remote Denial of Service) by sending maliciously crafted payload sizes.
🔧 Fix: Replaced panics with safe error returns and added security comments.
✅ Verification: Verified via go test ./...

---
*PR created automatically by Jules for task [2910534895007512528](https://jules.google.com/task/2910534895007512528) started by @okdaichi*