### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Remote Denial of Service (DoS) via Panic

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,7 @@ Checking memory constraints for OOM vulnerabilities...
 **Vulnerability:** A memory exhaustion (OOM) vulnerability caused by lack of bounds checking when pre-allocating slices for variable-length arrays based on an untrusted varint count prefix (e.g., `make([]string, 0, count)` or `make([]uint64, count)`). An attacker can specify a huge count for an array with very few bytes, causing the server to allocate massive amounts of memory and crash before parsing the next item.
 **Learning:** Even if the overall message size is constrained or the buffer is small, `make` pre-allocations using unvalidated array lengths can cause OOM DoS.
 **Prevention:** Compute a clamped capacity based on `len(b)` and the maximum possible count before allocating, and allocate `make([]T, 0, allocCap)`. Let the subsequent decode loop naturally fail with an EOF when the buffer is exhausted.
+## YYYY-MM-DD - [Prevent Remote DoS via Panic on Untrusted Input]
+**Vulnerability:** The network message parser `ReadBytes` and `ReadStringArray` panicked when processing maliciously large length prefixes, resulting in an easily exploitable Remote Denial of Service (DoS).
+**Learning:** Panicking on invalid or oversized untrusted input provides attackers with a reliable method to crash the application remotely.
+**Prevention:** Always fail securely by returning appropriate errors (e.g., `errors.New(...)` or domain-specific errors) instead of using `panic()` during the parsing of external network payloads.

--- a/moqt/broadcast_test.go
+++ b/moqt/broadcast_test.go
@@ -29,7 +29,6 @@ func TestBroadcastRegisterAndServeTrack(t *testing.T) {
 	}
 }
 
-
 func TestBroadcastRemoveClosesActiveTracks(t *testing.T) {
 	broadcast := NewBroadcast()
 
@@ -257,16 +256,15 @@ func TestBroadcastClose_MultipleHandlers(t *testing.T) {
 	assert.Equal(t, reflect.ValueOf(NotFoundTrackHandler).Pointer(), reflect.ValueOf(broadcast.Handler("audio")).Pointer())
 }
 
-
 func TestBroadcast_Register(t *testing.T) {
 	dummyHandler := TrackHandlerFunc(func(*TrackWriter) {})
 
 	tests := []struct {
-		name         string
-		broadcast    *Broadcast
-		trackName    TrackName
-		handler      TrackHandler
-		wantErr      string
+		name      string
+		broadcast *Broadcast
+		trackName TrackName
+		handler   TrackHandler
+		wantErr   string
 	}{
 		{
 			name:      "valid registration",

--- a/moqt/internal/message/message_reader.go
+++ b/moqt/internal/message/message_reader.go
@@ -79,7 +79,8 @@ func ReadBytes(b []byte) ([]byte, int, error) {
 	}
 	b = b[n:]
 	if num > math.MaxInt {
-		panic("byte slice too large")
+		// SECURITY: Return an error instead of panicking on oversized untrusted input to prevent remote Denial of Service (DoS).
+		return nil, 0, errors.New("byte slice too large")
 	}
 
 	if uint64(len(b)) < num {
@@ -104,7 +105,8 @@ func ReadStringArray(b []byte) ([]string, int, error) {
 	}
 
 	if count > math.MaxInt {
-		panic("string array too large")
+		// SECURITY: Return an error instead of panicking on oversized untrusted input to prevent remote Denial of Service (DoS).
+		return nil, 0, errors.New("string array too large")
 	}
 
 	b = b[total:]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The network message parser panicked when processing maliciously large length prefixes.
🎯 Impact: Remote Denial of Service (DoS) by sending crafted payloads.
🔧 Fix: Replaced `panic()` calls with graceful error returns in `ReadBytes` and `ReadStringArray`.
✅ Verification: Ran full test suite to ensure robust parsing.

---
*PR created automatically by Jules for task [18202445187273248199](https://jules.google.com/task/18202445187273248199) started by @okdaichi*